### PR TITLE
feat: embedded agent skills (rosita-migrate + rosita-remember) via rosita skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to rosita are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
+## Unreleased
+
+### Added
+
+- The `rosita-migrate` agent skill is now embedded in the binary and managed by
+  the new `rosita skill [install|remove|status]` command — no repo checkout or
+  manual symlink needed. It installs to the cross-agent `~/.agents/skills/`
+  location (read natively by Gemini CLI and opencode) with symlinks into
+  `~/.claude/skills/` and `~/.codex/skills/` when those agents are present, and
+  the skill itself was rewritten to the portable Agent Skills format so it works
+  beyond Claude Code.
+- `rosita run` offers the skill once (interactive terminals only, and only while
+  your config has no profiles yet — i.e. before you've migrated); the answer is
+  remembered per machine. Accepted installs are kept healthy on later runs:
+  deleted symlinks are repaired and new rosita versions refresh the skill files —
+  unless you've edited them, in which case rosita leaves them alone.
+- `rosita doctor` gained an "Agent skills" section reporting install state,
+  staleness, local edits, and broken links; `rosita studio`'s welcome screen
+  gained a card that installs the skill (with confirmation) and shows the
+  one-liner to invoke it.
+
 ## 0.3.0 — 2026-06-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to rosita are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
-## Unreleased
+## 0.4.0 — 2026-06-10
 
 ### Added
 
@@ -24,7 +24,7 @@ version and date (see [RELEASING.md](RELEASING.md)).
   fragment (or updates the fragment it contradicts) instead of leaving it in
   one agent's local memory. Deliberately scoped: project- and session-specific
   notes stay in the agent's own memory.
-- `rosita run` offers the skill once (interactive terminals only, and only while
+- `rosita run` offers the skills once, as a single bundled question (interactive terminals only, and only while
   your config has no profiles yet — i.e. before you've migrated); the answer is
   remembered per machine. Accepted installs are kept healthy on later runs:
   deleted symlinks are repaired and new rosita versions refresh the skill files —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ version and date (see [RELEASING.md](RELEASING.md)).
   `~/.claude/skills/` and `~/.codex/skills/` when those agents are present, and
   the skill itself was rewritten to the portable Agent Skills format so it works
   beyond Claude Code.
+- A second embedded skill, `rosita-remember`: when you state a durable,
+  cross-project preference mid-session, your agent saves it as a rosita
+  fragment (or updates the fragment it contradicts) instead of leaving it in
+  one agent's local memory. Deliberately scoped: project- and session-specific
+  notes stay in the agent's own memory.
 - `rosita run` offers the skill once (interactive terminals only, and only while
   your config has no profiles yet — i.e. before you've migrated); the answer is
   remembered per machine. Accepted installs are kept healthy on later runs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "rosita"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosita"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Inject global context into your AI coding agents: detect the project, select the profile that fits, and render an agent-specific instruction overlay."

--- a/README.md
+++ b/README.md
@@ -259,15 +259,26 @@ inert until you `sync init`; tune them under `[sync]` (see
 
 ## Already have a `CLAUDE.md` / `AGENTS.md`?
 
-Don't hand-translate it. rosita ships a Claude Code **skill**,
+Don't hand-translate it. rosita ships an **agent skill**,
 [`rosita-migrate`](skills/rosita-migrate/SKILL.md), that reads your existing
 global agent instructions and turns them into rosita fragments plus the few
 profiles you actually need — additively (your originals are left untouched).
+It follows the cross-agent Agent Skills format (`SKILL.md`), so the same
+install works in Claude Code, Codex CLI, Gemini CLI, and opencode.
 
 ```bash
-ln -s "$PWD/skills/rosita-migrate" ~/.claude/skills/rosita-migrate
-# then, in Claude Code:  /rosita-migrate   (or "import my CLAUDE.md into rosita")
+rosita skill install
+# then, in any agent session:  /rosita-migrate   (or "import my CLAUDE.md into rosita")
 ```
+
+The skill is embedded in the binary — no repo checkout needed. It installs to
+`~/.agents/skills/` (read natively by Gemini CLI and opencode) with symlinks
+into `~/.claude/skills/` and `~/.codex/skills/` for agents that scan their own
+dotdir — created only when that agent's directory already exists. The first
+interactive `rosita run` also offers it (once) while your config has no
+profiles yet; `rosita skill remove` uninstalls and stops the offer, and
+`rosita doctor` reports the install's health. If you edit the installed files,
+rosita stops touching them.
 
 ## Commands
 
@@ -285,6 +296,7 @@ ln -s "$PWD/skills/rosita-migrate" ~/.claude/skills/rosita-migrate
 | `rosita fragments [list\|show <id>] [--json]` | List your fragment library (active ones marked), or show one in detail. |
 | `rosita profiles [--json]` | List your profiles with their `targets`, marking which match and which is selected. |
 | `rosita agents [--json]` | List configured agents and how each delivers the overlay. |
+| `rosita skill [install\|remove\|status] [id]` | Manage the embedded agent skills under `~/.agents/skills` (bare `skill` shows status). |
 | `rosita update [--check]` | Self-update to the latest release (installer-based installs); `--check` only reports availability. |
 
 `<id>` is an agent id — built-ins are `claude`, `codex`, `gemini`, `opencode`,

--- a/README.md
+++ b/README.md
@@ -271,11 +271,17 @@ rosita skill install
 # then, in any agent session:  /rosita-migrate   (or "import my CLAUDE.md into rosita")
 ```
 
-The skill is embedded in the binary — no repo checkout needed. It installs to
-`~/.agents/skills/` (read natively by Gemini CLI and opencode) with symlinks
+rosita also ships [`rosita-remember`](skills/rosita-remember/SKILL.md): when
+you tell your agent a durable, cross-project preference mid-session ("always
+X", "stop doing Y"), the skill saves it as a rosita fragment — or updates the
+fragment it contradicts — instead of leaving it stranded in one agent's local
+memory. Project- and session-specific notes stay in the agent's own memory.
+
+The skills are embedded in the binary — no repo checkout needed. They install
+to `~/.agents/skills/` (read natively by Gemini CLI and opencode) with symlinks
 into `~/.claude/skills/` and `~/.codex/skills/` for agents that scan their own
 dotdir — created only when that agent's directory already exists. The first
-interactive `rosita run` also offers it (once) while your config has no
+interactive `rosita run` also offers them (once) while your config has no
 profiles yet; `rosita skill remove` uninstalls and stops the offer, and
 `rosita doctor` reports the install's health. If you edit the installed files,
 rosita stops touching them.

--- a/skills/rosita-migrate/SKILL.md
+++ b/skills/rosita-migrate/SKILL.md
@@ -15,11 +15,18 @@ untouched; rosita renders a separate, generated overlay.
 Read [reference.md](reference.md) for the full TOML schema and a worked example
 before writing any config.
 
-## Orientation (gathered for you)
+## Orientation (run these probes first)
 
-- rosita on PATH: !`command -v rosita >/dev/null 2>&1 && rosita --version || echo "NOT INSTALLED — install rosita first"`
-- Existing global config: !`sed -n '1,60p' ~/.config/rosita/config.toml 2>/dev/null || echo "(none yet — this will be a fresh setup)"`
-- Candidate source files: !`for f in ~/.claude/CLAUDE.md ~/.codex/AGENTS.md ~/.config/AGENTS.md ./CLAUDE.md ./AGENTS.md ./.github/copilot-instructions.md; do [ -f "$f" ] && echo "$f"; done; echo "(also ask the user if their global rules live elsewhere)"`
+Before anything else, run these and use their output for the rest of the process:
+
+```bash
+# rosita on PATH?
+command -v rosita >/dev/null 2>&1 && rosita --version || echo "NOT INSTALLED — install rosita first"
+# Existing global config (fresh setup if missing)
+sed -n '1,60p' ~/.config/rosita/config.toml 2>/dev/null || echo "(none yet — this will be a fresh setup)"
+# Candidate source files (also ask the user if their global rules live elsewhere)
+for f in ~/.claude/CLAUDE.md ~/.codex/AGENTS.md ~/.config/AGENTS.md ./CLAUDE.md ./AGENTS.md ./.github/copilot-instructions.md; do [ -f "$f" ] && echo "$f"; done
+```
 
 ## The model (so you decompose well)
 

--- a/skills/rosita-remember/SKILL.md
+++ b/skills/rosita-remember/SKILL.md
@@ -58,7 +58,11 @@ fragment descriptions, which tells you *which* fragment the user is correcting.
 
 3. **Propose the edit before writing.** Show: the fragment id, the exact new
    or changed `guidance` text (condensed, faithful — don't editorialize), and —
-   for a new fragment — which profiles will compose it. Get explicit approval.
+   for a new fragment — which profiles will compose it. If the agreed scope has
+   no profile yet (e.g. the first node-specific rule and no profile targets
+   `node`), propose creating one: a `[[profiles]]` block with the right
+   `targets` composing the new fragment (see reference.md). Get explicit
+   approval.
 
 4. **Write to `~/.config/rosita/config.toml`** (the global config — never a
    repo's `.rosita/`):

--- a/skills/rosita-remember/SKILL.md
+++ b/skills/rosita-remember/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: rosita-remember
+description: Save a durable, cross-project user preference into rosita's global fragments/profiles — or update the fragment it contradicts. Use when the user states lasting guidance that should follow them across projects and agents ("always X", "never Y", "stop doing Z"), especially when it conflicts with guidance the rosita context block already injects. Not a replacement for your normal memory — project-specific, session-specific, or factual notes stay there.
+when_to_use: The user gives feedback or states a preference that is (a) about how agents should work, (b) durable, and (c) not specific to the current project — or explicitly asks to "remember this in rosita", "make this global", or "update my rosita guidance".
+---
+
+# Remember durable guidance in rosita
+
+rosita injects the user's **global** agent guidance from
+`~/.config/rosita/config.toml`: reusable **fragments** composed into
+stack-targeted **profiles**. When the user states a preference that should
+outlive this session and this project, the right home for it is a fragment —
+not a repo CLAUDE.md, and not your agent-local memory.
+
+Read [reference.md](reference.md) for the exact TOML schema before editing.
+
+## Decision boundary — when this skill applies
+
+Apply the test in order; stop at the first match:
+
+1. **Project- or session-specific?** ("this repo uses pnpm", "call it Foo in
+   this PR") → your normal memory / the repo's own files. **Not this skill.**
+2. **A fact, not guidance?** (who the user is, an URL, a deadline) → normal
+   memory. **Not this skill.**
+3. **Durable cross-project guidance that contradicts or refines something the
+   rosita context block already says?** → **edit that fragment** (the strongest
+   signal: the user is correcting guidance rosita itself injected).
+4. **Durable cross-project guidance with no matching fragment?** → offer a
+   **new fragment** (and ask which profiles should compose it).
+
+When unsure whether it's durable or global, ask the user one short question
+rather than guessing. Saving to rosita *and* your own memory is redundant —
+prefer rosita for anything that passes the test, since it reaches every agent.
+
+## Orientation (run these probes first)
+
+```bash
+# rosita on PATH?
+command -v rosita >/dev/null 2>&1 && rosita --version || echo "NOT INSTALLED — stop; suggest installing rosita"
+# Current fragments (ids + descriptions)
+rosita fragments 2>/dev/null
+# The active profile for this repo (what's actually injected here)
+rosita explain 2>/dev/null | head -40
+```
+
+Also check the rosita context block already in your conversation (it starts
+with "What is rosita?" / "rosita snapshot") — the section headings there map to
+fragment descriptions, which tells you *which* fragment the user is correcting.
+
+## Process
+
+1. **Pin down the guidance.** Restate it in one sentence and confirm scope
+   with the user if ambiguous: all projects, or one stack (rust/node/…)?
+
+2. **Find the target fragment.** Match the guidance against `rosita fragments`
+   and the in-context overlay. Correction of existing guidance → that fragment.
+   New topic → a new fragment (kebab `id`, short `description`).
+
+3. **Propose the edit before writing.** Show: the fragment id, the exact new
+   or changed `guidance` text (condensed, faithful — don't editorialize), and —
+   for a new fragment — which profiles will compose it. Get explicit approval.
+
+4. **Write to `~/.config/rosita/config.toml`** (the global config — never a
+   repo's `.rosita/`):
+   - Back it up first: `cp ~/.config/rosita/config.toml ~/.config/rosita/config.toml.bak`.
+   - **Edit minimally** — change only the target fragment's `guidance` (or
+     append one `[[fragments]]` block and add its id to the agreed profiles).
+     Preserve all other content, comments, and formatting.
+   - Machine-specific literals (hostnames, IPs, usernames) belong in
+     `~/.config/rosita/local.toml` under `[fragment_params.<id>]`, not the
+     shareable public config.
+
+5. **Validate** (and fix anything flagged):
+   - `rosita doctor` — healthy, no leak-lint findings.
+   - `rosita fragments show <id>` — the new text reads back correctly.
+   - Suggest `rosita refresh` so the running repo's overlay picks it up now
+     (other repos refresh on their next `rosita run`).
+
+6. **Tell the user where it landed** — fragment id, profiles affected, and
+   that it now applies across all their agents and machines (if they sync).
+
+## Rules
+
+- **Confirm before writing**, and back up `config.toml` first.
+- **Minimal diffs.** Never reorder, rewrite, or delete config the user didn't
+  ask to change.
+- **Fragments and profiles are global-only.** Never write them into a repo's
+  `.rosita/`.
+- **Stay faithful.** Capture the user's preference as stated; condense, don't
+  invent policy or generalize beyond what they said.
+- **Don't hoard.** If it fails the decision boundary, say so and use your
+  normal memory instead — this skill is for guidance rosita should inject.

--- a/skills/rosita-remember/reference.md
+++ b/skills/rosita-remember/reference.md
@@ -1,0 +1,98 @@
+# rosita config reference (for the remember skill)
+
+Everything lives in `~/.config/rosita/config.toml` (public, shareable) and,
+for machine-specific values, `~/.config/rosita/local.toml` (private,
+gitignored). Fragments and profiles are **global-only** — never put them in
+a repo's `.rosita/`.
+
+## `[[fragments]]`
+
+A fragment is one reusable unit of context. The parser is strict
+(`deny_unknown_fields`) — only these keys are valid:
+
+| key | required | notes |
+|-----|----------|-------|
+| `id` | yes | kebab-case, unique. How profiles reference it. |
+| `description` | no | short title shown in listings. |
+| `guidance` | no¹ | the instructions. A minijinja template — may reference `{{ params.x }}`. |
+| `category` | no | human-friendly group label shown in studio, e.g. `"Safety"`. |
+| `agents` | no | restrict to certain agents, e.g. `["claude", "codex"]`. Empty/absent = all. |
+| `when` | no | conditions that gate the fragment (advanced; usually omit). |
+| `requires` | no | ids of other fragments to pull in first. |
+| `params` | no | default values for `{{ params.* }}` in guidance. |
+| `provider` | no² | a built-in live probe: `host`, `toolchain`, `ai-tools`, `tailnet`, `docker`. |
+| `command` | no² | a shell script whose stdout becomes the rendered body. Set `script_lang = "bash"`. |
+| `script_lang` | no | language for `command` (use `"bash"`). |
+| `cache` | no | for dynamic fragments: how long to cache output, e.g. `"5m"`. |
+
+¹ A fragment needs *either* `guidance` (static) *or* `command`/`provider` (dynamic).
+² `provider` and `command` are mutually exclusive.
+
+## `[[profiles]]`
+
+A profile composes fragments and is selected by detected context.
+
+| key | required | notes |
+|-----|----------|-------|
+| `name` | yes | unique. |
+| `targets` | no | stacks this profile applies to: `["rust"]`, `["node"]`, … or `["machine"]` for the no-repo context. Empty ⇒ the catch-all default. |
+| `fragments` | no | ordered list of fragment ids (or `{ id = "x", params = { … } }`). |
+| `guidance` | no | inline guidance appended as a synthetic fragment. |
+| `disabled` | no | `true` keeps the definition but never selects it. |
+
+## Editing example
+
+The user says *"stop suggesting `git push --force`; always use
+`--force-with-lease`"* and the overlay's "Git commit conventions" section maps
+to the `conventional-commits` fragment. The minimal edit — only that
+fragment's `guidance` changes, everything else byte-identical:
+
+```toml
+[[fragments]]
+id = "conventional-commits"
+description = "Git commit conventions"
+guidance = """
+Use Conventional Commits (feat:/fix:/refactor:/docs:). Imperative subject
+≤72 chars; body explains why.
+Never `git push --force`; use `--force-with-lease` when a force is required.
+"""
+```
+
+A brand-new preference instead becomes a new fragment plus a one-line addition
+to each profile that should carry it:
+
+```toml
+[[fragments]]
+id = "dependency-policy"
+description = "Dependency policy"
+guidance = "Ask before adding a new dependency; prefer the standard library when reasonable."
+
+[[profiles]]
+name = "machine"
+targets = ["machine"]
+fragments = ["conventional-commits", "dependency-policy"]
+```
+
+(In a real edit you *add* `"dependency-policy"` to the existing profile's
+`fragments` list rather than restating the profile.)
+
+### Private values → `local.toml`
+
+If guidance needs a real hostname or other machine-specific literal, keep it
+out of the public config:
+
+```toml
+# ~/.config/rosita/config.toml  (public)
+[[fragments]]
+id = "deploy"
+description = "Deploy target"
+guidance = "Deploy as {{ params.user }}@{{ params.host }}."
+
+# ~/.config/rosita/local.toml  (private, gitignored)
+[fragment_params.deploy]
+host = "box.internal.example"
+user = "deployer"
+```
+
+`rosita doctor` leak-lints the public config and tells you when a literal looks
+private and belongs in `local.toml`.

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -11,6 +11,11 @@
 //!
 //! The store is rosita-owned, so the global file is written with the plain
 //! `toml` serializer; only the hand-editable `local.toml` needs `toml_edit`.
+//!
+//! The same store also remembers per-machine **skill decisions** (the ask-once
+//! "install the rosita-migrate skill?" answer) in a `[skills]` table — rosita-
+//! owned machine state of the same class as a binding, and deliberately *not*
+//! in `local.toml`, whose strict config parse rejects unknown tables.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -156,11 +161,15 @@ pub fn write_repo(repo_base: &Path, b: &Binding) -> Result<()> {
 
 // --- machine scope: the global path-keyed store ------------------------------
 
-/// The global bindings store: cwd path → remembered choice.
+/// The global bindings store: cwd path → remembered choice, plus per-machine
+/// skill decisions (skill id → `"accepted"`/`"declined"`). Lenient parse: files
+/// written by newer rosita versions with extra tables still load.
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct BindingStore {
     #[serde(default)]
     bound: BTreeMap<String, RawBinding>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    skills: BTreeMap<String, String>,
 }
 
 /// Path to the global bindings store, if a global config dir resolves.
@@ -207,6 +216,61 @@ pub fn read_global_at(store_path: &Path, cwd: &Path) -> Option<Binding> {
 pub fn write_global_at(store_path: &Path, cwd: &Path, b: &Binding) -> Result<()> {
     let mut store = load(store_path);
     store.bound.insert(key(cwd), RawBinding::from_binding(b));
+    save(store_path, &store)
+}
+
+// --- skill decisions: the ask-once install answer, per machine ----------------
+
+/// The remembered answer to "install this skill?". There is no "ask again
+/// later" value: an unrecorded decision *is* "ask when appropriate".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillDecision {
+    /// Install and keep current (repair links, refresh on upgrade).
+    Accepted,
+    /// Don't install, don't ask again. Re-enable via `rosita skill install`.
+    Declined,
+}
+
+impl SkillDecision {
+    fn as_str(self) -> &'static str {
+        match self {
+            SkillDecision::Accepted => "accepted",
+            SkillDecision::Declined => "declined",
+        }
+    }
+
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "accepted" => Some(SkillDecision::Accepted),
+            "declined" => Some(SkillDecision::Declined),
+            _ => None,
+        }
+    }
+}
+
+/// Read the remembered decision for a skill id, if any.
+pub fn read_skill_decision(skill_id: &str) -> Option<SkillDecision> {
+    read_skill_decision_at(&store_path()?, skill_id)
+}
+
+/// Persist the decision for a skill id.
+pub fn write_skill_decision(skill_id: &str, d: SkillDecision) -> Result<()> {
+    let path = store_path().ok_or_else(|| anyhow!("no global config dir to store decisions in"))?;
+    write_skill_decision_at(&path, skill_id, d)
+}
+
+/// [`read_skill_decision`] against an explicit store path (testable core).
+pub fn read_skill_decision_at(store_path: &Path, skill_id: &str) -> Option<SkillDecision> {
+    load(store_path)
+        .skills
+        .get(skill_id)
+        .and_then(|s| SkillDecision::parse(s))
+}
+
+/// [`write_skill_decision`] against an explicit store path (testable core).
+pub fn write_skill_decision_at(store_path: &Path, skill_id: &str, d: SkillDecision) -> Result<()> {
+    let mut store = load(store_path);
+    store.skills.insert(skill_id.to_string(), d.as_str().to_string());
     save(store_path, &store)
 }
 
@@ -281,6 +345,35 @@ mod tests {
         assert_eq!(read_global_at(&store, b), Some(Binding::profile("kernel")));
         // Independent paths don't bleed into each other.
         assert_eq!(read_global_at(&store, Path::new("/elsewhere")), None);
+    }
+
+    #[test]
+    fn skill_decisions_round_trip_and_coexist_with_bindings() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("bindings.toml");
+
+        assert_eq!(read_skill_decision_at(&store, "rosita-migrate"), None);
+        write_skill_decision_at(&store, "rosita-migrate", SkillDecision::Declined).unwrap();
+        assert_eq!(
+            read_skill_decision_at(&store, "rosita-migrate"),
+            Some(SkillDecision::Declined)
+        );
+
+        // Flipping the decision and adding a binding don't clobber each other.
+        write_skill_decision_at(&store, "rosita-migrate", SkillDecision::Accepted).unwrap();
+        write_global_at(&store, Path::new("/work/p"), &Binding::profile("machine")).unwrap();
+        assert_eq!(
+            read_skill_decision_at(&store, "rosita-migrate"),
+            Some(SkillDecision::Accepted)
+        );
+        assert_eq!(
+            read_global_at(&store, Path::new("/work/p")),
+            Some(Binding::profile("machine"))
+        );
+
+        // An unknown value (written by a future rosita) reads as undecided.
+        std::fs::write(&store, "[skills]\nrosita-migrate = \"snoozed\"\n").unwrap();
+        assert_eq!(read_skill_decision_at(&store, "rosita-migrate"), None);
     }
 
     #[test]

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -270,7 +270,9 @@ pub fn read_skill_decision_at(store_path: &Path, skill_id: &str) -> Option<Skill
 /// [`write_skill_decision`] against an explicit store path (testable core).
 pub fn write_skill_decision_at(store_path: &Path, skill_id: &str, d: SkillDecision) -> Result<()> {
     let mut store = load(store_path);
-    store.skills.insert(skill_id.to_string(), d.as_str().to_string());
+    store
+        .skills
+        .insert(skill_id.to_string(), d.as_str().to_string());
     save(store_path, &store)
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,8 +68,36 @@ pub enum Command {
     Studio(StudioArgs),
     /// Sync your global config (fragments & profiles) across machines via git.
     Sync(SyncArgs),
+    /// Manage the agent skills rosita ships (installed under `~/.agents/skills`).
+    Skill(SkillArgs),
     /// Update rosita to the latest release (installer-based installs only).
     Update(UpdateArgs),
+}
+
+/// `skill` options. Bare `rosita skill` shows status.
+#[derive(Debug, Args)]
+pub struct SkillArgs {
+    /// `install`, `remove`, or `status` (the default).
+    #[command(subcommand)]
+    pub action: Option<SkillAction>,
+}
+
+/// `skill` subcommands.
+#[derive(Debug, Subcommand)]
+pub enum SkillAction {
+    /// Install (or repair/upgrade) shipped skills into `~/.agents/skills`,
+    /// with symlinks for agents that need their own skills dir.
+    Install {
+        /// Skill id (defaults to every shipped skill).
+        id: Option<String>,
+    },
+    /// Remove rosita-installed skills (canonical files + agent symlinks).
+    Remove {
+        /// Skill id (defaults to every shipped skill).
+        id: Option<String>,
+    },
+    /// Show each shipped skill's install state, links, and remembered decision.
+    Status,
 }
 
 /// `update` options.

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -152,8 +152,106 @@ pub fn run(rt: &Runtime) -> crate::Result<()> {
     );
     check_overlays(&mut c, &prep);
 
+    // Embedded agent skills (global; managed by `rosita skill`).
+    println!("\nAgent skills (~/.agents/skills)");
+    check_skills(&mut c);
+
     print_summary(&c);
     Ok(())
+}
+
+/// Health of rosita's embedded skills: install state, content freshness, the
+/// per-agent links, and the remembered ask-once decision.
+fn check_skills(c: &mut Checks) {
+    let Some(home) = config::home_dir() else {
+        c.line(Status::Warn, "cannot resolve $HOME — skill checks skipped");
+        return;
+    };
+    for skill in crate::skills::all() {
+        let st = crate::skills::status(&home, skill);
+        let decision = crate::binding::read_skill_decision(skill.id);
+        use crate::binding::SkillDecision as D;
+        use crate::skills::{LinkState, SkillState};
+
+        match (&st.state, decision) {
+            (SkillState::NotInstalled, Some(D::Declined)) => c.line(
+                Status::Ok,
+                format!("{}: not installed (declined — `rosita skill install` re-enables)", skill.id),
+            ),
+            (SkillState::NotInstalled, Some(D::Accepted)) => c.line(
+                Status::Warn,
+                format!(
+                    "{}: accepted but missing from disk — `rosita skill install` restores it",
+                    skill.id
+                ),
+            ),
+            (SkillState::NotInstalled, None) => c.line(
+                Status::Ok,
+                format!(
+                    "{}: not installed — `rosita skill install` imports your CLAUDE.md/AGENTS.md into rosita",
+                    skill.id
+                ),
+            ),
+            (SkillState::Unmanaged, _) => c.line(
+                Status::Ok,
+                format!(
+                    "{}: present but not rosita-managed (your own copy; rosita leaves it alone)",
+                    skill.id
+                ),
+            ),
+            (SkillState::Managed { user_modified: true, .. }, _) => c.line(
+                Status::Warn,
+                format!(
+                    "{}: installed with local edits — auto-upgrade is off ('rosita skill install' would not overwrite)",
+                    skill.id
+                ),
+            ),
+            (SkillState::Managed { upgrade_available: true, .. }, _) => c.line(
+                Status::Warn,
+                format!(
+                    "{}: installed but stale — `rosita skill install` upgrades it to this rosita's version",
+                    skill.id
+                ),
+            ),
+            (SkillState::Managed { .. }, _) => c.line(
+                Status::Ok,
+                format!("{}: installed and current", skill.id),
+            ),
+        }
+
+        if matches!(st.state, SkillState::Managed { .. }) {
+            for link in &st.links {
+                match link.state {
+                    LinkState::Missing | LinkState::Dangling => c.line(
+                        Status::Warn,
+                        format!(
+                            "{}: link {} is {} — `rosita skill install` repairs it",
+                            skill.id,
+                            link.path.display(),
+                            if link.state == LinkState::Missing { "missing" } else { "dangling" },
+                        ),
+                    ),
+                    LinkState::Foreign => c.line(
+                        Status::Warn,
+                        format!(
+                            "{}: {} exists but isn't rosita's — left alone",
+                            skill.id,
+                            link.path.display()
+                        ),
+                    ),
+                    LinkState::CopyManaged => c.line(
+                        Status::Ok,
+                        format!(
+                            "{}: {} is a copy (symlink fallback) — upgrades re-copy it",
+                            skill.id,
+                            link.path.display()
+                        ),
+                    ),
+                    LinkState::Linked | LinkState::AgentAbsent => {}
+                }
+            }
+        }
+    }
 }
 
 fn print_summary(c: &Checks) {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -228,7 +228,11 @@ fn check_skills(c: &mut Checks) {
                             "{}: link {} is {} — `rosita skill install` repairs it",
                             skill.id,
                             link.path.display(),
-                            if link.state == LinkState::Missing { "missing" } else { "dangling" },
+                            if link.state == LinkState::Missing {
+                                "missing"
+                            } else {
+                                "dangling"
+                            },
                         ),
                     ),
                     LinkState::Foreign => c.line(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod introspect;
 pub mod refresh;
 pub mod render;
 pub mod run;
+pub mod skill;
 pub mod sync;
 pub mod update;
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -27,10 +27,12 @@ use super::{
     now_rfc3339, prepare_with_live, Aborted, Choice, MissingPolicy, ProfileChooser, Runtime,
 };
 use crate::adapters::{self, AgentDescriptor, ApplyOptions, ApplyResult};
+use crate::binding::SkillDecision;
 use crate::cli::{RunArgs, StudioArgs};
 use crate::context::Context;
 use crate::hash;
 use crate::profile::ProfileConfig;
+use crate::skills::{self, LinkState, SkillState};
 use crate::style::Painter;
 use crate::sync::{self, SyncStatus};
 use crate::vlog;
@@ -195,6 +197,13 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
         }
     }
 
+    // Embedded-skill preflight: keep accepted installs healthy, and — ask-once,
+    // TTY-gated, only while the user looks pre-migration — offer the migrate
+    // skill. Best-effort: a skill hiccup must never block the launch.
+    if !rt.dry_run {
+        skill_preflight(&prep, &p);
+    }
+
     let descriptor = adapters::descriptor(&prep.config, agent)
         .ok_or_else(|| anyhow!("unknown agent '{agent}'"))?
         .clone();
@@ -262,6 +271,155 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
     print_launch_step(&p, &program, &args.args);
 
     launch(&program, &launch_args, &rendered_at, &rt.cwd, &extra_env)
+}
+
+// --- embedded-skill preflight --------------------------------------------------
+
+/// Maintain or offer rosita's embedded skills before launch. All branches are
+/// best-effort: errors are logged verbosely and never abort the run.
+fn skill_preflight(prep: &super::Prepared, p: &Painter) {
+    let Some(home) = crate::config::home_dir() else {
+        return;
+    };
+    for skill in skills::all() {
+        let outcome = match crate::binding::read_skill_decision(skill.id) {
+            Some(SkillDecision::Declined) => Ok(()),
+            Some(SkillDecision::Accepted) => maintain_skill(&home, skill, p),
+            None => offer_skill(&home, skill, prep, p),
+        };
+        if let Err(e) = outcome {
+            vlog!("skill preflight for '{}' failed: {e:#}", skill.id);
+        }
+    }
+}
+
+/// The user said yes once — keep the install healthy: repair deleted/dangling
+/// links, refresh a pristine install when this binary ships a newer version.
+/// A user-deleted canonical dir is respected (recorded as declined, one notice);
+/// user-edited files are never touched (`doctor` reports them).
+fn maintain_skill(home: &std::path::Path, skill: &skills::Skill, p: &Painter) -> crate::Result<()> {
+    let st = skills::status(home, skill);
+    match st.state {
+        SkillState::NotInstalled => {
+            // The user deleted it; don't resurrect. Remember the opt-out.
+            crate::binding::write_skill_decision(skill.id, SkillDecision::Declined)?;
+            println!(
+                "{}",
+                step(
+                    p,
+                    p.dim("·"),
+                    "skill",
+                    p.dim(&format!(
+                        "'{}' was removed — leaving it; `rosita skill install` restores it",
+                        skill.id
+                    )),
+                )
+            );
+        }
+        SkillState::Unmanaged | SkillState::Managed {
+            user_modified: true,
+            ..
+        } => {} // hands off; `rosita doctor` reports the divergence
+        SkillState::Managed {
+            upgrade_available, ..
+        } => {
+            let links_broken = st
+                .links
+                .iter()
+                .any(|l| matches!(l.state, LinkState::Missing | LinkState::Dangling));
+            if upgrade_available || links_broken {
+                skills::install(home, skill)?;
+                let what = if upgrade_available {
+                    "refreshed to this rosita's version"
+                } else {
+                    "repaired agent links"
+                };
+                println!(
+                    "{}",
+                    step(p, p.green("✓"), "skill", format!("'{}' {what}", skill.id))
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// No decision recorded: offer the skill once — only on a real terminal, and
+/// only while the user looks pre-migration (no profiles configured yet), which
+/// is exactly when `rosita-migrate` is useful. Configured users are never
+/// interrupted; they get the skill via `rosita skill install` or studio.
+fn offer_skill(
+    home: &std::path::Path,
+    skill: &skills::Skill,
+    prep: &super::Prepared,
+    p: &Painter,
+) -> crate::Result<()> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        return Ok(());
+    }
+    if !prep.config.profiles.is_empty() {
+        return Ok(());
+    }
+    match skills::status(home, skill).state {
+        // Already present (e.g. installed on another rosita version or by hand
+        // with our marker): adopt it silently instead of asking.
+        SkillState::Managed { .. } => {
+            return crate::binding::write_skill_decision(skill.id, SkillDecision::Accepted);
+        }
+        SkillState::Unmanaged => return Ok(()), // the user's own copy; never ours to manage
+        SkillState::NotInstalled => {}
+    }
+
+    println!();
+    println!(
+        "  {} rosita ships {} — an agent skill that imports an existing CLAUDE.md/AGENTS.md",
+        p.cyan("✦"),
+        p.bold(&format!("'{}'", skill.id))
+    );
+    println!(
+        "    into rosita fragments & profiles {}",
+        p.dim("(works in Claude Code, Codex, Gemini CLI, opencode)")
+    );
+    println!(
+        "  install it to {}?",
+        p.bold("~/.agents/skills")
+    );
+    println!("    1) yes — install {}", p.dim("(`rosita skill remove` undoes this)"));
+    println!("    2) no — don't ask again {}", p.dim("(`rosita skill install` re-enables)"));
+
+    loop {
+        print!("  ❯ ");
+        std::io::stdout().flush().ok();
+        let mut line = String::new();
+        if std::io::stdin().read_line(&mut line)? == 0 {
+            return Ok(()); // EOF: no answer — stay undecided, never nag mid-launch
+        }
+        match line.trim() {
+            "1" => {
+                skills::install(home, skill)?;
+                crate::binding::write_skill_decision(skill.id, SkillDecision::Accepted)?;
+                println!(
+                    "{}",
+                    step(
+                        p,
+                        p.green("✓"),
+                        "skill",
+                        format!(
+                            "'{}' installed → {}",
+                            skill.id,
+                            skills::canonical_dir(home, skill.id).display()
+                        ),
+                    )
+                );
+                return Ok(());
+            }
+            "2" => {
+                crate::binding::write_skill_decision(skill.id, SkillDecision::Declined)?;
+                return Ok(());
+            }
+            _ => println!("  please enter 1 or 2."),
+        }
+    }
 }
 
 // --- sync + the stepped run summary ------------------------------------------

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -335,7 +335,8 @@ fn maintain_skill(home: &std::path::Path, skill: &skills::Skill, p: &Painter) ->
                 )
             );
         }
-        SkillState::Unmanaged | SkillState::Managed {
+        SkillState::Unmanaged
+        | SkillState::Managed {
             user_modified: true,
             ..
         } => {} // hands off; `rosita doctor` reports the divergence
@@ -393,11 +394,7 @@ fn offer_skills(
         p.dim("(work in Claude Code, Codex, Gemini CLI, opencode)")
     );
     for skill in offerable {
-        println!(
-            "    {} — {}",
-            p.bold(skill.id),
-            skill_blurb(skill.id)
-        );
+        println!("    {} — {}", p.bold(skill.id), skill_blurb(skill.id));
     }
     println!("  install to {}?", p.bold("~/.agents/skills"));
     println!(

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -276,19 +276,38 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
 // --- embedded-skill preflight --------------------------------------------------
 
 /// Maintain or offer rosita's embedded skills before launch. All branches are
-/// best-effort: errors are logged verbosely and never abort the run.
+/// best-effort: errors are logged verbosely and never abort the run. Undecided,
+/// not-yet-installed skills are collected into ONE bundled offer — a fresh user
+/// gets a single question no matter how many skills rosita ships.
 fn skill_preflight(prep: &super::Prepared, p: &Painter) {
     let Some(home) = crate::config::home_dir() else {
         return;
     };
+    let mut offerable: Vec<&skills::Skill> = Vec::new();
     for skill in skills::all() {
         let outcome = match crate::binding::read_skill_decision(skill.id) {
             Some(SkillDecision::Declined) => Ok(()),
             Some(SkillDecision::Accepted) => maintain_skill(&home, skill, p),
-            None => offer_skill(&home, skill, prep, p),
+            None => match skills::status(&home, skill).state {
+                // Already present with our marker (installed elsewhere or on
+                // another rosita version): adopt silently instead of asking.
+                SkillState::Managed { .. } => {
+                    crate::binding::write_skill_decision(skill.id, SkillDecision::Accepted)
+                }
+                SkillState::Unmanaged => Ok(()), // the user's own copy; never ours
+                SkillState::NotInstalled => {
+                    offerable.push(skill);
+                    Ok(())
+                }
+            },
         };
         if let Err(e) = outcome {
             vlog!("skill preflight for '{}' failed: {e:#}", skill.id);
+        }
+    }
+    if !offerable.is_empty() {
+        if let Err(e) = offer_skills(&home, &offerable, prep, p) {
+            vlog!("skill offer failed: {e:#}");
         }
     }
 }
@@ -344,13 +363,14 @@ fn maintain_skill(home: &std::path::Path, skill: &skills::Skill, p: &Painter) ->
     Ok(())
 }
 
-/// No decision recorded: offer the skill once — only on a real terminal, and
-/// only while the user looks pre-migration (no profiles configured yet), which
-/// is exactly when `rosita-migrate` is useful. Configured users are never
-/// interrupted; they get the skill via `rosita skill install` or studio.
-fn offer_skill(
+/// No decision recorded yet: offer the not-yet-installed skills once, as one
+/// bundle — only on a real terminal, and only while the user looks
+/// pre-migration (no profiles configured yet), which is exactly when the
+/// migrate skill is useful. Configured users are never interrupted; they get
+/// the skills via `rosita skill install` or studio.
+fn offer_skills(
     home: &std::path::Path,
-    skill: &skills::Skill,
+    offerable: &[&skills::Skill],
     prep: &super::Prepared,
     p: &Painter,
 ) -> crate::Result<()> {
@@ -360,32 +380,34 @@ fn offer_skill(
     if !prep.config.profiles.is_empty() {
         return Ok(());
     }
-    match skills::status(home, skill).state {
-        // Already present (e.g. installed on another rosita version or by hand
-        // with our marker): adopt it silently instead of asking.
-        SkillState::Managed { .. } => {
-            return crate::binding::write_skill_decision(skill.id, SkillDecision::Accepted);
-        }
-        SkillState::Unmanaged => return Ok(()), // the user's own copy; never ours to manage
-        SkillState::NotInstalled => {}
-    }
 
+    let ids = offerable
+        .iter()
+        .map(|s| format!("'{}'", s.id))
+        .collect::<Vec<_>>()
+        .join(", ");
     println!();
     println!(
-        "  {} rosita ships {} — an agent skill that imports an existing CLAUDE.md/AGENTS.md",
+        "  {} rosita ships agent skills {}",
         p.cyan("✦"),
-        p.bold(&format!("'{}'", skill.id))
+        p.dim("(work in Claude Code, Codex, Gemini CLI, opencode)")
+    );
+    for skill in offerable {
+        println!(
+            "    {} — {}",
+            p.bold(skill.id),
+            skill_blurb(skill.id)
+        );
+    }
+    println!("  install to {}?", p.bold("~/.agents/skills"));
+    println!(
+        "    1) yes — install {}",
+        p.dim("(`rosita skill remove` undoes this)")
     );
     println!(
-        "    into rosita fragments & profiles {}",
-        p.dim("(works in Claude Code, Codex, Gemini CLI, opencode)")
+        "    2) no — don't ask again {}",
+        p.dim("(`rosita skill install` re-enables)")
     );
-    println!(
-        "  install it to {}?",
-        p.bold("~/.agents/skills")
-    );
-    println!("    1) yes — install {}", p.dim("(`rosita skill remove` undoes this)"));
-    println!("    2) no — don't ask again {}", p.dim("(`rosita skill install` re-enables)"));
 
     loop {
         print!("  ❯ ");
@@ -396,8 +418,10 @@ fn offer_skill(
         }
         match line.trim() {
             "1" => {
-                skills::install(home, skill)?;
-                crate::binding::write_skill_decision(skill.id, SkillDecision::Accepted)?;
+                for skill in offerable {
+                    skills::install(home, skill)?;
+                    crate::binding::write_skill_decision(skill.id, SkillDecision::Accepted)?;
+                }
                 println!(
                     "{}",
                     step(
@@ -405,20 +429,30 @@ fn offer_skill(
                         p.green("✓"),
                         "skill",
                         format!(
-                            "'{}' installed → {}",
-                            skill.id,
-                            skills::canonical_dir(home, skill.id).display()
+                            "{ids} installed → {}",
+                            home.join(".agents").join("skills").display()
                         ),
                     )
                 );
                 return Ok(());
             }
             "2" => {
-                crate::binding::write_skill_decision(skill.id, SkillDecision::Declined)?;
+                for skill in offerable {
+                    crate::binding::write_skill_decision(skill.id, SkillDecision::Declined)?;
+                }
                 return Ok(());
             }
             _ => println!("  please enter 1 or 2."),
         }
+    }
+}
+
+/// One-line pitch per shipped skill for the bundled offer.
+fn skill_blurb(id: &str) -> &'static str {
+    match id {
+        "rosita-migrate" => "imports an existing CLAUDE.md/AGENTS.md into rosita",
+        "rosita-remember" => "saves durable preferences you state mid-session as rosita guidance",
+        _ => "an agent skill shipped with rosita",
     }
 }
 

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -1,0 +1,208 @@
+//! `rosita skill` — install, remove, and inspect the skills rosita ships.
+//!
+//! The sole lifecycle path for embedded skills (see [`crate::skills`]):
+//! `clean` stays repo-scoped and never touches them, and the ask-once prompt
+//! in `rosita run` is just a frontend over `install`. Installing records an
+//! `accepted` decision; removing records `declined` so `run` won't re-offer —
+//! `rosita skill install` is the re-enable path.
+
+use anyhow::anyhow;
+
+use super::Runtime;
+use crate::binding::{self, SkillDecision};
+use crate::cli::{SkillAction, SkillArgs};
+use crate::config;
+use crate::skills::{self, InstallAction, LinkState, Skill, SkillState};
+use crate::style::Painter;
+
+/// Entry point for `rosita skill`.
+pub fn run(rt: &Runtime, args: &SkillArgs) -> crate::Result<()> {
+    match args.action.as_ref().unwrap_or(&SkillAction::Status) {
+        SkillAction::Status => status(),
+        SkillAction::Install { id } => install(rt, id.as_deref()),
+        SkillAction::Remove { id } => remove(rt, id.as_deref()),
+    }
+}
+
+/// Resolve `id` to one shipped skill, or all of them when omitted.
+fn targets(id: Option<&str>) -> crate::Result<Vec<&'static Skill>> {
+    match id {
+        None => Ok(skills::all().iter().collect()),
+        Some(id) => skills::by_id(id).map(|s| vec![s]).ok_or_else(|| {
+            anyhow!(
+                "unknown skill '{id}' — shipped skills: {}",
+                skills::all()
+                    .iter()
+                    .map(|s| s.id)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        }),
+    }
+}
+
+fn home() -> crate::Result<std::path::PathBuf> {
+    config::home_dir().ok_or_else(|| anyhow!("cannot resolve $HOME"))
+}
+
+/// `rosita skill install [id]`.
+fn install(rt: &Runtime, id: Option<&str>) -> crate::Result<()> {
+    let p = Painter::auto();
+    let home = home()?;
+    for skill in targets(id)? {
+        if rt.dry_run {
+            describe_plan(&p, &home, skill);
+            continue;
+        }
+        let actions = skills::install(&home, skill)?;
+        binding::write_skill_decision(skill.id, SkillDecision::Accepted)?;
+        report_actions(&p, skill, &actions);
+    }
+    Ok(())
+}
+
+/// `rosita skill remove [id]`.
+fn remove(rt: &Runtime, id: Option<&str>) -> crate::Result<()> {
+    let p = Painter::auto();
+    let home = home()?;
+    for skill in targets(id)? {
+        if rt.dry_run {
+            println!(
+                "  {} (dry-run) would remove {} and its agent links",
+                p.cyan("→"),
+                skills::canonical_dir(&home, skill.id).display()
+            );
+            continue;
+        }
+        let removed = skills::remove(&home, skill)?;
+        // Remember the opt-out so `rosita run` doesn't immediately re-offer it.
+        binding::write_skill_decision(skill.id, SkillDecision::Declined)?;
+        if removed.is_empty() {
+            println!("  {} {} was not installed", p.dim("·"), p.bold(skill.id));
+        } else {
+            for path in removed {
+                println!("  {} removed {}", p.green("✓"), path.display());
+            }
+            println!(
+                "    {}",
+                p.dim("re-enable any time with `rosita skill install`")
+            );
+        }
+    }
+    Ok(())
+}
+
+/// `rosita skill [status]`.
+fn status() -> crate::Result<()> {
+    let p = Painter::auto();
+    let home = home()?;
+    for skill in skills::all() {
+        let st = skills::status(&home, skill);
+        let decision = match binding::read_skill_decision(skill.id) {
+            Some(SkillDecision::Accepted) => "accepted",
+            Some(SkillDecision::Declined) => "declined",
+            None => "undecided",
+        };
+        let state = match &st.state {
+            SkillState::NotInstalled => p.dim("not installed"),
+            SkillState::Unmanaged => p.yellow("present but not rosita-managed"),
+            SkillState::Managed {
+                user_modified: true,
+                ..
+            } => p.yellow("installed, edited by you (auto-upgrade off)"),
+            SkillState::Managed {
+                upgrade_available: true,
+                ..
+            } => p.cyan("installed, upgrade available (`rosita skill install`)"),
+            SkillState::Managed { .. } => p.green("installed, current"),
+        };
+        println!(
+            "  {} — {state} {}",
+            p.bold(skill.id),
+            p.dim(&format!("(decision: {decision})"))
+        );
+        println!(
+            "    {}",
+            p.dim(&format!(
+                "canonical: {}",
+                skills::canonical_dir(&home, skill.id).display()
+            ))
+        );
+        if st.state == SkillState::NotInstalled {
+            continue; // no install → per-agent link detail is just noise
+        }
+        for link in &st.links {
+            let what = match link.state {
+                LinkState::AgentAbsent => continue, // agent not installed; nothing expected
+                LinkState::Linked => p.green("linked"),
+                LinkState::Missing => p.yellow("missing (`rosita skill install` repairs)"),
+                LinkState::Dangling => p.yellow("dangling (`rosita skill install` repairs)"),
+                LinkState::CopyManaged => p.cyan("copy (symlink fallback)"),
+                LinkState::Foreign => p.yellow("occupied by a file rosita didn't create"),
+            };
+            println!("    {}", p.dim(&format!("{}: {what}", link.path.display())));
+        }
+    }
+    Ok(())
+}
+
+fn describe_plan(p: &Painter, home: &std::path::Path, skill: &Skill) {
+    let st = skills::status(home, skill);
+    let verb = match st.state {
+        SkillState::NotInstalled => "install",
+        SkillState::Managed {
+            user_modified: false,
+            upgrade_available: true,
+            ..
+        } => "upgrade",
+        _ => "leave as-is",
+    };
+    println!(
+        "  {} (dry-run) would {verb} {} at {}",
+        p.cyan("→"),
+        p.bold(skill.id),
+        skills::canonical_dir(home, skill.id).display()
+    );
+}
+
+fn report_actions(p: &Painter, skill: &Skill, actions: &[InstallAction]) {
+    for a in actions {
+        match a {
+            InstallAction::WroteCanonical(path) => {
+                println!("  {} installed {} → {}", p.green("✓"), p.bold(skill.id), path.display());
+            }
+            InstallAction::CanonicalCurrent(path) => {
+                println!(
+                    "  {} {} already current at {}",
+                    p.green("✓"),
+                    p.bold(skill.id),
+                    path.display()
+                );
+            }
+            InstallAction::SkippedModified(path) => {
+                println!(
+                    "  {} {} at {} has local edits — left untouched",
+                    p.yellow("⚠"),
+                    p.bold(skill.id),
+                    path.display()
+                );
+            }
+            InstallAction::Linked(path) => {
+                println!("    {}", p.dim(&format!("linked {}", path.display())));
+            }
+            InstallAction::Copied(path) => {
+                println!(
+                    "    {}",
+                    p.dim(&format!("copied to {} (symlink unavailable)", path.display()))
+                );
+            }
+            InstallAction::SkippedForeign(path) => {
+                println!(
+                    "  {} {} exists and isn't rosita's — left untouched",
+                    p.yellow("⚠"),
+                    path.display()
+                );
+            }
+        }
+    }
+}

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -169,7 +169,12 @@ fn report_actions(p: &Painter, skill: &Skill, actions: &[InstallAction]) {
     for a in actions {
         match a {
             InstallAction::WroteCanonical(path) => {
-                println!("  {} installed {} → {}", p.green("✓"), p.bold(skill.id), path.display());
+                println!(
+                    "  {} installed {} → {}",
+                    p.green("✓"),
+                    p.bold(skill.id),
+                    path.display()
+                );
             }
             InstallAction::UpgradedCanonical(path) => {
                 println!(
@@ -201,7 +206,10 @@ fn report_actions(p: &Painter, skill: &Skill, actions: &[InstallAction]) {
             InstallAction::Copied(path) => {
                 println!(
                     "    {}",
-                    p.dim(&format!("copied to {} (symlink unavailable)", path.display()))
+                    p.dim(&format!(
+                        "copied to {} (symlink unavailable)",
+                        path.display()
+                    ))
                 );
             }
             InstallAction::SkippedForeign(path) => {

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -171,6 +171,14 @@ fn report_actions(p: &Painter, skill: &Skill, actions: &[InstallAction]) {
             InstallAction::WroteCanonical(path) => {
                 println!("  {} installed {} → {}", p.green("✓"), p.bold(skill.id), path.display());
             }
+            InstallAction::UpgradedCanonical(path) => {
+                println!(
+                    "  {} upgraded {} to this rosita's version → {}",
+                    p.green("⟳"),
+                    p.bold(skill.id),
+                    path.display()
+                );
+            }
             InstallAction::CanonicalCurrent(path) => {
                 println!(
                     "  {} {} already current at {}",

--- a/src/config.rs
+++ b/src/config.rs
@@ -914,7 +914,10 @@ mod tests {
     "#;
 
     fn assert_operational_tables_stripped(c: &Config) {
-        assert_eq!(c.default_agent, "claude", "repo must not change [defaults].agent");
+        assert_eq!(
+            c.default_agent, "claude",
+            "repo must not change [defaults].agent"
+        );
         assert!(c.sync.auto_pull, "repo must not change [sync].auto_pull");
         assert!(c.sync.auto_push, "repo must not change [sync].auto_push");
         assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod providers;
 pub mod redact;
 pub mod render;
 pub mod report;
+pub mod skills;
 pub mod studio;
 pub mod style;
 pub mod sync;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ fn main() -> ExitCode {
         Command::Agents(args) => commands::introspect::agents(&rt, args),
         Command::Studio(args) => rosita::studio::serve(&rt, args),
         Command::Sync(args) => commands::sync::run(&rt, args),
+        Command::Skill(args) => commands::skill::run(&rt, args),
         Command::Update(args) => commands::update::run(&rt, args),
     };
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -348,7 +348,8 @@ pub fn install(home: &Path, skill: &Skill) -> Result<Vec<InstallAction>> {
             actions.push(InstallAction::UpgradedCanonical(dir.clone()));
         }
         SkillState::Managed {
-            user_modified: true, ..
+            user_modified: true,
+            ..
         } => actions.push(InstallAction::SkippedModified(dir.clone())),
         SkillState::Unmanaged => actions.push(InstallAction::SkippedModified(dir.clone())),
         SkillState::Managed { .. } => actions.push(InstallAction::CanonicalCurrent(dir.clone())),
@@ -503,12 +504,19 @@ mod tests {
         assert!(actions.contains(&InstallAction::Linked(
             h.path().join(".claude/skills").join(MIGRATE.id)
         )));
-        assert!(!h.path().join(".codex").exists(), "codex dir must not be created");
+        assert!(
+            !h.path().join(".codex").exists(),
+            "codex dir must not be created"
+        );
 
         let st = status(h.path(), &MIGRATE);
         assert!(matches!(
             st.state,
-            SkillState::Managed { user_modified: false, upgrade_available: false, .. }
+            SkillState::Managed {
+                user_modified: false,
+                upgrade_available: false,
+                ..
+            }
         ));
         assert!(st
             .links
@@ -552,11 +560,19 @@ mod tests {
         std::fs::write(&refpath, &text).unwrap();
 
         let st = status(h.path(), &MIGRATE);
-        assert!(matches!(st.state, SkillState::Managed { user_modified: true, .. }));
+        assert!(matches!(
+            st.state,
+            SkillState::Managed {
+                user_modified: true,
+                ..
+            }
+        ));
 
         let actions = install(h.path(), &MIGRATE).unwrap();
         assert!(actions.contains(&InstallAction::SkippedModified(dir)));
-        assert!(std::fs::read_to_string(&refpath).unwrap().contains("user note"));
+        assert!(std::fs::read_to_string(&refpath)
+            .unwrap()
+            .contains("user note"));
     }
 
     #[test]
@@ -611,7 +627,11 @@ mod tests {
         let st = status(h.path(), &MIGRATE);
         assert!(matches!(
             st.state,
-            SkillState::Managed { user_modified: false, upgrade_available: true, .. }
+            SkillState::Managed {
+                user_modified: false,
+                upgrade_available: true,
+                ..
+            }
         ));
 
         let actions = install(h.path(), &MIGRATE).unwrap();
@@ -619,7 +639,11 @@ mod tests {
         let st = status(h.path(), &MIGRATE);
         assert!(matches!(
             st.state,
-            SkillState::Managed { user_modified: false, upgrade_available: false, .. }
+            SkillState::Managed {
+                user_modified: false,
+                upgrade_available: false,
+                ..
+            }
         ));
     }
 }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,0 +1,597 @@
+//! Embedded agent skills — install, inspect, upgrade, remove.
+//!
+//! rosita ships agent skills (SKILL.md directories per the cross-agent Agent
+//! Skills format) embedded in the binary, so installer-based users get them
+//! without a repo checkout. The canonical install location is
+//! `~/.agents/skills/<id>/` — read natively by Gemini CLI and opencode — with
+//! symlinks from `~/.claude/skills/<id>` and `~/.codex/skills/<id>` for agents
+//! that only scan their own dotdir. Symlinks are only created when the agent's
+//! dotdir already exists (no littering for agents the user doesn't have), and
+//! fall back to a marked copy where symlinking fails.
+//!
+//! Installed SKILL.md files carry a managed marker line (after the YAML
+//! frontmatter) holding the content hash of the installed version. Three hashes
+//! drive the lifecycle:
+//!
+//! - **marker hash** — what rosita last installed;
+//! - **embedded hash** — what this binary ships;
+//! - **on-disk hash** — recomputed from the files (marker stripped).
+//!
+//! managed = marker present; user-modified = on-disk ≠ marker (never touched
+//! again; `doctor` warns); upgrade available = marker ≠ embedded. The ask-once
+//! install decision is remembered per-machine in the bindings store (see
+//! [`crate::binding`]); all lifecycle changes go through `rosita skill …` —
+//! `clean` stays repo-scoped and never touches skills.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context as _, Result};
+
+use crate::hash;
+use crate::writer::atomic_write;
+
+/// One file of an embedded skill.
+#[derive(Debug, Clone, Copy)]
+pub struct SkillFile {
+    /// Path relative to the skill directory (e.g. `SKILL.md`).
+    pub relpath: &'static str,
+    /// Embedded content (the repo source, marker-free).
+    pub content: &'static str,
+}
+
+/// An embedded skill: a directory of files identified by a stable id.
+#[derive(Debug, Clone, Copy)]
+pub struct Skill {
+    /// Stable id — also the install directory name.
+    pub id: &'static str,
+    /// The files; the first must be `SKILL.md`.
+    pub files: &'static [SkillFile],
+}
+
+/// The `rosita-migrate` skill: imports an existing CLAUDE.md/AGENTS.md into
+/// rosita fragments + profiles.
+pub const MIGRATE: Skill = Skill {
+    id: "rosita-migrate",
+    files: &[
+        SkillFile {
+            relpath: "SKILL.md",
+            content: include_str!("../skills/rosita-migrate/SKILL.md"),
+        },
+        SkillFile {
+            relpath: "reference.md",
+            content: include_str!("../skills/rosita-migrate/reference.md"),
+        },
+    ],
+};
+
+/// Every skill shipped in this binary.
+pub fn all() -> &'static [Skill] {
+    &[MIGRATE]
+}
+
+/// Look up an embedded skill by id.
+pub fn by_id(id: &str) -> Option<&'static Skill> {
+    all().iter().find(|s| s.id == id)
+}
+
+// --- marker -------------------------------------------------------------------
+
+/// Prefix of the managed marker line written into installed SKILL.md files.
+pub const SKILL_MARKER: &str = "<!-- rosita:skill";
+
+fn marker_line(content_hash: &str) -> String {
+    format!(
+        "{SKILL_MARKER} content={content_hash} — installed by rosita; edits disable auto-upgrade; manage with `rosita skill` -->"
+    )
+}
+
+/// Extract the `content=sha256:…` hash from an installed SKILL.md, if marked.
+pub fn extract_marker_hash(skill_md: &str) -> Option<String> {
+    for line in skill_md.lines() {
+        let Some(rest) = line.trim_start().strip_prefix(SKILL_MARKER) else {
+            continue;
+        };
+        let Some(token) = rest.trim_start().strip_prefix("content=") else {
+            continue;
+        };
+        let hash: String = token.chars().take_while(|c| !c.is_whitespace()).collect();
+        if !hash.is_empty() {
+            return Some(hash);
+        }
+    }
+    None
+}
+
+/// Remove any managed marker lines, restoring the embedded content byte-for-byte.
+fn strip_marker(content: &str) -> String {
+    // Filter marker lines while preserving the original line endings exactly:
+    // split inclusively so unmarked content round-trips unchanged.
+    content
+        .split_inclusive('\n')
+        .filter(|line| !line.trim_start().starts_with(SKILL_MARKER))
+        .collect()
+}
+
+/// Insert the marker line after the YAML frontmatter (agents require the
+/// frontmatter to open the file); prepends if no frontmatter is found.
+fn insert_marker(content: &str, content_hash: &str) -> String {
+    let marker = marker_line(content_hash);
+    if let Some(rest) = content.strip_prefix("---\n") {
+        if let Some(end) = rest.find("\n---\n") {
+            let split = 4 + end + 5; // opening "---\n" + body + closing "\n---\n"
+            return format!("{}{}\n{}", &content[..split], marker, &content[split..]);
+        }
+    }
+    format!("{}\n{}", marker, content)
+}
+
+// --- hashes -------------------------------------------------------------------
+
+/// `sha256:…` over the skill's embedded files (relpath + content).
+pub fn embedded_hash(skill: &Skill) -> String {
+    let pairs: Vec<(&str, &str)> = skill.files.iter().map(|f| (f.relpath, f.content)).collect();
+    hash::context_hash(&pairs)
+}
+
+/// Recompute the content hash from an installed directory, stripping markers.
+/// `None` if any manifest file is missing or unreadable.
+fn on_disk_hash(dir: &Path, skill: &Skill) -> Option<String> {
+    let mut pairs: Vec<(&str, String)> = Vec::new();
+    for f in skill.files {
+        let text = std::fs::read_to_string(dir.join(f.relpath)).ok()?;
+        pairs.push((f.relpath, strip_marker(&text)));
+    }
+    Some(hash::context_hash(&pairs))
+}
+
+// --- layout -------------------------------------------------------------------
+
+/// Agent dotdirs that need their own `skills/` entry (symlinked to canonical).
+/// Gemini CLI and opencode read `~/.agents/skills/` natively and need nothing.
+const LINKED_AGENT_DIRS: &[&str] = &[".claude", ".codex"];
+
+/// Canonical install directory: `<home>/.agents/skills/<id>`.
+pub fn canonical_dir(home: &Path, id: &str) -> PathBuf {
+    home.join(".agents").join("skills").join(id)
+}
+
+fn link_path(home: &Path, dotdir: &str, id: &str) -> PathBuf {
+    home.join(dotdir).join("skills").join(id)
+}
+
+// --- status -------------------------------------------------------------------
+
+/// State of the canonical install.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillState {
+    /// Canonical directory absent.
+    NotInstalled,
+    /// Marker present: rosita manages this install.
+    Managed {
+        /// Hash recorded by the marker (the installed version).
+        marker_hash: String,
+        /// On-disk content (marker stripped) no longer matches the marker —
+        /// the user edited the files; rosita won't touch them again.
+        user_modified: bool,
+        /// The binary ships a different version than the marker records.
+        upgrade_available: bool,
+    },
+    /// Files exist but carry no marker — the user's own copy; never touched.
+    Unmanaged,
+}
+
+/// State of one agent-dotdir link.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkStatus {
+    /// The agent dotdir (e.g. `.claude`).
+    pub dotdir: &'static str,
+    /// The link/copy path under that dotdir.
+    pub path: PathBuf,
+    /// What's there.
+    pub state: LinkState,
+}
+
+/// What occupies an agent-dotdir skill path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkState {
+    /// Agent dotdir absent — agent not installed; nothing expected.
+    AgentAbsent,
+    /// Symlink resolving to the canonical directory.
+    Linked,
+    /// Nothing there (agent present, link missing).
+    Missing,
+    /// Symlink exists but its target is gone or isn't the canonical dir.
+    Dangling,
+    /// A real directory carrying our marker (Windows/copy-fallback install).
+    CopyManaged,
+    /// A real file/dir without our marker — the user's own; never touched.
+    Foreign,
+}
+
+/// Full install status for a skill under `home`.
+#[derive(Debug, Clone)]
+pub struct SkillStatus {
+    /// Canonical directory state.
+    pub state: SkillState,
+    /// Per-agent link states.
+    pub links: Vec<LinkStatus>,
+}
+
+/// Inspect the install under `home` (pure filesystem; no decision state).
+pub fn status(home: &Path, skill: &Skill) -> SkillStatus {
+    let dir = canonical_dir(home, skill.id);
+    let state = if !dir.exists() {
+        SkillState::NotInstalled
+    } else {
+        let skill_md = std::fs::read_to_string(dir.join("SKILL.md")).unwrap_or_default();
+        match extract_marker_hash(&skill_md) {
+            None => SkillState::Unmanaged,
+            Some(marker_hash) => {
+                let on_disk = on_disk_hash(&dir, skill);
+                SkillState::Managed {
+                    user_modified: on_disk.as_deref() != Some(marker_hash.as_str()),
+                    upgrade_available: marker_hash != embedded_hash(skill),
+                    marker_hash,
+                }
+            }
+        }
+    };
+
+    let links = LINKED_AGENT_DIRS
+        .iter()
+        .map(|dotdir| {
+            let path = link_path(home, dotdir, skill.id);
+            LinkStatus {
+                dotdir,
+                state: link_state(home, dotdir, &path, &dir),
+                path,
+            }
+        })
+        .collect();
+
+    SkillStatus { state, links }
+}
+
+fn link_state(home: &Path, dotdir: &str, path: &Path, canonical: &Path) -> LinkState {
+    if !home.join(dotdir).exists() {
+        return LinkState::AgentAbsent;
+    }
+    match std::fs::symlink_metadata(path) {
+        Err(_) => LinkState::Missing,
+        Ok(meta) if meta.is_symlink() => match (std::fs::read_link(path), path.exists()) {
+            (Ok(target), true) if resolves_to(path, &target, canonical) => LinkState::Linked,
+            _ => LinkState::Dangling,
+        },
+        Ok(_) => {
+            let skill_md = std::fs::read_to_string(path.join("SKILL.md")).unwrap_or_default();
+            if extract_marker_hash(&skill_md).is_some() {
+                LinkState::CopyManaged
+            } else {
+                LinkState::Foreign
+            }
+        }
+    }
+}
+
+/// Does `target` (as read from the symlink at `link`) point at `canonical`?
+fn resolves_to(link: &Path, target: &Path, canonical: &Path) -> bool {
+    let resolved = if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        link.parent().unwrap_or(Path::new("/")).join(target)
+    };
+    // Compare canonicalized forms when possible; fall back to literal paths.
+    match (resolved.canonicalize(), canonical.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => resolved == canonical,
+    }
+}
+
+// --- install / repair / remove -------------------------------------------------
+
+/// One line of an install/repair report, for the CLI to print.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallAction {
+    /// Wrote the canonical files (fresh install or upgrade).
+    WroteCanonical(PathBuf),
+    /// Canonical files already current; nothing written.
+    CanonicalCurrent(PathBuf),
+    /// Canonical files left alone: user-modified (or unmanaged).
+    SkippedModified(PathBuf),
+    /// Created a symlink in an agent dotdir.
+    Linked(PathBuf),
+    /// Symlinking failed; installed a marked copy instead.
+    Copied(PathBuf),
+    /// Existing foreign file/dir in the way; left alone.
+    SkippedForeign(PathBuf),
+}
+
+/// Install (or repair) the skill under `home`: write canonical files when new
+/// or upgrading a pristine managed install, then ensure links for every agent
+/// dotdir that exists. Idempotent; never touches user-modified or foreign
+/// files. Returns the actions taken.
+pub fn install(home: &Path, skill: &Skill) -> Result<Vec<InstallAction>> {
+    let mut actions = Vec::new();
+    let dir = canonical_dir(home, skill.id);
+    let current = status(home, skill);
+
+    match current.state {
+        SkillState::NotInstalled => {
+            write_skill_files(&dir, skill)?;
+            actions.push(InstallAction::WroteCanonical(dir.clone()));
+        }
+        SkillState::Managed {
+            user_modified: false,
+            upgrade_available: true,
+            ..
+        } => {
+            write_skill_files(&dir, skill)?;
+            actions.push(InstallAction::WroteCanonical(dir.clone()));
+        }
+        SkillState::Managed {
+            user_modified: true, ..
+        } => actions.push(InstallAction::SkippedModified(dir.clone())),
+        SkillState::Unmanaged => actions.push(InstallAction::SkippedModified(dir.clone())),
+        SkillState::Managed { .. } => actions.push(InstallAction::CanonicalCurrent(dir.clone())),
+    }
+
+    for link in status(home, skill).links {
+        match link.state {
+            LinkState::AgentAbsent | LinkState::Linked | LinkState::CopyManaged => {}
+            LinkState::Foreign => actions.push(InstallAction::SkippedForeign(link.path)),
+            LinkState::Missing | LinkState::Dangling => {
+                if link.state == LinkState::Dangling {
+                    remove_path(&link.path)?;
+                }
+                if let Some(parent) = link.path.parent() {
+                    std::fs::create_dir_all(parent)
+                        .with_context(|| format!("creating {}", parent.display()))?;
+                }
+                match make_symlink(&dir, &link.path) {
+                    Ok(()) => actions.push(InstallAction::Linked(link.path)),
+                    Err(_) => {
+                        // Copy fallback (e.g. Windows without symlink rights):
+                        // a marked, independent copy; doctor tracks its staleness.
+                        write_skill_files(&link.path, skill)?;
+                        actions.push(InstallAction::Copied(link.path));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(actions)
+}
+
+/// Remove the managed install: canonical dir (only when it carries our marker)
+/// plus every symlink/copy rosita created. Refuses to delete an unmanaged
+/// (marker-less) canonical dir. Returns the paths removed.
+pub fn remove(home: &Path, skill: &Skill) -> Result<Vec<PathBuf>> {
+    let current = status(home, skill);
+    let mut removed = Vec::new();
+
+    // Links first, so a failure midway never leaves links pointing at nothing.
+    for link in &current.links {
+        match link.state {
+            LinkState::Linked | LinkState::Dangling | LinkState::CopyManaged => {
+                remove_path(&link.path)?;
+                removed.push(link.path.clone());
+            }
+            _ => {}
+        }
+    }
+
+    let dir = canonical_dir(home, skill.id);
+    match current.state {
+        SkillState::NotInstalled => {}
+        SkillState::Unmanaged => bail!(
+            "{} exists but has no rosita marker — not removing a file rosita didn't install",
+            dir.display()
+        ),
+        SkillState::Managed { .. } => {
+            std::fs::remove_dir_all(&dir).with_context(|| format!("removing {}", dir.display()))?;
+            removed.push(dir);
+        }
+    }
+
+    Ok(removed)
+}
+
+fn write_skill_files(dir: &Path, skill: &Skill) -> Result<()> {
+    std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    let content_hash = embedded_hash(skill);
+    for f in skill.files {
+        let body = if f.relpath == "SKILL.md" {
+            insert_marker(f.content, &content_hash)
+        } else {
+            f.content.to_string()
+        };
+        atomic_write(&dir.join(f.relpath), &body)?;
+    }
+    Ok(())
+}
+
+fn remove_path(path: &Path) -> Result<()> {
+    let meta = std::fs::symlink_metadata(path)
+        .with_context(|| format!("inspecting {}", path.display()))?;
+    if meta.is_dir() {
+        std::fs::remove_dir_all(path).with_context(|| format!("removing {}", path.display()))
+    } else {
+        std::fs::remove_file(path).with_context(|| format!("removing {}", path.display()))
+    }
+}
+
+#[cfg(unix)]
+fn make_symlink(target: &Path, link: &Path) -> Result<()> {
+    std::os::unix::fs::symlink(target, link)
+        .with_context(|| format!("symlinking {} → {}", link.display(), target.display()))
+}
+
+#[cfg(not(unix))]
+fn make_symlink(_target: &Path, _link: &Path) -> Result<()> {
+    Err(anyhow::anyhow!("symlinks unavailable on this platform"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn home() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn embedded_skill_md_has_frontmatter_and_no_marker() {
+        let md = MIGRATE.files[0].content;
+        assert!(md.starts_with("---\n"), "SKILL.md must open with frontmatter");
+        assert!(!md.contains(SKILL_MARKER));
+        // The skill must be portable: no Claude-only dynamic preamble.
+        assert!(
+            !md.contains("!`"),
+            "SKILL.md must not use Claude-only dynamic preamble commands"
+        );
+    }
+
+    #[test]
+    fn marker_insert_after_frontmatter_round_trips() {
+        let src = "---\nname: x\n---\n\n# Title\nbody\n";
+        let marked = insert_marker(src, "sha256:abc");
+        let lines: Vec<&str> = marked.lines().collect();
+        assert_eq!(lines[2], "---");
+        assert!(lines[3].starts_with(SKILL_MARKER));
+        assert_eq!(extract_marker_hash(&marked).as_deref(), Some("sha256:abc"));
+        assert_eq!(strip_marker(&marked), src);
+    }
+
+    #[test]
+    fn fresh_install_links_only_existing_agent_dirs() {
+        let h = home();
+        std::fs::create_dir_all(h.path().join(".claude")).unwrap(); // claude present, codex absent
+        let actions = install(h.path(), &MIGRATE).unwrap();
+
+        let dir = canonical_dir(h.path(), MIGRATE.id);
+        assert!(dir.join("SKILL.md").exists());
+        assert!(dir.join("reference.md").exists());
+        assert!(actions.contains(&InstallAction::WroteCanonical(dir.clone())));
+        assert!(actions.contains(&InstallAction::Linked(
+            h.path().join(".claude/skills").join(MIGRATE.id)
+        )));
+        assert!(!h.path().join(".codex").exists(), "codex dir must not be created");
+
+        let st = status(h.path(), &MIGRATE);
+        assert!(matches!(
+            st.state,
+            SkillState::Managed { user_modified: false, upgrade_available: false, .. }
+        ));
+        assert!(st
+            .links
+            .iter()
+            .any(|l| l.dotdir == ".claude" && l.state == LinkState::Linked));
+        assert!(st
+            .links
+            .iter()
+            .any(|l| l.dotdir == ".codex" && l.state == LinkState::AgentAbsent));
+    }
+
+    #[test]
+    fn reinstall_is_idempotent_and_repairs_deleted_symlink() {
+        let h = home();
+        std::fs::create_dir_all(h.path().join(".claude")).unwrap();
+        install(h.path(), &MIGRATE).unwrap();
+
+        // Second run: canonical current, nothing rewritten.
+        let actions = install(h.path(), &MIGRATE).unwrap();
+        let dir = canonical_dir(h.path(), MIGRATE.id);
+        assert!(actions.contains(&InstallAction::CanonicalCurrent(dir)));
+
+        // Delete only the symlink → repaired regardless of version.
+        let link = h.path().join(".claude/skills").join(MIGRATE.id);
+        std::fs::remove_file(&link).unwrap();
+        let actions = install(h.path(), &MIGRATE).unwrap();
+        assert!(actions.contains(&InstallAction::Linked(link.clone())));
+        assert!(link.exists());
+    }
+
+    #[test]
+    fn user_modified_install_is_never_overwritten() {
+        let h = home();
+        install(h.path(), &MIGRATE).unwrap();
+        let dir = canonical_dir(h.path(), MIGRATE.id);
+
+        // Edit a non-marker file.
+        let refpath = dir.join("reference.md");
+        let mut text = std::fs::read_to_string(&refpath).unwrap();
+        text.push_str("\nuser note\n");
+        std::fs::write(&refpath, &text).unwrap();
+
+        let st = status(h.path(), &MIGRATE);
+        assert!(matches!(st.state, SkillState::Managed { user_modified: true, .. }));
+
+        let actions = install(h.path(), &MIGRATE).unwrap();
+        assert!(actions.contains(&InstallAction::SkippedModified(dir)));
+        assert!(std::fs::read_to_string(&refpath).unwrap().contains("user note"));
+    }
+
+    #[test]
+    fn unmanaged_dir_is_never_touched_or_removed() {
+        let h = home();
+        let dir = canonical_dir(h.path(), MIGRATE.id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("SKILL.md"), "---\nname: mine\n---\nmy own skill\n").unwrap();
+
+        assert_eq!(status(h.path(), &MIGRATE).state, SkillState::Unmanaged);
+        let actions = install(h.path(), &MIGRATE).unwrap();
+        assert!(actions.contains(&InstallAction::SkippedModified(dir.clone())));
+        assert!(std::fs::read_to_string(dir.join("SKILL.md"))
+            .unwrap()
+            .contains("my own skill"));
+        assert!(remove(h.path(), &MIGRATE).is_err());
+    }
+
+    #[test]
+    fn remove_deletes_canonical_and_links() {
+        let h = home();
+        std::fs::create_dir_all(h.path().join(".claude")).unwrap();
+        std::fs::create_dir_all(h.path().join(".codex")).unwrap();
+        install(h.path(), &MIGRATE).unwrap();
+
+        let removed = remove(h.path(), &MIGRATE).unwrap();
+        assert_eq!(removed.len(), 3); // two links + canonical dir
+        assert_eq!(status(h.path(), &MIGRATE).state, SkillState::NotInstalled);
+        assert!(!h.path().join(".claude/skills").join(MIGRATE.id).exists());
+
+        // Removing again is a no-op.
+        assert!(remove(h.path(), &MIGRATE).unwrap().is_empty());
+    }
+
+    #[test]
+    fn stale_marker_reports_upgrade_and_reinstall_refreshes() {
+        let h = home();
+        let dir = canonical_dir(h.path(), MIGRATE.id);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Hand-build a *pristine* older install: the marker hash matches the
+        // on-disk content but differs from what this binary embeds.
+        let old_skill_md = "---\nname: rosita-migrate\n---\nold body\n";
+        let old_reference = "old reference\n";
+        let old_hash = hash::context_hash(&[
+            ("SKILL.md", old_skill_md.to_string()),
+            ("reference.md", old_reference.to_string()),
+        ]);
+        std::fs::write(dir.join("SKILL.md"), insert_marker(old_skill_md, &old_hash)).unwrap();
+        std::fs::write(dir.join("reference.md"), old_reference).unwrap();
+
+        let st = status(h.path(), &MIGRATE);
+        assert!(matches!(
+            st.state,
+            SkillState::Managed { user_modified: false, upgrade_available: true, .. }
+        ));
+
+        install(h.path(), &MIGRATE).unwrap();
+        let st = status(h.path(), &MIGRATE);
+        assert!(matches!(
+            st.state,
+            SkillState::Managed { user_modified: false, upgrade_available: false, .. }
+        ));
+    }
+}

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -309,8 +309,10 @@ fn resolves_to(link: &Path, target: &Path, canonical: &Path) -> bool {
 /// One line of an install/repair report, for the CLI to print.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InstallAction {
-    /// Wrote the canonical files (fresh install or upgrade).
+    /// Wrote the canonical files (fresh install).
     WroteCanonical(PathBuf),
+    /// Rewrote a pristine managed install with this binary's newer version.
+    UpgradedCanonical(PathBuf),
     /// Canonical files already current; nothing written.
     CanonicalCurrent(PathBuf),
     /// Canonical files left alone: user-modified (or unmanaged).
@@ -343,7 +345,7 @@ pub fn install(home: &Path, skill: &Skill) -> Result<Vec<InstallAction>> {
             ..
         } => {
             write_skill_files(&dir, skill)?;
-            actions.push(InstallAction::WroteCanonical(dir.clone()));
+            actions.push(InstallAction::UpgradedCanonical(dir.clone()));
         }
         SkillState::Managed {
             user_modified: true, ..
@@ -612,7 +614,8 @@ mod tests {
             SkillState::Managed { user_modified: false, upgrade_available: true, .. }
         ));
 
-        install(h.path(), &MIGRATE).unwrap();
+        let actions = install(h.path(), &MIGRATE).unwrap();
+        assert!(actions.contains(&InstallAction::UpgradedCanonical(dir)));
         let st = status(h.path(), &MIGRATE);
         assert!(matches!(
             st.state,

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -64,9 +64,26 @@ pub const MIGRATE: Skill = Skill {
     ],
 };
 
+/// The `rosita-remember` skill: saves durable, cross-project user guidance
+/// into rosita fragments — the ongoing-maintenance complement to migrate's
+/// one-time import.
+pub const REMEMBER: Skill = Skill {
+    id: "rosita-remember",
+    files: &[
+        SkillFile {
+            relpath: "SKILL.md",
+            content: include_str!("../skills/rosita-remember/SKILL.md"),
+        },
+        SkillFile {
+            relpath: "reference.md",
+            content: include_str!("../skills/rosita-remember/reference.md"),
+        },
+    ],
+};
+
 /// Every skill shipped in this binary.
 pub fn all() -> &'static [Skill] {
-    &[MIGRATE]
+    &[MIGRATE, REMEMBER]
 }
 
 /// Look up an embedded skill by id.
@@ -441,15 +458,23 @@ mod tests {
     }
 
     #[test]
-    fn embedded_skill_md_has_frontmatter_and_no_marker() {
-        let md = MIGRATE.files[0].content;
-        assert!(md.starts_with("---\n"), "SKILL.md must open with frontmatter");
-        assert!(!md.contains(SKILL_MARKER));
-        // The skill must be portable: no Claude-only dynamic preamble.
-        assert!(
-            !md.contains("!`"),
-            "SKILL.md must not use Claude-only dynamic preamble commands"
-        );
+    fn embedded_skill_mds_have_frontmatter_and_no_marker() {
+        for skill in all() {
+            assert_eq!(skill.files[0].relpath, "SKILL.md");
+            let md = skill.files[0].content;
+            assert!(
+                md.starts_with("---\n"),
+                "{}: SKILL.md must open with frontmatter",
+                skill.id
+            );
+            assert!(!md.contains(SKILL_MARKER), "{}: embedded marker", skill.id);
+            // The skills must be portable: no Claude-only dynamic preamble.
+            assert!(
+                !md.contains("!`"),
+                "{}: SKILL.md must not use Claude-only dynamic preamble commands",
+                skill.id
+            );
+        }
     }
 
     #[test]

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -2574,8 +2574,9 @@ mod tests {
 
     #[test]
     fn skill_card_route_serves_a_card() {
-        // Read-only against the real $HOME: whatever the install state, the
-        // card names the skill and never errors.
+        // Read-only against the real $HOME, so the install state varies by
+        // machine — every card state must name the skills (the assertion below
+        // is what keeps this test environment-independent).
         let d = rust_repo();
         let st = state_for(d.path(), None);
         let r = route(&st, &req("GET", "/skills/card", "", &[HOST, COOKIE], ""));

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -145,6 +145,8 @@ pub fn route(state: &Arc<Mutex<StudioState>>, req: &Req) -> Resp {
         ("POST", "/targets") => handle_target_save(state, req),
         ("POST", "/targets/try") => handle_target_try(state, req),
         ("GET", "/packs") => handle_packs(state),
+        ("GET", "/skills/card") => handle_skill_card(),
+        ("POST", "/skills/install") => handle_skill_install(),
         ("GET", "/onboarding/welcome") => handle_onboarding_welcome(state),
         ("POST", "/onboarding/quickstart") => handle_quickstart(state),
         ("GET", "/profiles/new") => handle_profile_new(state),
@@ -813,6 +815,59 @@ fn handle_quickstart(state: &Arc<Mutex<StudioState>>) -> Resp {
         Some(p) => apply_pack_and_show(state, &p),
         None => handle_packs(state),
     }
+}
+
+// --- agent skill card ----------------------------------------------------------
+
+/// Derive the skill card's state from the real filesystem + decision store.
+/// Deliberately not part of the studio snapshot: skill install is a direct,
+/// immediate action on `~/.agents/skills`, not a staged config edit.
+fn skill_card_state(skill: &crate::skills::Skill) -> views::SkillCardState {
+    use crate::skills::SkillState;
+    let Some(home) = crate::config::home_dir() else {
+        return views::SkillCardState::HandsOff;
+    };
+    match crate::skills::status(&home, skill).state {
+        SkillState::NotInstalled => views::SkillCardState::Offer,
+        SkillState::Unmanaged
+        | SkillState::Managed {
+            user_modified: true,
+            ..
+        } => views::SkillCardState::HandsOff,
+        SkillState::Managed {
+            upgrade_available: true,
+            ..
+        } => views::SkillCardState::UpgradeAvailable,
+        SkillState::Managed { .. } => views::SkillCardState::Installed,
+    }
+}
+
+/// `GET /skills/card` — the lazily-loaded agent-skill card on the welcome screen.
+fn handle_skill_card() -> Resp {
+    let skill = &crate::skills::MIGRATE;
+    Resp::html(views::skill_card(skill.id, &skill_card_state(skill)))
+}
+
+/// `POST /skills/install` — install (or upgrade) the embedded skill NOW and
+/// record the accepted decision, then re-render the card. Gated client-side by
+/// `hx-confirm`; this is studio's one immediate-side-effect action (everything
+/// config-shaped stays in the staged session).
+fn handle_skill_install() -> Resp {
+    let skill = &crate::skills::MIGRATE;
+    let Some(home) = crate::config::home_dir() else {
+        return Resp::html(views::error_fragment("cannot resolve $HOME"));
+    };
+    if let Err(e) = crate::skills::install(&home, skill) {
+        return Resp::html(views::error_fragment(&format!("skill install failed: {e:#}")));
+    }
+    if let Err(e) =
+        crate::binding::write_skill_decision(skill.id, crate::binding::SkillDecision::Accepted)
+    {
+        return Resp::html(views::error_fragment(&format!(
+            "skill installed, but recording the decision failed: {e:#}"
+        )));
+    }
+    Resp::html(views::skill_card(skill.id, &skill_card_state(skill)))
 }
 
 /// `GET /onboarding/welcome` — (re)show the first-launch welcome on demand (the
@@ -2475,5 +2530,41 @@ mod tests {
         assert!(body.contains("fragment-detail"));
         assert!(body.contains("Fresh guidance"));
         assert!(body.contains("/close")); // modal-close loader appended
+    }
+
+    #[test]
+    fn welcome_embeds_the_lazy_skill_card_loader() {
+        // Fresh config → first-launch welcome → the skill card placeholder is
+        // present and wired to load itself from /skills/card.
+        let d = rust_repo();
+        let st = state_for(d.path(), None);
+        let body = body_of(route(
+            &st,
+            &req("GET", "/onboarding/welcome", "", &[HOST, COOKIE], ""),
+        ));
+        assert!(body.contains("id=\"skill-card\""));
+        assert!(body.contains("hx-get=\"/skills/card\""));
+    }
+
+    #[test]
+    fn skill_card_route_serves_a_card() {
+        // Read-only against the real $HOME: whatever the install state, the
+        // card names the skill and never errors.
+        let d = rust_repo();
+        let st = state_for(d.path(), None);
+        let r = route(&st, &req("GET", "/skills/card", "", &[HOST, COOKIE], ""));
+        assert_eq!(r.status, 200);
+        let body = String::from_utf8(r.body).unwrap();
+        assert!(body.contains("rosita-migrate"));
+    }
+
+    #[test]
+    fn skill_install_requires_origin_like_all_mutations() {
+        // POST without Origin/Referer is rejected before the handler runs, so
+        // the CSRF guard covers the new immediate-side-effect route too.
+        let d = rust_repo();
+        let st = state_for(d.path(), None);
+        let r = route(&st, &req("POST", "/skills/install", "", &[HOST, COOKIE], ""));
+        assert_eq!(r.status, 403);
     }
 }

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -2591,7 +2591,10 @@ mod tests {
         // the CSRF guard covers the new immediate-side-effect route too.
         let d = rust_repo();
         let st = state_for(d.path(), None);
-        let r = route(&st, &req("POST", "/skills/install", "", &[HOST, COOKIE], ""));
+        let r = route(
+            &st,
+            &req("POST", "/skills/install", "", &[HOST, COOKIE], ""),
+        );
         assert_eq!(r.status, 403);
     }
 }

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -819,55 +819,81 @@ fn handle_quickstart(state: &Arc<Mutex<StudioState>>) -> Resp {
 
 // --- agent skill card ----------------------------------------------------------
 
-/// Derive the skill card's state from the real filesystem + decision store.
+/// Derive the skill card's state from the real filesystem + decision store,
+/// aggregated over every shipped skill (the card offers them as one bundle).
 /// Deliberately not part of the studio snapshot: skill install is a direct,
 /// immediate action on `~/.agents/skills`, not a staged config edit.
-fn skill_card_state(skill: &crate::skills::Skill) -> views::SkillCardState {
+fn skill_card_state() -> views::SkillCardState {
     use crate::skills::SkillState;
     let Some(home) = crate::config::home_dir() else {
         return views::SkillCardState::HandsOff;
     };
-    match crate::skills::status(&home, skill).state {
-        SkillState::NotInstalled => views::SkillCardState::Offer,
-        SkillState::Unmanaged
-        | SkillState::Managed {
-            user_modified: true,
-            ..
-        } => views::SkillCardState::HandsOff,
-        SkillState::Managed {
-            upgrade_available: true,
-            ..
-        } => views::SkillCardState::UpgradeAvailable,
-        SkillState::Managed { .. } => views::SkillCardState::Installed,
+    let states: Vec<SkillState> = crate::skills::all()
+        .iter()
+        .map(|s| crate::skills::status(&home, s).state)
+        .collect();
+    if states.contains(&SkillState::NotInstalled) {
+        return views::SkillCardState::Offer;
     }
+    if states.iter().any(|s| {
+        matches!(
+            s,
+            SkillState::Managed {
+                user_modified: false,
+                upgrade_available: true,
+                ..
+            }
+        )
+    }) {
+        return views::SkillCardState::UpgradeAvailable;
+    }
+    if states.iter().all(|s| {
+        matches!(
+            s,
+            SkillState::Managed {
+                user_modified: false,
+                ..
+            }
+        )
+    }) {
+        return views::SkillCardState::Installed;
+    }
+    views::SkillCardState::HandsOff
+}
+
+fn skill_ids() -> Vec<&'static str> {
+    crate::skills::all().iter().map(|s| s.id).collect()
 }
 
 /// `GET /skills/card` — the lazily-loaded agent-skill card on the welcome screen.
 fn handle_skill_card() -> Resp {
-    let skill = &crate::skills::MIGRATE;
-    Resp::html(views::skill_card(skill.id, &skill_card_state(skill)))
+    Resp::html(views::skill_card(&skill_ids(), &skill_card_state()))
 }
 
-/// `POST /skills/install` — install (or upgrade) the embedded skill NOW and
-/// record the accepted decision, then re-render the card. Gated client-side by
+/// `POST /skills/install` — install (or upgrade) every embedded skill NOW and
+/// record the accepted decisions, then re-render the card. Gated client-side by
 /// `hx-confirm`; this is studio's one immediate-side-effect action (everything
 /// config-shaped stays in the staged session).
 fn handle_skill_install() -> Resp {
-    let skill = &crate::skills::MIGRATE;
     let Some(home) = crate::config::home_dir() else {
         return Resp::html(views::error_fragment("cannot resolve $HOME"));
     };
-    if let Err(e) = crate::skills::install(&home, skill) {
-        return Resp::html(views::error_fragment(&format!("skill install failed: {e:#}")));
+    for skill in crate::skills::all() {
+        if let Err(e) = crate::skills::install(&home, skill) {
+            return Resp::html(views::error_fragment(&format!(
+                "skill install failed for '{}': {e:#}",
+                skill.id
+            )));
+        }
+        if let Err(e) =
+            crate::binding::write_skill_decision(skill.id, crate::binding::SkillDecision::Accepted)
+        {
+            return Resp::html(views::error_fragment(&format!(
+                "skills installed, but recording the decision failed: {e:#}"
+            )));
+        }
     }
-    if let Err(e) =
-        crate::binding::write_skill_decision(skill.id, crate::binding::SkillDecision::Accepted)
-    {
-        return Resp::html(views::error_fragment(&format!(
-            "skill installed, but recording the decision failed: {e:#}"
-        )));
-    }
-    Resp::html(views::skill_card(skill.id, &skill_card_state(skill)))
+    Resp::html(views::skill_card(&skill_ids(), &skill_card_state()))
 }
 
 /// `GET /onboarding/welcome` — (re)show the first-launch welcome on demand (the

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -460,7 +460,7 @@ pub fn skill_card(ids: &[&str], state: &SkillCardState) -> String {
                     span class="muted small" { "remove with " code { "rosita skill remove" } }
                 }
                 SkillCardState::UpgradeAvailable => {
-                    span class="muted small" { "The rosita skills are installed but a newer version ships with this rosita." }
+                    span class="muted small" { "The rosita skills (" strong { (id_list) } ") are installed but a newer version ships with this rosita." }
                     button class="btn btn-ghost"
                         hx-post="/skills/install" hx-target="#skill-card"
                         hx-confirm="Upgrade the rosita skills in ~/.agents/skills? This rewrites the skill files immediately." {
@@ -469,7 +469,7 @@ pub fn skill_card(ids: &[&str], state: &SkillCardState) -> String {
                 }
                 SkillCardState::HandsOff => {
                     span class="muted small" {
-                        "Skills exist in ~/.agents/skills with local edits — rosita leaves them alone."
+                        "Skills (" strong { (id_list) } ") exist in ~/.agents/skills with local edits — rosita leaves them alone."
                     }
                 }
             }

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -408,8 +408,73 @@ fn studio_welcome(o: &Onboarding, packs: &[PackView]) -> Markup {
             div class="welcome-actions" {
                 button class="btn btn-ghost" hx-get="/profiles/new" hx-target="#main" { (icon("plus")) "Start from scratch" }
             }
+            // The skill card loads lazily so the welcome render never blocks on
+            // (or threads through) global-filesystem state.
+            div id="skill-card" hx-get="/skills/card" hx-trigger="load" hx-target="#skill-card" {}
         }
     }
+}
+
+// --- agent skill card -------------------------------------------------------
+
+/// What the skill card shows; derived from the real filesystem by the server
+/// (never from session state — installing is a direct action, not a staged op).
+pub enum SkillCardState {
+    /// Not installed: offer the install button.
+    Offer,
+    /// Installed and current: show the handoff command.
+    Installed,
+    /// Installed but this rosita ships a newer version.
+    UpgradeAvailable,
+    /// Present with local edits (or a copy rosita didn't write) — hands off.
+    HandsOff,
+}
+
+/// The agent-skill card (fills `#skill-card`). Unlike packs, the Install button
+/// writes `~/.agents/skills` immediately on confirm — there is nothing staged
+/// to review or discard, so it must not imply staged semantics.
+pub fn skill_card(skill_id: &str, state: &SkillCardState) -> String {
+    html! {
+        div class="cmd-block" {
+            @match state {
+                SkillCardState::Offer => {
+                    span class="muted small" {
+                        "Already have a CLAUDE.md or AGENTS.md? rosita ships the "
+                        strong { (skill_id) }
+                        " agent skill — it imports your existing instructions into fragments & profiles "
+                        "(works in Claude Code, Codex, Gemini CLI, opencode)."
+                    }
+                    button class="btn btn-ghost"
+                        hx-post="/skills/install" hx-target="#skill-card"
+                        hx-confirm=(format!(
+                            "Install the {skill_id} skill into ~/.agents/skills now? \
+                             This writes files immediately (not staged); `rosita skill remove` undoes it."
+                        )) {
+                        (icon("bolt")) "Install the skill"
+                    }
+                }
+                SkillCardState::Installed => {
+                    span class="muted small" { "The " strong { (skill_id) } " skill is installed. Import your existing instructions from any agent session:" }
+                    code { "rosita run claude -- \"/" (skill_id) "\"" }
+                    span class="muted small" { "remove with " code { "rosita skill remove" } }
+                }
+                SkillCardState::UpgradeAvailable => {
+                    span class="muted small" { "The " strong { (skill_id) } " skill is installed but a newer version ships with this rosita." }
+                    button class="btn btn-ghost"
+                        hx-post="/skills/install" hx-target="#skill-card"
+                        hx-confirm=(format!("Upgrade the {skill_id} skill in ~/.agents/skills? This rewrites the skill files immediately.")) {
+                        (icon("refresh")) "Upgrade the skill"
+                    }
+                }
+                SkillCardState::HandsOff => {
+                    span class="muted small" {
+                        "A " strong { (skill_id) } " skill exists in ~/.agents/skills with local edits — rosita leaves it alone."
+                    }
+                }
+            }
+        }
+    }
+    .into_string()
 }
 
 /// The first-launch welcome as a standalone `#main` fragment — used by the "?"

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -430,45 +430,46 @@ pub enum SkillCardState {
     HandsOff,
 }
 
-/// The agent-skill card (fills `#skill-card`). Unlike packs, the Install button
-/// writes `~/.agents/skills` immediately on confirm — there is nothing staged
-/// to review or discard, so it must not imply staged semantics.
-pub fn skill_card(skill_id: &str, state: &SkillCardState) -> String {
+/// The agent-skill card (fills `#skill-card`). `ids` lists the shipped skills
+/// (display only). Unlike packs, the Install button writes `~/.agents/skills`
+/// immediately on confirm — there is nothing staged to review or discard, so
+/// it must not imply staged semantics.
+pub fn skill_card(ids: &[&str], state: &SkillCardState) -> String {
+    let id_list = ids.join(", ");
     html! {
         div class="cmd-block" {
             @match state {
                 SkillCardState::Offer => {
                     span class="muted small" {
-                        "Already have a CLAUDE.md or AGENTS.md? rosita ships the "
-                        strong { (skill_id) }
-                        " agent skill — it imports your existing instructions into fragments & profiles "
-                        "(works in Claude Code, Codex, Gemini CLI, opencode)."
+                        "rosita ships agent skills (" strong { (id_list) } "): import an existing "
+                        "CLAUDE.md/AGENTS.md, and save preferences you state mid-session as global guidance "
+                        "(work in Claude Code, Codex, Gemini CLI, opencode)."
                     }
                     button class="btn btn-ghost"
                         hx-post="/skills/install" hx-target="#skill-card"
                         hx-confirm=(format!(
-                            "Install the {skill_id} skill into ~/.agents/skills now? \
+                            "Install the rosita skills ({id_list}) into ~/.agents/skills now? \
                              This writes files immediately (not staged); `rosita skill remove` undoes it."
                         )) {
-                        (icon("bolt")) "Install the skill"
+                        (icon("bolt")) "Install the skills"
                     }
                 }
                 SkillCardState::Installed => {
-                    span class="muted small" { "The " strong { (skill_id) } " skill is installed. Import your existing instructions from any agent session:" }
-                    code { "rosita run claude -- \"/" (skill_id) "\"" }
+                    span class="muted small" { "The rosita skills (" strong { (id_list) } ") are installed. Import your existing instructions from any agent session:" }
+                    code { "rosita run claude -- \"/rosita-migrate\"" }
                     span class="muted small" { "remove with " code { "rosita skill remove" } }
                 }
                 SkillCardState::UpgradeAvailable => {
-                    span class="muted small" { "The " strong { (skill_id) } " skill is installed but a newer version ships with this rosita." }
+                    span class="muted small" { "The rosita skills are installed but a newer version ships with this rosita." }
                     button class="btn btn-ghost"
                         hx-post="/skills/install" hx-target="#skill-card"
-                        hx-confirm=(format!("Upgrade the {skill_id} skill in ~/.agents/skills? This rewrites the skill files immediately.")) {
-                        (icon("refresh")) "Upgrade the skill"
+                        hx-confirm="Upgrade the rosita skills in ~/.agents/skills? This rewrites the skill files immediately." {
+                        (icon("refresh")) "Upgrade the skills"
                     }
                 }
                 SkillCardState::HandsOff => {
                     span class="muted small" {
-                        "A " strong { (skill_id) } " skill exists in ~/.agents/skills with local edits — rosita leaves it alone."
+                        "Skills exist in ~/.agents/skills with local edits — rosita leaves them alone."
                     }
                 }
             }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1345,3 +1345,118 @@ fn update_check_without_a_receipt_reports_unmanaged() {
         .success()
         .stdout(predicate::str::contains("installer"));
 }
+
+// --- embedded agent skills (`rosita skill`) ------------------------------------
+
+/// Path helpers for the isolated `$HOME`.
+impl Fixture {
+    fn home(&self) -> std::path::PathBuf {
+        self.global.path().join("home")
+    }
+
+    fn mkdir_home(&self, rel: &str) {
+        fs::create_dir_all(self.home().join(rel)).unwrap();
+    }
+}
+
+#[test]
+fn skill_install_writes_canonical_links_existing_agents_and_records_accepted() {
+    let fx = Fixture::new();
+    fx.mkdir_home(".claude"); // claude present; codex absent
+
+    fx.cmd()
+        .args(["skill", "install"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("installed rosita-migrate"));
+
+    // Canonical files under the cross-agent dir, marker in place.
+    let skill_md = fx.read_home(".agents/skills/rosita-migrate/SKILL.md");
+    assert!(skill_md.contains("<!-- rosita:skill content=sha256:"));
+    assert!(fx.home_exists(".agents/skills/rosita-migrate/reference.md"));
+
+    // A symlink only for the agent dir that exists.
+    let link = fx.home().join(".claude/skills/rosita-migrate");
+    assert!(link.join("SKILL.md").exists());
+    assert!(fs::symlink_metadata(&link).unwrap().is_symlink());
+    assert!(!fx.home_exists(".codex"));
+
+    // The ask-once decision is remembered in the rosita-owned store — and the
+    // strict config loader still works with it present (regression guard for
+    // the deny_unknown_fields layer).
+    let store = fx.read_global("bindings.toml");
+    assert!(store.contains("rosita-migrate = \"accepted\""));
+    fx.cmd().args(["skill", "status"]).assert().success().stdout(
+        predicate::str::contains("installed, current")
+            .and(predicate::str::contains("decision: accepted")),
+    );
+}
+
+#[test]
+fn skill_remove_deletes_everything_and_records_declined() {
+    let fx = Fixture::new();
+    fx.mkdir_home(".claude");
+    fx.cmd().args(["skill", "install"]).assert().success();
+
+    fx.cmd()
+        .args(["skill", "remove"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("removed"));
+
+    assert!(!fx.home_exists(".agents/skills/rosita-migrate"));
+    assert!(!fx.home_exists(".claude/skills/rosita-migrate"));
+    assert!(fx
+        .read_global("bindings.toml")
+        .contains("rosita-migrate = \"declined\""));
+}
+
+#[test]
+fn skill_install_never_overwrites_user_edits() {
+    let fx = Fixture::new();
+    fx.cmd().args(["skill", "install"]).assert().success();
+
+    // The user customizes the installed reference.
+    let refpath = fx.home().join(".agents/skills/rosita-migrate/reference.md");
+    let mut text = fs::read_to_string(&refpath).unwrap();
+    text.push_str("\nmy own notes\n");
+    fs::write(&refpath, &text).unwrap();
+
+    fx.cmd()
+        .args(["skill", "install"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("left untouched"));
+    assert!(fs::read_to_string(&refpath).unwrap().contains("my own notes"));
+
+    fx.cmd()
+        .args(["skill", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("edited by you"));
+}
+
+#[test]
+fn doctor_reports_accepted_but_missing_skill() {
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.cmd().args(["skill", "install"]).assert().success();
+    fs::remove_dir_all(fx.home().join(".agents/skills/rosita-migrate")).unwrap();
+
+    fx.cmd()
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("accepted but missing from disk"));
+}
+
+#[test]
+fn dry_run_skill_install_writes_nothing() {
+    let fx = Fixture::new();
+    fx.cmd()
+        .args(["--dry-run", "skill", "install"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("would install"));
+    assert!(!fx.home_exists(".agents"));
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1392,10 +1392,14 @@ fn skill_install_writes_canonical_links_existing_agents_and_records_accepted() {
     // the deny_unknown_fields layer).
     let store = fx.read_global("bindings.toml");
     assert!(store.contains("rosita-migrate = \"accepted\""));
-    fx.cmd().args(["skill", "status"]).assert().success().stdout(
-        predicate::str::contains("installed, current")
-            .and(predicate::str::contains("decision: accepted")),
-    );
+    fx.cmd()
+        .args(["skill", "status"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("installed, current")
+                .and(predicate::str::contains("decision: accepted")),
+        );
 }
 
 #[test]
@@ -1434,7 +1438,9 @@ fn skill_install_never_overwrites_user_edits() {
         .assert()
         .success()
         .stdout(predicate::str::contains("left untouched"));
-    assert!(fs::read_to_string(&refpath).unwrap().contains("my own notes"));
+    assert!(fs::read_to_string(&refpath)
+        .unwrap()
+        .contains("my own notes"));
 
     fx.cmd()
         .args(["skill", "status"])

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1368,12 +1368,18 @@ fn skill_install_writes_canonical_links_existing_agents_and_records_accepted() {
         .args(["skill", "install"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("installed rosita-migrate"));
+        .stdout(
+            predicate::str::contains("installed rosita-migrate")
+                .and(predicate::str::contains("installed rosita-remember")),
+        );
 
-    // Canonical files under the cross-agent dir, marker in place.
+    // Canonical files under the cross-agent dir, marker in place — for every
+    // shipped skill.
     let skill_md = fx.read_home(".agents/skills/rosita-migrate/SKILL.md");
     assert!(skill_md.contains("<!-- rosita:skill content=sha256:"));
     assert!(fx.home_exists(".agents/skills/rosita-migrate/reference.md"));
+    assert!(fx.home_exists(".agents/skills/rosita-remember/SKILL.md"));
+    assert!(fx.home_exists(".claude/skills/rosita-remember"));
 
     // A symlink only for the agent dir that exists.
     let link = fx.home().join(".claude/skills/rosita-migrate");
@@ -1405,10 +1411,11 @@ fn skill_remove_deletes_everything_and_records_declined() {
         .stdout(predicate::str::contains("removed"));
 
     assert!(!fx.home_exists(".agents/skills/rosita-migrate"));
+    assert!(!fx.home_exists(".agents/skills/rosita-remember"));
     assert!(!fx.home_exists(".claude/skills/rosita-migrate"));
-    assert!(fx
-        .read_global("bindings.toml")
-        .contains("rosita-migrate = \"declined\""));
+    let store = fx.read_global("bindings.toml");
+    assert!(store.contains("rosita-migrate = \"declined\""));
+    assert!(store.contains("rosita-remember = \"declined\""));
 }
 
 #[test]

--- a/tests/skill_examples.rs
+++ b/tests/skill_examples.rs
@@ -1,6 +1,6 @@
-//! The TOML examples shipped in the `rosita-migrate` skill must stay valid
-//! rosita config — otherwise the skill would teach people a schema that no
-//! longer parses. This guards every ```toml block in the skill's reference.
+//! The TOML examples shipped in the embedded skills must stay valid rosita
+//! config — otherwise a skill would teach people a schema that no longer
+//! parses. This guards every ```toml block in each skill's reference.
 
 use std::path::PathBuf;
 
@@ -28,24 +28,26 @@ fn parse_global(toml: &str) -> rosita::Result<Config> {
     )])
 }
 
-#[test]
-fn skill_reference_toml_examples_are_valid_config() {
-    let path = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/skills/rosita-migrate/reference.md"
-    );
-    let md = std::fs::read_to_string(path).expect("read skill reference.md");
+/// Parse-check every ```toml block in a skill's reference.md, returning them.
+fn check_skill_reference(skill: &str) -> Vec<String> {
+    let path = format!("{}/skills/{skill}/reference.md", env!("CARGO_MANIFEST_DIR"));
+    let md = std::fs::read_to_string(&path).expect("read skill reference.md");
     let blocks = toml_blocks(&md);
     assert!(
         !blocks.is_empty(),
-        "expected ```toml examples in the skill reference"
+        "{skill}: expected ```toml examples in the skill reference"
     );
-
     for block in &blocks {
         parse_global(block).unwrap_or_else(|e| {
-            panic!("skill example must parse as config:\n{block}\n\nerror: {e}")
+            panic!("{skill}: example must parse as config:\n{block}\n\nerror: {e}")
         });
     }
+    blocks
+}
+
+#[test]
+fn skill_reference_toml_examples_are_valid_config() {
+    let blocks = check_skill_reference("rosita-migrate");
 
     // The first (complete) example defines the documented profiles + a dynamic
     // fragment — assert the schema the skill teaches still resolves.
@@ -53,6 +55,16 @@ fn skill_reference_toml_examples_are_valid_config() {
     assert!(cfg.profiles.iter().any(|p| p.name == "machine"));
     assert!(cfg.profiles.iter().any(|p| p.name == "rust"));
     assert!(cfg.fragments.iter().any(|c| c.id == "host"));
+}
+
+#[test]
+fn remember_skill_reference_toml_examples_are_valid_config() {
+    let blocks = check_skill_reference("rosita-remember");
+
+    // The editing example teaches a minimal fragment edit — it must keep
+    // resolving as a fragment with guidance.
+    let cfg = parse_global(&blocks[0]).unwrap();
+    assert!(cfg.fragments.iter().any(|c| c.id == "conventional-commits"));
 }
 
 #[test]


### PR DESCRIPTION
Embeds the rosita-migrate skill in the binary (previously repo-checkout + manual symlink only), adds the new rosita-remember skill, and manages both via `rosita skill install|remove|status`.

- Cross-agent install: canonical files at `~/.agents/skills/` (native for Gemini CLI/opencode), symlinks into `~/.claude/skills/` and `~/.codex/skills/` only when those dotdirs exist; copy fallback.
- Marker + three-hash lifecycle: pristine installs upgrade with the binary, user-edited files are never touched, deleted installs are not resurrected.
- Ask-once bundled offer in `rosita run` (TTY-only, only pre-migration); decision stored in the rosita-owned `bindings.toml`.
- `rosita doctor` skill section; studio welcome card with confirm-gated direct install.
- The skills are rewritten to the portable Agent Skills format (no Claude-only dynamic preamble).

Verified live: both skills discovered and loaded by Claude Code via the symlink path, including a content upgrade cycle.

Release prep included: version 0.4.0, changelog dated. Tag v0.4.0 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)