### PR TITLE
feat: live repo grounding in stack packs + project-scripts/work-summary fragments

### DIFF
--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -280,6 +280,16 @@ pub fn palette() -> Vec<Fragment> {
              fine; keep changes scoped to this branch and don't wire them into shared \
              modules yet.",
         ),
+        frag(
+            "work-summary",
+            "Summarize work and next steps",
+            "Dev Workflow",
+            "When you finish a unit of work, close with two short, scannable bullet \
+             lists: **Done** — one bullet per change, in plain language (what changed \
+             and where, not how it was implemented); and **Next steps** — one concrete \
+             action per bullet for what remains, or an explicit note that nothing does. \
+             Keep both tight: no preamble, no restating the request.",
+        ),
         // --- quality -------------------------------------------------------
         frag(
             "validate-before-done",
@@ -337,13 +347,13 @@ pub fn palette() -> Vec<Fragment> {
             "environment",
             "Environment ground truth",
             "Local Environment",
-            "Environment is ground truth, not assumption. The sections below are \
-             probed live from this machine at render time — treat them as \
-             authoritative for identity, network posture, running containers, \
-             secret stores, and installed tooling. Before reasoning about \
-             deployment, networking, or host targets, consult them. A missing \
-             section means the probe found nothing (tool absent, daemon down, or \
-             logged out), so ask rather than guess.",
+            "Environment is ground truth, not assumption. The sections that follow \
+             are probed live at render time — treat them as authoritative for what \
+             is actually installed, running, and reachable here, plus the commands \
+             this repo defines. Consult them before assuming a tool, version, \
+             service, or command exists, and prefer them over guessing. A missing \
+             or empty section means the probe found nothing (tool absent, daemon \
+             down, or logged out), so ask rather than guess.",
         ),
         script_frag(
             "host",
@@ -387,10 +397,111 @@ fi
             r#"
 for tool in git node pnpm npm bun deno python3 uv ruby go cargo rustc rg fd gh docker; do
   if command -v "$tool" >/dev/null 2>&1; then
-    v=$("$tool" --version 2>&1 | head -n1)
+    # `go` reports its version via `go version`, not `--version` (the latter errors).
+    if [ "$tool" = go ]; then
+      v=$(go version 2>&1 | head -n1)
+    else
+      v=$("$tool" --version 2>&1 | head -n1)
+    fi
     printf '%-10s %s\n' "$tool" "$v"
   fi
 done
+"#,
+        ),
+        script_frag(
+            "project-scripts",
+            "Runnable project commands",
+            "5m",
+            r#"
+# Repo-scoped probe: the commands THIS project defines (package.json scripts,
+# Makefile/justfile targets, Cargo, go.mod) so the agent uses real entry points
+# instead of inventing them. Read-only; ends with `exit 0` so a short-circuiting
+# final test can't drop the output.
+out=""
+add() { out="${out}$1
+"; }
+
+# package.json scripts (node / bun)
+if [ -f package.json ]; then
+  pm="<pm> run"
+  [ -f package-lock.json ] && pm="npm run"
+  [ -f yarn.lock ] && pm="yarn"
+  [ -f pnpm-lock.yaml ] && pm="pnpm run"
+  [ -f bun.lock ] && pm="bun run"
+  [ -f bun.lockb ] && pm="bun run"
+  scripts=""
+  if command -v jq >/dev/null 2>&1; then
+    scripts=$(jq -r '.scripts // {} | to_entries[] | "  \(.key) — \(.value | gsub("\\s+";" "))"' package.json 2>/dev/null)
+  elif command -v node >/dev/null 2>&1; then
+    scripts=$(node -e 'try{const s=(require(process.cwd()+"/package.json").scripts)||{};for(const[k,v]of Object.entries(s))console.log("  "+k+" — "+String(v).replace(/\s+/g," ").trim())}catch(e){}' 2>/dev/null)
+  elif command -v bun >/dev/null 2>&1; then
+    scripts=$(bun -e 'try{const s=(require(process.cwd()+"/package.json").scripts)||{};for(const[k,v]of Object.entries(s))console.log("  "+k+" — "+String(v).replace(/\s+/g," ").trim())}catch(e){}' 2>/dev/null)
+  fi
+  if [ -n "$scripts" ]; then
+    add "package.json scripts (run with \`$pm <name>\`):"
+    add "$scripts"
+    add ""
+  fi
+fi
+
+# Makefile targets
+for mk in Makefile makefile GNUmakefile; do
+  if [ -f "$mk" ]; then
+    targets=$(grep -E '^[a-zA-Z0-9][a-zA-Z0-9_.-]*:' "$mk" 2>/dev/null | grep -v ':=' | sed -E 's/:.*//' | sort -u | sed 's/^/  /')
+    if [ -n "$targets" ]; then
+      add "Makefile targets (run with \`make <target>\`):"
+      add "$targets"
+      add ""
+    fi
+    break
+  fi
+done
+
+# justfile recipes
+for jf in justfile Justfile .justfile; do
+  if [ -f "$jf" ]; then
+    if command -v just >/dev/null 2>&1; then
+      recipes=$(just --list --unsorted 2>/dev/null | sed '1d')
+    else
+      recipes=$(grep -E '^[a-zA-Z0-9][a-zA-Z0-9_-]*( [^:]*)?:' "$jf" 2>/dev/null | sed -E 's/[ :].*//' | sort -u | sed 's/^/  /')
+    fi
+    if [ -n "$recipes" ]; then
+      add "justfile recipes (run with \`just <recipe>\`):"
+      add "$recipes"
+      add ""
+    fi
+    break
+  fi
+done
+
+# Cargo (rust)
+if [ -f Cargo.toml ]; then
+  add "Cargo: \`cargo build | test | run | clippy | fmt\` (standard)."
+  for cfg in .cargo/config.toml .cargo/config; do
+    if [ -f "$cfg" ]; then
+      aliases=$(sed -n '/^\[alias\]/,/^\[/p' "$cfg" 2>/dev/null | grep -E '^[a-zA-Z]')
+      if [ -n "$aliases" ]; then
+        add "  cargo aliases:"
+        add "$(printf '%s\n' "$aliases" | sed 's/^/    /')"
+      fi
+      break
+    fi
+  done
+  add ""
+fi
+
+# Go module
+if [ -f go.mod ]; then
+  add "Go module: \`go build ./... | go test ./... | go vet ./... | gofmt\` (standard)."
+  add ""
+fi
+
+if [ -n "$out" ]; then
+  echo "Commands this repo defines — prefer these over inventing build/test/lint/run invocations:"
+  echo
+  printf '%s' "$out"
+fi
+exit 0
 "#,
         ),
         script_frag(

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -61,9 +61,13 @@ impl Pack {
     }
 }
 
-// Each pack's fragment set is spelled out below (a stack cap + the shared
-// "everyday" essentials) so each profile is self-contained; the integrity tests
-// keep the shared tail consistent across the stack packs.
+// Each pack's fragment set is spelled out below: a stack cap + the shared
+// "everyday" essentials (incl. work-summary) + a live, repo-relevant grounding
+// tail (the `environment` framing, `toolchain`, `project-scripts`, `containers`).
+// Composition is one-profile-per-repo, so a dev who selects a stack pack never
+// co-applies the machine `everyday` pack — hence each stack pack carries its own
+// grounding. Machine-identity / security probes (`host`, `ai-tools`, VPN & secret
+// posture) stay in `everyday`. Integrity tests keep both tails consistent.
 const EVERYDAY: &[&str] = &[
     // Static guidance essentials.
     "terse-comms",
@@ -72,6 +76,7 @@ const EVERYDAY: &[&str] = &[
     "ask-before-risky",
     "secrets-hygiene",
     "validate-before-done",
+    "work-summary",
     "infra-caution",
     // Live machine grounding (dynamic probes). `environment` frames the probed
     // sections that follow; each script embeds its redacted stdout at render
@@ -97,6 +102,12 @@ const RUST: &[&str] = &[
     "ask-before-risky",
     "validate-before-done",
     "testing-discipline",
+    "work-summary",
+    // Live, repo-relevant grounding (machine-only probes stay in `everyday`).
+    "environment",
+    "toolchain",
+    "project-scripts",
+    "containers",
 ];
 const NODE: &[&str] = &[
     "node-conventions",
@@ -108,6 +119,12 @@ const NODE: &[&str] = &[
     "ask-before-risky",
     "validate-before-done",
     "testing-discipline",
+    "work-summary",
+    // Live, repo-relevant grounding (machine-only probes stay in `everyday`).
+    "environment",
+    "toolchain",
+    "project-scripts",
+    "containers",
 ];
 const NEXTJS: &[&str] = &[
     "nextjs-conventions",
@@ -119,6 +136,12 @@ const NEXTJS: &[&str] = &[
     "ask-before-risky",
     "validate-before-done",
     "testing-discipline",
+    "work-summary",
+    // Live, repo-relevant grounding (machine-only probes stay in `everyday`).
+    "environment",
+    "toolchain",
+    "project-scripts",
+    "containers",
 ];
 const GO: &[&str] = &[
     "go-conventions",
@@ -130,6 +153,12 @@ const GO: &[&str] = &[
     "ask-before-risky",
     "validate-before-done",
     "testing-discipline",
+    "work-summary",
+    // Live, repo-relevant grounding (machine-only probes stay in `everyday`).
+    "environment",
+    "toolchain",
+    "project-scripts",
+    "containers",
 ];
 const PYTHON: &[&str] = &[
     "python-conventions",
@@ -141,6 +170,12 @@ const PYTHON: &[&str] = &[
     "ask-before-risky",
     "validate-before-done",
     "testing-discipline",
+    "work-summary",
+    // Live, repo-relevant grounding (machine-only probes stay in `everyday`).
+    "environment",
+    "toolchain",
+    "project-scripts",
+    "containers",
 ];
 
 /// The shipped starter packs, in gallery display order (the stack-agnostic
@@ -152,9 +187,9 @@ pub fn packs() -> Vec<Pack> {
             name: "Everyday essentials",
             description: "Safe, sensible defaults for general or no-repo work — terse \
                           communication, conventional commits, secrets discipline, ask \
-                          before risky actions, validate-before-done — plus live machine \
-                          grounding (host, toolchain, containers, AI tools, VPN/egress, \
-                          and secret-store posture) probed fresh at render.",
+                          before risky actions, validate-before-done, summarize work — plus \
+                          live machine grounding (host, toolchain, containers, AI tools, \
+                          VPN/egress, and secret-store posture) probed fresh at render.",
             icon: "shield",
             recommended_for: &["machine"],
             profile_name: "everyday",
@@ -165,7 +200,8 @@ pub fn packs() -> Vec<Pack> {
             id: "rust",
             name: "Rust",
             description: "Rust conventions (cargo, clippy, rustfmt) on top of the everyday \
-                          safety, commit, and quality essentials.",
+                          safety, commit, and quality essentials, plus live repo grounding \
+                          (toolchain, project commands, containers) probed at render.",
             icon: "code",
             recommended_for: &["rust"],
             profile_name: "rust",
@@ -176,7 +212,8 @@ pub fn packs() -> Vec<Pack> {
             id: "node",
             name: "Node.js / TypeScript",
             description: "Node.js conventions (pnpm, TypeScript) plus the everyday safety, \
-                          commit, and quality essentials.",
+                          commit, and quality essentials, plus live repo grounding \
+                          (toolchain, project commands, containers) probed at render.",
             icon: "code",
             recommended_for: &["node"],
             profile_name: "node",
@@ -187,7 +224,8 @@ pub fn packs() -> Vec<Pack> {
             id: "nextjs",
             name: "Next.js",
             description: "Next.js conventions (router + server/client boundaries, pnpm) plus \
-                          the everyday safety, commit, and quality essentials.",
+                          the everyday safety, commit, and quality essentials, plus live repo \
+                          grounding (toolchain, project commands, containers) probed at render.",
             icon: "code",
             recommended_for: &["nextjs"],
             profile_name: "nextjs",
@@ -198,7 +236,8 @@ pub fn packs() -> Vec<Pack> {
             id: "go",
             name: "Go",
             description: "Go conventions (standard toolchain + golangci-lint) plus the \
-                          everyday safety, commit, and quality essentials.",
+                          everyday safety, commit, and quality essentials, plus live repo \
+                          grounding (toolchain, project commands, containers) probed at render.",
             icon: "code",
             recommended_for: &["go"],
             profile_name: "go",
@@ -209,7 +248,8 @@ pub fn packs() -> Vec<Pack> {
             id: "python",
             name: "Python",
             description: "Python conventions (uv, ruff, pytest) plus the everyday safety, \
-                          commit, and quality essentials.",
+                          commit, and quality essentials, plus live repo grounding \
+                          (toolchain, project commands, containers) probed at render.",
             icon: "code",
             recommended_for: &["python"],
             profile_name: "python",
@@ -236,7 +276,12 @@ mod tests {
         "ask-before-risky",
         "validate-before-done",
         "testing-discipline",
+        "work-summary",
     ];
+
+    /// Live, repo-relevant grounding every stack pack bakes in (one-profile-per-
+    /// repo means the machine `everyday` pack never co-applies in a stack repo).
+    const STACK_GROUNDING: &[&str] = &["environment", "toolchain", "project-scripts", "containers"];
 
     #[test]
     fn pack_ids_and_profile_names_are_unique() {
@@ -305,6 +350,21 @@ mod tests {
                 assert!(
                     p.fragments.contains(essential),
                     "stack pack {} is missing essential {essential}",
+                    p.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn stack_packs_include_live_grounding() {
+        // Because composition is one-profile-per-repo, each stack pack must carry
+        // its own live grounding — the machine `everyday` pack never co-applies.
+        for p in packs().into_iter().filter(|p| p.id != "everyday") {
+            for g in STACK_GROUNDING {
+                assert!(
+                    p.fragments.contains(g),
+                    "stack pack {} is missing live grounding {g}",
                     p.id
                 );
             }

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -1652,9 +1652,9 @@ mod tests {
             ),
         );
         assert_eq!(r.status, 200);
-        // Applied the recommended Rust pack: its 9 fragments are duplicated and
-        // its profile is created (9 + 1 staged ops).
-        assert_eq!(st.lock().unwrap().session.ops().len(), 10);
+        // Applied the recommended Rust pack: its 14 fragments are duplicated and
+        // its profile is created (14 + 1 staged ops).
+        assert_eq!(st.lock().unwrap().session.ops().len(), 15);
         let body = String::from_utf8(r.body).unwrap();
         // The Profiles tab now shows the staged "rust" profile and its caps.
         assert!(body.contains("staged the"), "pack flash missing");
@@ -1700,8 +1700,8 @@ mod tests {
             ),
         );
         assert_eq!(r.status, 200);
-        // The 14 everyday caps are duplicated and the "everyday" profile is created.
-        assert_eq!(st.lock().unwrap().session.ops().len(), 15);
+        // The 15 everyday caps are duplicated and the "everyday" profile is created.
+        assert_eq!(st.lock().unwrap().session.ops().len(), 16);
         let body = String::from_utf8(r.body).unwrap();
         assert!(body.contains("staged the"), "pack flash missing");
         assert!(body.contains("Terse communication"));
@@ -1729,8 +1729,8 @@ mod tests {
         let after_second = st.lock().unwrap().session.ops().len();
         // The second apply owns every cap already, so it re-stages only the
         // profile (EditProfile) — exactly one new op, no re-duplication.
-        assert_eq!(after_first, 15);
-        assert_eq!(after_second, 16);
+        assert_eq!(after_first, 16);
+        assert_eq!(after_second, 17);
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Stack packs (`rust`/`node`/`nextjs`/`go`/`python`) shipped with **zero live grounding** — only the `everyday` pack carried the environment probes. Because composition is one-profile-per-repo, a dev who selects a stack pack never co-applies `everyday`, so they got no toolchain, no containers, and no sense of what the repo can actually run. This bakes a repo-relevant grounding tail into every stack pack, and adds the two fragments that make it useful.

## Changes

**`feat(palette)` — new atoms + a probe fix (`src/fragment.rs`)**
- **`project-scripts`** — repo-scoped script fragment listing the commands a project actually defines (package.json scripts, Makefile/justfile targets, Cargo, `go.mod`) so agents use real entry points instead of inventing them. Ends with `exit 0` so a short-circuiting final test can't trip the "non-zero exit → output dropped" behaviour.
- **`work-summary`** — static fragment asking for Done / Next-steps bullets when wrapping up a unit of work.
- **`toolchain` fix** — probe `go` with `go version`, not `--version` (the latter errors, and `2>&1` was embedding `flag provided but not defined: -version` into the rendered output).
- **`environment`** — reworded to be section-agnostic, so it reads correctly when a profile composes only a subset of the probes.

**`feat(packs)` — grounding tail (`src/pack.rs`, `src/studio/server.rs`)**
- Added `environment`, `toolchain`, `project-scripts`, `containers` (+ `work-summary`) to each stack pack. Machine-identity / security probes (`host`, `ai-tools`, VPN & secret posture) stay in `everyday`.
- Updated the pack-card descriptions and the studio apply-count assertions that shifted as the packs grew.
- New `stack_packs_include_live_grounding` test enforces the tail across all stack packs.

## Validation
- `cargo test` — 294 passing (incl. `bash -n` syntax-check on the new script and the pack-integrity guards)
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

## Not included (deliberate, open to follow-ups)
- Bun support (needs a generic `bun-conventions` first)
- Context lines baked into the *shipped* env probes (UX call)
- A `doctor`/studio warning for the non-zero-exit-drops-output footgun

🤖 Generated with [Claude Code](https://claude.com/claude-code)