### PR TITLE
feat: Bun support, env-probe context lines, project-scripts polish, doctor footgun check

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -97,6 +97,8 @@ pub fn run(rt: &Runtime) -> crate::Result<()> {
     check_env_policy(&mut c, &prep.config);
     // Private-data leak lint over public config layers.
     check_public_leaks(&mut c, &prep);
+    // Script fragments whose output rosita would silently drop (non-zero exit).
+    check_script_dropouts(&mut c, &prep);
 
     // Agents + their launch CLIs.
     println!("\nAgents ({} configured)", prep.config.agents.len());
@@ -255,6 +257,57 @@ fn check_skills(c: &mut Checks) {
                 }
             }
         }
+    }
+}
+
+/// Execute each configured script-backed fragment and flag any that exit
+/// non-zero while still printing to stdout. rosita drops a probe's output when
+/// its script exits non-zero, so such a fragment renders as nothing — usually a
+/// final `[ cond ] && cmd` that short-circuits. (Exit non-zero with *no* stdout
+/// is the normal "tool absent / nothing found" case and is left alone.) These
+/// are the user's own probes, which already run at render time, so executing
+/// them here adds no new capability — only a diagnosis.
+fn check_script_dropouts(c: &mut Checks, prep: &super::Prepared) {
+    let scripts: Vec<&crate::fragment::Fragment> = prep
+        .config
+        .fragments
+        .iter()
+        .filter(|f| f.command.is_some())
+        .collect();
+    if scripts.is_empty() {
+        return;
+    }
+    println!("\nScript fragments ({} probed)", scripts.len());
+    let mut clean = 0usize;
+    for f in scripts {
+        let cmd = f.command.as_deref().unwrap_or_default();
+        let out = crate::providers::run_once_in(cmd, f.script_lang.as_deref(), &prep.repo_base);
+        let status = out.data.get("status").and_then(serde_json::Value::as_i64);
+        let stdout = out
+            .data
+            .get("stdout")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        if status != Some(0) && !stdout.trim().is_empty() {
+            let exit = status
+                .map(|s| format!("exits {s}"))
+                .unwrap_or_else(|| "was killed by a signal".to_string());
+            c.line(
+                Status::Warn,
+                format!(
+                    "{}: prints output but {exit} — rosita drops a probe's output on a non-zero exit, so this renders nothing. End the script with `exit 0`.",
+                    f.id
+                ),
+            );
+        } else {
+            clean += 1;
+        }
+    }
+    if clean > 0 {
+        c.line(
+            Status::Ok,
+            format!("{clean} script fragment(s) exit cleanly"),
+        );
     }
 }
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -268,11 +268,15 @@ fn check_skills(c: &mut Checks) {
 /// are the user's own probes, which already run at render time, so executing
 /// them here adds no new capability — only a diagnosis.
 fn check_script_dropouts(c: &mut Checks, prep: &super::Prepared) {
+    // Honor `allow_exec = false` (the off-switch): render skips such a fragment
+    // without running it, so doctor must not execute it either — doing so would
+    // run an opted-out command and misdiagnose it (it renders a skip note, not
+    // "nothing").
     let scripts: Vec<&crate::fragment::Fragment> = prep
         .config
         .fragments
         .iter()
-        .filter(|f| f.command.is_some())
+        .filter(|f| f.command.is_some() && f.allow_exec)
         .collect();
     if scripts.is_empty() {
         return;

--- a/src/context/languages.rs
+++ b/src/context/languages.rs
@@ -115,11 +115,15 @@ pub fn detect_stacks_and_pms(base: &Path) -> (Vec<String>, Vec<String>) {
         pms.push("cargo".into());
     }
 
-    // Node / Next.js
+    // Node / Next.js / Bun. A bun repo also has a package.json, so `bun` rides
+    // alongside `node` (the way `nextjs` does) — profiles can target either.
     if has("package.json") {
         stacks.push("node".into());
         if package_json_has_next(base) {
             stacks.push("nextjs".into());
+        }
+        if has("bun.lock") || has("bun.lockb") {
+            stacks.push("bun".into());
         }
         pms.push(detect_node_pm(base));
     }
@@ -315,6 +319,17 @@ mod tests {
         assert!(stacks.contains(&"node".to_string()));
         assert!(stacks.contains(&"nextjs".to_string()));
         assert_eq!(pms, vec!["pnpm".to_string()]);
+    }
+
+    #[test]
+    fn detects_bun_alongside_node() {
+        let d = tmp();
+        fs::write(d.path().join("package.json"), r#"{"name":"x"}"#).unwrap();
+        fs::write(d.path().join("bun.lock"), "").unwrap();
+        let (stacks, pms) = detect_stacks_and_pms(d.path());
+        assert!(stacks.contains(&"node".to_string()));
+        assert!(stacks.contains(&"bun".to_string()));
+        assert_eq!(pms, vec!["bun".to_string()]);
     }
 
     #[test]

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -226,6 +226,16 @@ pub fn palette() -> Vec<Fragment> {
              before committing.",
         ),
         frag(
+            "bun-conventions",
+            "Bun conventions",
+            "Stack Conventions",
+            "Bun project. Use Bun as the runtime and package manager (`bun install`, \
+             `bun run`, `bunx`) and don't introduce a second lockfile. Prefer \
+             TypeScript and run sources directly with `bun run`. Keep the \
+             type-checker and linter clean, and use the project's configured test \
+             runner before committing.",
+        ),
+        frag(
             "nextjs-conventions",
             "Next.js conventions",
             "Stack Conventions",
@@ -395,6 +405,9 @@ fi
             "Toolchain detection",
             "5m",
             r#"
+echo "Toolchain installed on this machine (versions resolved at render)."
+echo "Prefer these over assuming a tool exists or guessing its version."
+echo
 for tool in git node pnpm npm bun deno python3 uv ruby go cargo rustc rg fd gh docker; do
   if command -v "$tool" >/dev/null 2>&1; then
     # `go` reports its version via `go version`, not `--version` (the latter errors).
@@ -423,7 +436,7 @@ add() { out="${out}$1
 
 # package.json scripts (node / bun)
 if [ -f package.json ]; then
-  pm="<pm> run"
+  pm="npm run" # fallback when no lockfile pins the manager
   [ -f package-lock.json ] && pm="npm run"
   [ -f yarn.lock ] && pm="yarn"
   [ -f pnpm-lock.yaml ] && pm="pnpm run"
@@ -463,7 +476,7 @@ for jf in justfile Justfile .justfile; do
     if command -v just >/dev/null 2>&1; then
       recipes=$(just --list --unsorted 2>/dev/null | sed '1d')
     else
-      recipes=$(grep -E '^[a-zA-Z0-9][a-zA-Z0-9_-]*( [^:]*)?:' "$jf" 2>/dev/null | sed -E 's/[ :].*//' | sort -u | sed 's/^/  /')
+      recipes=$(grep -E '^[a-zA-Z0-9][a-zA-Z0-9_-]*( [^:]*)?:' "$jf" 2>/dev/null | grep -v ':=' | sed -E 's/[ :].*//' | sort -u | sed 's/^/  /')
     fi
     if [ -n "$recipes" ]; then
       add "justfile recipes (run with \`just <recipe>\`):"
@@ -509,11 +522,18 @@ exit 0
             "Container runtime",
             "5m",
             r#"
-if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-  docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' 2>/dev/null
-fi
-if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
-  podman ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' 2>/dev/null
+# Guards live inside `if` (not a bare `&&` chain) so a missing runtime can't
+# leave the script on a non-zero exit, which would drop the whole section.
+have_docker=0
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then have_docker=1; fi
+have_podman=0
+if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then have_podman=1; fi
+if [ "$have_docker" = 1 ] || [ "$have_podman" = 1 ]; then
+  echo "Containers running on this machine right now (host-wide). Check here before"
+  echo "assuming a database, cache, or queue is or isn't up; PORTS are host->container."
+  echo
+  if [ "$have_docker" = 1 ]; then docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' 2>/dev/null; fi
+  if [ "$have_podman" = 1 ]; then podman ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' 2>/dev/null; fi
 fi
 "#,
         ),
@@ -522,14 +542,22 @@ fi
             "AI tooling",
             "5m",
             r#"
+out=""
 for tool in claude codex gemini opencode cursor-agent aider droid amp q goose; do
   if command -v "$tool" >/dev/null 2>&1; then
-    v=$("$tool" --version 2>/dev/null | head -n1)
-    printf '%-15s %s\n' "$tool" "$v"
+    out="$out$(printf '%-15s %s' "$tool" "$("$tool" --version 2>/dev/null | head -n1)")
+"
   fi
 done
 if command -v gh >/dev/null 2>&1 && gh extension list 2>/dev/null | grep -qi copilot; then
-  printf '%-15s %s\n' "gh copilot" "(gh extension)"
+  out="$out$(printf '%-15s %s' 'gh copilot' '(gh extension)')
+"
+fi
+if [ -n "$out" ]; then
+  echo "Peer AI coding CLIs installed here — use one for a cross-model review / second"
+  echo "opinion (a different, comparable-or-stronger model than the one doing the work)."
+  echo
+  printf '%s' "$out"
 fi
 "#,
         ),
@@ -550,10 +578,19 @@ else
   done
 fi
 [ -n "$ts" ] || exit 0
-# No `2>/dev/null || true`: a stopped/logged-out daemon must surface as a
-# non-zero exit + stderr so the run is reported as failed (and retryable),
-# not silently cached as "no peers".
-"$ts" status
+# Capture once. On success, prepend a one-line context; on failure, re-surface
+# stderr and the non-zero exit so a stopped/logged-out daemon is reported as
+# failed (and retryable), not silently cached as "no peers".
+status=$("$ts" status 2>&1); rc=$?
+if [ "$rc" = 0 ]; then
+  echo "Hosts reachable on this machine's tailnet — SSH / deploy targets by name or"
+  echo "100.x address. Lines marked offline aren't reachable right now."
+  echo
+  printf '%s\n' "$status"
+else
+  printf '%s\n' "$status" >&2
+  exit "$rc"
+fi
 "#,
         ),
         script_frag(

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -126,6 +126,23 @@ const NODE: &[&str] = &[
     "project-scripts",
     "containers",
 ];
+const BUN: &[&str] = &[
+    "bun-conventions",
+    "baseline",
+    "terse-comms",
+    "conventional-commits",
+    "branch-discipline",
+    "secrets-hygiene",
+    "ask-before-risky",
+    "validate-before-done",
+    "testing-discipline",
+    "work-summary",
+    // Live, repo-relevant grounding (machine-only probes stay in `everyday`).
+    "environment",
+    "toolchain",
+    "project-scripts",
+    "containers",
+];
 const NEXTJS: &[&str] = &[
     "nextjs-conventions",
     "baseline",
@@ -219,6 +236,18 @@ pub fn packs() -> Vec<Pack> {
             profile_name: "node",
             targets: &["node"],
             fragments: NODE,
+        },
+        Pack {
+            id: "bun",
+            name: "Bun",
+            description: "Bun conventions (bun runtime + package manager, TypeScript) plus the \
+                          everyday safety, commit, and quality essentials, plus live repo \
+                          grounding (toolchain, project commands, containers) probed at render.",
+            icon: "code",
+            recommended_for: &["bun"],
+            profile_name: "bun",
+            targets: &["bun"],
+            fragments: BUN,
         },
         Pack {
             id: "nextjs",

--- a/src/target.rs
+++ b/src/target.rs
@@ -231,6 +231,13 @@ pub fn builtin_targets() -> Vec<TargetDef> {
             file("package.json"),
         ),
         t(
+            "bun",
+            "a Bun lockfile (bun.lock or bun.lockb) at the repo root",
+            TargetRule::AnyOf {
+                rules: vec![file("bun.lock"), file("bun.lockb")],
+            },
+        ),
+        t(
             "nextjs",
             "package.json names `next` as a dependency",
             TargetRule::AllOf {
@@ -425,7 +432,8 @@ mod tests {
     fn builtin_catalog_is_well_formed() {
         let ids: Vec<String> = builtin_targets().into_iter().map(|t| t.id).collect();
         for needed in [
-            "rust", "node", "nextjs", "go", "python", "java", "ruby", "php", "swift", "dotnet",
+            "rust", "node", "bun", "nextjs", "go", "python", "java", "ruby", "php", "swift",
+            "dotnet",
         ] {
             assert!(
                 ids.contains(&needed.to_string()),
@@ -468,6 +476,23 @@ mod tests {
         // Plain node (no next) doesn't match the nextjs descriptor.
         fs::write(d.path().join("package.json"), r#"{"dependencies":{}}"#).unwrap();
         assert!(!nextjs.rule.declarative_match(d.path()));
+    }
+
+    #[test]
+    fn bun_descriptor_matches_either_lockfile() {
+        let bun = builtin_targets()
+            .into_iter()
+            .find(|t| t.id == "bun")
+            .unwrap();
+        for lock in ["bun.lock", "bun.lockb"] {
+            let d = tmp();
+            fs::write(d.path().join(lock), "").unwrap();
+            assert!(bun.rule.declarative_match(d.path()), "should match {lock}");
+        }
+        // A plain node repo (no bun lockfile) doesn't match the bun descriptor.
+        let d = tmp();
+        fs::write(d.path().join("package.json"), "{}").unwrap();
+        assert!(!bun.rule.declarative_match(d.path()));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -636,6 +636,29 @@ fn doctor_runs_and_reports() {
 }
 
 #[test]
+fn doctor_flags_a_script_fragment_that_drops_output() {
+    // A script that prints then exits non-zero has its output dropped at render
+    // (rosita treats a non-zero exit as a failed probe), so doctor flags it. A
+    // clean script is reported as exiting cleanly.
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.author(
+        "[[fragments]]\nid = \"dropper\"\nscript_lang = \"bash\"\ncommand = \"echo hi; exit 1\"\n\
+         \n[[fragments]]\nid = \"cleanprobe\"\nscript_lang = \"bash\"\ncommand = \"echo ok\"\n",
+    );
+
+    fx.cmd()
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Script fragments"))
+        .stdout(
+            predicate::str::contains("dropper").and(predicate::str::contains("renders nothing")),
+        )
+        .stdout(predicate::str::contains("exit cleanly"));
+}
+
+#[test]
 fn refresh_all_six_agents_emit_gitignored_overlays() {
     let fx = Fixture::new();
     fx.rust_project();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -659,6 +659,47 @@ fn doctor_flags_a_script_fragment_that_drops_output() {
 }
 
 #[test]
+fn doctor_skips_disabled_script_fragments() {
+    // `allow_exec = false` is the off-switch: render never runs the script, so
+    // doctor must not either. A disabled dropper is neither executed nor flagged;
+    // only the enabled probe is counted ("1 probed").
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.author(
+        "[[fragments]]\nid = \"disabled-dropper\"\nscript_lang = \"bash\"\nallow_exec = false\ncommand = \"echo hi; exit 1\"\n\
+         \n[[fragments]]\nid = \"cleanprobe\"\nscript_lang = \"bash\"\ncommand = \"echo ok\"\n",
+    );
+
+    fx.cmd()
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Script fragments (1 probed)"))
+        .stdout(predicate::str::contains("renders nothing").not())
+        .stdout(predicate::str::contains("disabled-dropper").not());
+}
+
+#[test]
+fn doctor_does_not_flag_stderr_only_failures() {
+    // A probe that exits non-zero with NO stdout (a tool absent / logged-out
+    // daemon, e.g. tailnet) renders nothing legitimately — that's the normal
+    // "found nothing" case, not the footgun, so it must not be flagged.
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.author(
+        "[[fragments]]\nid = \"failloud\"\nscript_lang = \"bash\"\ncommand = \"echo boom >&2; exit 1\"\n",
+    );
+
+    fx.cmd()
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Script fragments (1 probed)"))
+        .stdout(predicate::str::contains("renders nothing").not())
+        .stdout(predicate::str::contains("exit cleanly"));
+}
+
+#[test]
 fn refresh_all_six_agents_emit_gitignored_overlays() {
     let fx = Fixture::new();
     fx.rust_project();


### PR DESCRIPTION
Follow-ups to #2 — implements the deferred next-steps and the review nits.

## Changes

### Bun support
- Detect `bun` as a stack (alongside `node`, the way `nextjs` rides along) in `context/languages.rs`.
- Read-only `bun` built-in target (`bun.lock`/`bun.lockb`) in `target.rs` — auto-reserved via `reserved_target_ids()`.
- Generic `bun-conventions` palette fragment + a `Bun` starter pack carrying the same grounding tail as the other stack packs.

### Context lines in the shipped env probes
- `toolchain`, `containers`, `ai-tools`, `tailnet` now lead with a one-line "what this is / how to use it" (they were bare data dumps).
- Each stays exit-0 and degrades to empty when its tool is absent. **`tailnet` keeps its deliberate fail-loud-on-error semantics** — a logged-out daemon still exits non-zero so the probe is reported failed/retryable, not cached as "no peers".

### `project-scripts` review nits
- justfile fallback guards against `:=` lines (variable assignments / `set` were being listed as recipes).
- Package-manager hint defaults to `npm run` instead of a literal `<pm>` placeholder when no lockfile is present.

### `doctor` footgun check
- A non-zero script exit makes rosita drop a probe's output entirely. `doctor` now runs each configured script fragment and warns when one exits non-zero **while printing stdout** (the silent-drop trap), pointing at the `exit 0` fix. Non-zero with no output (tool absent) is the normal case and is left alone.

## Validation
- `cargo test` — **297 pass** (new: bun stack detection, bun descriptor, doctor footgun test).
- `cargo clippy --all-targets` + `cargo fmt --check` — clean.
- Real-binary smoke: a bun repo detects `[node, bun]` under a clean HOME.
- Ran the four rewritten probe scripts directly: all emit context + data and exit 0; tailnet's failure path exits non-zero; the justfile guard and `npm run` default behave as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)