### PR TITLE
refactor: remove dead code and the inert studio context simulator

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -566,11 +566,6 @@ pub fn global_config_path() -> Option<PathBuf> {
     global_config_dir().map(|d| d.join("config.toml"))
 }
 
-/// Path to the global private `local.toml` (gitignored), if resolvable.
-pub fn global_local_path() -> Option<PathBuf> {
-    global_config_dir().map(|d| d.join("local.toml"))
-}
-
 /// Repo private `local.toml` path (gitignored): real hostnames, `host_classes`,
 /// fragment `params` — the sensitive layer kept out of the shareable config.
 pub fn repo_local_path(repo_base: &Path) -> PathBuf {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -242,16 +242,10 @@ pub fn repo_base_for(cwd: &Path) -> PathBuf {
 
 /// Run the full detector pipeline for `cwd` against `config`. Detection is
 /// **cache-only** for script-predicate targets (no code runs) — the default for
-/// inspection commands; use [`detect_context_live`] on the real render paths.
+/// inspection commands; pass `live = true` via [`detect_context_with`] on the
+/// real render paths (`run`/`refresh`).
 pub fn detect_context(cwd: &Path, config: &Config) -> crate::Result<Context> {
     detect_context_with(cwd, config, false)
-}
-
-/// Like [`detect_context`] but **live**: script-predicate custom targets may
-/// execute (and cache their verdict). For `run`/`render`/`refresh`, which
-/// already execute dynamic fragments.
-pub fn detect_context_live(cwd: &Path, config: &Config) -> crate::Result<Context> {
-    detect_context_with(cwd, config, true)
 }
 
 /// Run the full detector pipeline for `cwd` against `config`, with `live`

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -73,8 +73,6 @@ pub struct RenderOutput {
     pub content: String,
     /// `sha256:…` of the context that produced it.
     pub context_hash: String,
-    /// Where the base template came from.
-    pub template_source: String,
     /// Concatenated fragment guidance (the `profile_guidance` body; may be
     /// empty, e.g. when every fragment is restricted to other agents).
     pub profile_guidance: String,
@@ -214,7 +212,6 @@ pub fn render(req: &RenderRequest) -> crate::Result<RenderOutput> {
     Ok(RenderOutput {
         content: format!("{header}{body}"),
         context_hash,
-        template_source: base.source,
         profile_guidance,
         has_dynamic,
         fragments: rendered_caps,

--- a/src/studio/edit.rs
+++ b/src/studio/edit.rs
@@ -59,11 +59,6 @@ pub enum StagedOp {
     /// Copy a shipped palette fragment into a layer to own it (the only way to
     /// "edit" a palette item). Re-resolved from the palette on replay.
     DuplicatePaletteItem { id: String, to_layer: Layer },
-    /// Add a new custom target to a layer.
-    CreateTarget {
-        layer: Layer,
-        target: Box<TargetDef>,
-    },
     /// Replace the target with this id in a layer (created if absent).
     EditTarget {
         layer: Layer,
@@ -84,7 +79,6 @@ impl StagedOp {
             | StagedOp::CreateProfile { layer, .. }
             | StagedOp::EditProfile { layer, .. }
             | StagedOp::DeleteProfile { layer, .. }
-            | StagedOp::CreateTarget { layer, .. }
             | StagedOp::EditTarget { layer, .. }
             | StagedOp::DeleteTarget { layer, .. } => *layer,
             StagedOp::DuplicatePaletteItem { to_layer, .. } => *to_layer,
@@ -421,9 +415,6 @@ fn apply_op(doc: &mut DocumentMut, op: &StagedOp) -> Result<()> {
                 .ok_or_else(|| anyhow!("unknown palette fragment '{id}'"))?;
             // Duplicating an existing id replaces it (you own the copy now).
             upsert(aot_mut(doc, "fragments"), "id", id, fragment_table(&cap)?);
-        }
-        StagedOp::CreateTarget { target, .. } => {
-            aot_mut(doc, "targets").push(target_table(target)?);
         }
         StagedOp::EditTarget { id, target, .. } => {
             upsert(aot_mut(doc, "targets"), "id", id, target_table(target)?);

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -29,7 +29,7 @@ use crate::pack::Pack;
 use crate::profile::ProfileConfig;
 use crate::studio::assets;
 use crate::studio::edit::{Session, StagedOp};
-use crate::studio::state::{self, LibraryView, PreviewOutcome, Simulated, StudioState};
+use crate::studio::state::{self, LibraryView, PreviewOutcome, StudioState};
 use crate::studio::views;
 
 /// The sole route reachable without the session cookie (carries the token).
@@ -132,7 +132,6 @@ pub fn route(state: &Arc<Mutex<StudioState>>, req: &Req) -> Resp {
         ("GET", "/tab/targets") => handle_tab(state, "targets"),
         ("GET", "/staged") => handle_staged(state),
         ("GET", "/close") => Resp::html(String::new()),
-        ("GET", "/fs-status") => handle_fs_status(state),
         ("GET", "/diff") => handle_diff(state),
         ("POST", "/apply") => handle_apply(state),
         ("POST", "/discard") => handle_discard(state),
@@ -196,11 +195,6 @@ fn handle_profile_param(state: &Arc<Mutex<StudioState>>, req: &Req) -> Resp {
     match (req.method.as_str(), action) {
         ("GET", "edit") => handle_profile_edit(state, &name),
         ("GET", "select") => handle_profile_select(state, &name),
-        ("GET", "preview") => handle_profile_preview(state, &name, ""),
-        ("POST", "preview") => {
-            let agent = field(&req.body, "agent");
-            handle_profile_preview(state, &name, &agent)
-        }
         ("POST", "disable") => handle_profile_disable(state, &name),
         ("POST", "run") => handle_profile_run(state, &name),
         ("DELETE", "") => handle_profile_delete(state, &name),
@@ -280,7 +274,7 @@ fn profiles_tab_main(
             .map(|p| p.disabled)
             .unwrap_or(false);
         let outcome = state::render_profile(&snap, &name, "", DynamicMode::ReadOnly)
-            .unwrap_or_else(|e| empty_preview(&name, format!("preview error: {e}")));
+            .unwrap_or_else(|e| empty_preview(format!("preview error: {e}")));
         (name, outcome, disabled)
     });
     // On a fresh config (no profiles and no own caps), the empty Profiles tab
@@ -404,10 +398,9 @@ fn handle_fragment_run(state: &Arc<Mutex<StudioState>>, id: &str, profile: &str)
 }
 
 /// An empty preview outcome (used when a profile can't be composed/rendered).
-fn empty_preview(name: &str, note: String) -> PreviewOutcome {
+fn empty_preview(note: String) -> PreviewOutcome {
     PreviewOutcome {
         agent: String::new(),
-        profile_label: name.to_string(),
         context_summary: String::new(),
         fragment_count: 0,
         overlay: String::new(),
@@ -973,17 +966,6 @@ fn handle_profile_select(state: &Arc<Mutex<StudioState>>, name: &str) -> Resp {
     )
 }
 
-fn handle_profile_preview(state: &Arc<Mutex<StudioState>>, name: &str, agent: &str) -> Resp {
-    handle_profile_detail(
-        state,
-        name,
-        agent,
-        DynamicMode::ReadOnly,
-        views::Expand::None,
-        None,
-    )
-}
-
 fn handle_profile_disable(state: &Arc<Mutex<StudioState>>, name: &str) -> Resp {
     let res = {
         let mut s = state.lock().unwrap();
@@ -1148,7 +1130,6 @@ fn profile_preview_or_empty(
     state::render_profile_config(snap, profile, agent, DynamicMode::ReadOnly).unwrap_or_else(|e| {
         PreviewOutcome {
             agent: agent.to_string(),
-            profile_label: profile.name.clone(),
             context_summary: String::new(),
             fragment_count: 0,
             overlay: String::new(),
@@ -1266,12 +1247,6 @@ fn auto_push_after_apply(state: &Arc<Mutex<StudioState>>) -> Option<String> {
     }
 }
 
-fn handle_fs_status(state: &Arc<Mutex<StudioState>>) -> Resp {
-    // A light read of ≤4 small files; the heavy work (render) is kept off-lock.
-    let changed = state.lock().unwrap().session.external_edits();
-    Resp::html(views::fs_status_fragment(&changed))
-}
-
 // --- security guards ---------------------------------------------------------
 
 fn host_ok(req: &Req, port: u16) -> bool {
@@ -1339,11 +1314,6 @@ pub fn serve(rt: &Runtime, args: &StudioArgs) -> crate::Result<()> {
         .unwrap_or(args.port);
 
     let state = Arc::new(Mutex::new(StudioState {
-        sim: Simulated {
-            agent: config.default_agent.clone(),
-            lang: None,
-            scope: None,
-        },
         session,
         base_context,
         repo_base,
@@ -1525,11 +1495,6 @@ mod tests {
         let base_context = context::detect_context(repo, &config).unwrap();
         let session = Session::open(repo, Some(&gdir)).unwrap();
         Arc::new(Mutex::new(StudioState {
-            sim: Simulated {
-                agent: config.default_agent.clone(),
-                lang: None,
-                scope: None,
-            },
             session,
             base_context,
             repo_base: repo.to_path_buf(),
@@ -1895,16 +1860,10 @@ mod tests {
         // The rendered/raw toggle is gone in the new design.
         assert!(!body.contains("overlay-toggle") && !body.contains("ov-raw"));
 
-        // The agent-change POST is CSRF-guarded (no Origin → rejected).
+        // A state-changing POST is CSRF-guarded (no Origin → rejected).
         let r = route(
             &st,
-            &req(
-                "POST",
-                "/profiles/rust/preview",
-                "",
-                &[HOST, COOKIE],
-                "agent=claude",
-            ),
+            &req("POST", "/profiles/rust/disable", "", &[HOST, COOKIE], ""),
         );
         assert_eq!(r.status, 403);
     }

--- a/src/studio/state.rs
+++ b/src/studio/state.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 use crate::adapters;
 use crate::config::Config;
-use crate::context::{Context, GitContext, Scope};
+use crate::context::{Context, Scope};
 use crate::dynamic::DynamicMode;
 use crate::fragment::{palette, Fragment, Layer};
 use crate::pack::{self, Pack};
@@ -18,50 +18,15 @@ use crate::profile::{self, FragmentRef, ProfileConfig, Selection};
 use crate::render::{self, RenderRequest};
 use crate::studio::edit::{Session, StagedOp};
 
-/// The simulated context the preview is rendered for. Each field overrides the
-/// real detected context; `None`/empty means "use what was detected".
-#[derive(Debug, Clone)]
-pub struct Simulated {
-    /// Target agent id to render for.
-    pub agent: String,
-    /// Override the detected stack/language (empty ⇒ no stack).
-    pub lang: Option<String>,
-    /// Override repo-vs-machine scope.
-    pub scope: Option<Scope>,
-}
-
-impl Simulated {
-    /// Update the simulator from a posted urlencoded form (`lang`/`scope`/`agent`).
-    /// Unrecognized/blank values reset to "use detected".
-    pub fn update_from_form(&mut self, body: &str) {
-        for (k, v) in parse_pairs(body) {
-            match k.as_str() {
-                "agent" if !v.is_empty() => self.agent = v,
-                "lang" => self.lang = if v.is_empty() { None } else { Some(v) },
-                "scope" => {
-                    self.scope = match v.as_str() {
-                        "repo" => Some(Scope::Repo),
-                        "machine" => Some(Scope::Machine),
-                        _ => None,
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-}
-
 /// A studio editing/viewing session: the edit engine + the detected context +
-/// the simulator + the security token/port. Lives behind an `Arc<Mutex<…>>`.
+/// the security token/port. Lives behind an `Arc<Mutex<…>>`.
 pub struct StudioState {
     /// The comment-preserving edit engine over the writable layers.
     pub session: Session,
-    /// The real detected context (the simulator overrides a clone of this).
+    /// The real detected context the preview is rendered for.
     pub base_context: Context,
     /// Repo base (git root or cwd).
     pub repo_base: PathBuf,
-    /// The simulated context the preview reflects.
-    pub sim: Simulated,
     /// Per-session CSRF/session token (also the bootstrap-cookie value).
     pub token: String,
     /// Bound port (for Host/Origin checks).
@@ -79,7 +44,6 @@ impl StudioState {
     pub fn snapshot(&self) -> Snapshot {
         Snapshot {
             base_context: self.base_context.clone(),
-            sim: self.sim.clone(),
             layer_texts: self.session.staged_layer_texts(),
         }
     }
@@ -88,7 +52,6 @@ impl StudioState {
 /// An owned, lock-free snapshot for rendering a view.
 pub struct Snapshot {
     pub base_context: Context,
-    pub sim: Simulated,
     pub layer_texts: Vec<(Layer, PathBuf, String)>,
 }
 
@@ -96,10 +59,7 @@ pub struct Snapshot {
 pub struct PreviewOutcome {
     /// Agent the overlay was rendered for.
     pub agent: String,
-    /// Selected profile label (`none` when no profile applies). Retained for the
-    /// `profile {label}` text in the overlay head.
-    pub profile_label: String,
-    /// Short human summary of the simulated context, e.g. `rust · repo`.
+    /// Short human summary of the context, e.g. `rust · repo`.
     pub context_summary: String,
     /// How many fragments actually render for `agent` (after agent gating) —
     /// the provenance breadcrumb's count, truthful to what's in the overlay.
@@ -148,8 +108,6 @@ pub struct FragmentView {
     pub script_lang: Option<String>,
     /// True when authored in a `*local.toml` layer (private / gitignored).
     pub private: bool,
-    /// Composed into the current preview overlay.
-    pub active: bool,
 }
 
 /// Whether a profile's referenced fragment id resolves to something that
@@ -176,10 +134,8 @@ pub struct ProfileView {
     pub name: String,
     pub targets: Vec<String>,
     pub selected: bool,
-    pub candidate: bool,
     /// When true the profile is an off-switch off (never selected/composed).
     pub disabled: bool,
-    pub fragments: Vec<String>,
     /// Resolved composition atoms, in declared order (drives the card's dots).
     pub atoms: Vec<AtomDot>,
 }
@@ -220,31 +176,6 @@ pub struct TargetsView {
 /// Assemble the staged config (origin-tagged) from a snapshot.
 pub fn staged_config(snap: &Snapshot) -> crate::Result<Config> {
     Config::from_layer_strs(snap.layer_texts.clone())
-}
-
-/// Apply the simulator overrides to the detected context.
-pub fn simulated_context(base: &Context, sim: &Simulated) -> Context {
-    let mut ctx = base.clone();
-    if let Some(lang) = &sim.lang {
-        ctx.stacks = if lang.is_empty() {
-            vec![]
-        } else {
-            vec![lang.clone()]
-        };
-    }
-    match sim.scope {
-        Some(Scope::Machine) => ctx.git = None,
-        Some(Scope::Repo) if ctx.git.is_none() => {
-            ctx.git = Some(GitContext {
-                root: ctx.repo_base.clone(),
-                branch: Some("main".to_string()),
-                remotes: vec![],
-                is_worktree: false,
-            });
-        }
-        _ => {}
-    }
-    ctx
 }
 
 /// Select the profile for `(cfg, ctx)` honoring the on-disk binding. `select`
@@ -394,7 +325,6 @@ fn render_profile_in_config(
         .collect();
     Ok(PreviewOutcome {
         agent: agent_id,
-        profile_label: profile.name.clone(),
         context_summary: context_summary(&ctx),
         fragment_count,
         overlay: out.content,
@@ -460,8 +390,8 @@ fn context_for_profile(base: &Context, profile: &ProfileConfig) -> Context {
     ctx
 }
 
-/// A short human summary of a (simulated) context for the provenance
-/// breadcrumb, e.g. `rust · repo` or `no stack · machine`.
+/// A short human summary of a context for the provenance breadcrumb,
+/// e.g. `rust · repo` or `no stack · machine`.
 fn context_summary(ctx: &Context) -> String {
     let stack = if ctx.stacks.is_empty() {
         "no stack".to_string()
@@ -473,35 +403,22 @@ fn context_summary(ctx: &Context) -> String {
 }
 
 /// Build the left-pane library view (your caps + the palette + your profiles),
-/// marking what's active/selected for the snapshot's simulated context.
+/// marking the profile selected for the snapshot's detected context.
 pub fn library_view(snap: &Snapshot) -> crate::Result<LibraryView> {
     let cfg = staged_config(snap)?;
-    let ctx = simulated_context(&snap.base_context, &snap.sim);
-    let selection = select_for(&cfg, &ctx);
+    let selection = select_for(&cfg, &snap.base_context);
 
     let selected_name = match &selection {
         Selection::Use(p) | Selection::Default(p) => Some(p.name.clone()),
         _ => None,
     };
-    let active_ids: Vec<String> = match &selection {
-        Selection::Use(p) | Selection::Default(p) => {
-            profile::compose_profile(&ctx, p, &cfg.fragments, &cfg.fragment_params)
-                .fragments
-                .iter()
-                .map(|rc| rc.fragment.id.clone())
-                .collect()
-        }
-        _ => vec![],
-    };
 
-    let tags = ctx.selection_targets();
     let yours = cfg
         .fragments
         .iter()
         .map(|c| FragmentView {
             kind: kind_of(c.command.is_some(), c.provider.is_some()),
             category: c.category.clone(),
-            active: active_ids.contains(&c.id),
             title: c.title().to_string(),
             summary: fragment_summary(c),
             script_lang: c.script_lang.clone(),
@@ -535,7 +452,6 @@ pub fn library_view(snap: &Snapshot) -> crate::Result<LibraryView> {
         .map(|c| FragmentView {
             kind: kind_of(c.command.is_some(), c.provider.is_some()),
             category: c.category.clone(),
-            active: false,
             title: c.title().to_string(),
             summary: fragment_summary(c),
             script_lang: c.script_lang.clone(),
@@ -550,9 +466,7 @@ pub fn library_view(snap: &Snapshot) -> crate::Result<LibraryView> {
             name: p.name.clone(),
             targets: p.targets.clone(),
             selected: selected_name.as_deref() == Some(p.name.as_str()),
-            candidate: profile::profile_matches_targets(p, &tags),
             disabled: p.disabled,
-            fragments: p.fragments.iter().map(|r| r.id().to_string()).collect(),
             atoms: p
                 .fragments
                 .iter()
@@ -630,10 +544,8 @@ pub fn targets_view(snap: &Snapshot) -> TargetsView {
 }
 
 /// First-launch onboarding readout for a fresh config (no profiles **and** no
-/// own fragments yet): what rosita detected here, plus a "quick start"
-/// suggestion — a starter profile pre-filled from the detected target and a few
-/// palette fragments. The palette items are only *suggested*; quick-start
-/// duplicates them into your library (staged) so you own and can edit them.
+/// own fragments yet): what rosita detected here. The welcome view pairs this
+/// with the starter-pack gallery, which is what actually seeds a profile.
 pub struct Onboarding {
     /// The detected primary stack (`rust`, `node`, …), or `None` when none was
     /// recognized / outside a repo.
@@ -642,55 +554,18 @@ pub struct Onboarding {
     pub scope: Scope,
     /// The current branch, when in a repo.
     pub branch: Option<String>,
-    /// Suggested profile name (the detected target, `machine`, or `project`).
-    pub name: String,
-    /// Suggested `targets` (the detected target, or empty when none was found).
-    pub targets: Vec<String>,
-    /// Palette fragment ids the quick-start composes (each duplicated into the
-    /// library on use). Already filtered to real palette ids and de-duplicated.
-    pub caps: Vec<String>,
 }
 
-/// Compute the [`Onboarding`] suggestion for a detected context. The mapping is
-/// deliberately coarse: the matching `<stack>-conventions` palette cap (or
-/// `infra-caution` for the machine context), plus the universal `terse-comms`
-/// and `conventional-commits` starters.
+/// Compute the [`Onboarding`] readout (detected stack/scope/branch) for a fresh
+/// config. The welcome view renders this above the starter-pack gallery.
 pub fn onboarding(base: &Context) -> Onboarding {
     let scope = base.scope();
     let stack = base.stacks.first().cloned();
     let branch = base.git.as_ref().and_then(|g| g.branch.clone());
-    let (name, targets) = match (&stack, scope) {
-        (Some(s), _) => (s.clone(), vec![s.clone()]),
-        (None, Scope::Machine) => ("machine".to_string(), vec!["machine".to_string()]),
-        (None, Scope::Repo) => ("project".to_string(), Vec::new()),
-    };
-    let stack_cap = match stack.as_deref() {
-        Some("rust") => Some("rust-conventions"),
-        Some("nextjs") => Some("nextjs-conventions"),
-        Some("node") => Some("node-conventions"),
-        Some("go") => Some("go-conventions"),
-        Some("python") => Some("python-conventions"),
-        _ => None,
-    };
-    let mut caps: Vec<String> = Vec::new();
-    if let Some(c) = stack_cap {
-        caps.push(c.to_string());
-    } else if scope == Scope::Machine {
-        caps.push("infra-caution".to_string());
-    }
-    caps.push("terse-comms".to_string());
-    caps.push("conventional-commits".to_string());
-    // Keep only ids that really exist in the palette, de-duplicated, order-stable.
-    let pal: std::collections::HashSet<String> = palette().into_iter().map(|c| c.id).collect();
-    let mut seen = std::collections::HashSet::new();
-    caps.retain(|id| pal.contains(id) && seen.insert(id.clone()));
     Onboarding {
         stack,
         scope,
         branch,
-        name,
-        targets,
-        caps,
     }
 }
 
@@ -713,20 +588,18 @@ pub struct PackView {
 /// The pack recommended for the snapshot's detected context, if any (the first
 /// pack whose `recommended_for` matches a selection target).
 pub fn recommended_pack(snap: &Snapshot) -> Option<Pack> {
-    let ctx = simulated_context(&snap.base_context, &snap.sim);
-    let targets = ctx.selection_targets();
+    let targets = snap.base_context.selection_targets();
     pack::packs()
         .into_iter()
         .find(|p| targets.iter().any(|t| p.is_recommended_for(t)))
 }
 
-/// Build the starter-pack gallery for the snapshot's (simulated) context:
+/// Build the starter-pack gallery for the snapshot's detected context:
 /// recommended packs first, each with its fragments' atom dots and an
 /// already-applied flag. No probes — purely from the staged snapshot.
 pub fn pack_views(snap: &Snapshot) -> crate::Result<Vec<PackView>> {
     let cfg = staged_config(snap)?;
-    let ctx = simulated_context(&snap.base_context, &snap.sim);
-    let targets = ctx.selection_targets();
+    let targets = snap.base_context.selection_targets();
 
     let owned_ids: std::collections::HashSet<&str> =
         cfg.fragments.iter().map(|c| c.id.as_str()).collect();
@@ -1321,23 +1194,6 @@ mod tests {
             fragment_summary(&c).as_deref(),
             Some("Runs a script; its output is embedded.")
         );
-    }
-
-    #[test]
-    fn simulator_form_updates_and_resets() {
-        let mut sim = Simulated {
-            agent: "claude".into(),
-            lang: None,
-            scope: None,
-        };
-        sim.update_from_form("lang=go&scope=machine&agent=codex");
-        assert_eq!(sim.lang.as_deref(), Some("go"));
-        assert!(matches!(sim.scope, Some(Scope::Machine)));
-        assert_eq!(sim.agent, "codex");
-        // Blank lang resets to "use detected".
-        sim.update_from_form("lang=&scope=");
-        assert!(sim.lang.is_none());
-        assert!(sim.scope.is_none());
     }
 
     #[test]

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -1740,15 +1740,6 @@ pub fn error_page(msg: &str) -> String {
     html! { (DOCTYPE) html { head { title { "Rosita studio — error" } } body { pre class="error" { (msg) } } } }.into_string()
 }
 
-/// `GET /fs-status` — the light external-edit poll banner.
-pub fn fs_status_fragment(changed: &[std::path::PathBuf]) -> String {
-    if changed.is_empty() {
-        return html! { span class="fs-clean" { "on-disk unchanged since load" } }.into_string();
-    }
-    let names: Vec<String> = changed.iter().map(|p| display_name(p)).collect();
-    html! { div class="banner warn" { span class="banner-icon" { (icon("alert")) } div class="banner-body" { "Config changed on disk: " (names.join(", ")) " — reload before applying." } } }.into_string()
-}
-
 // --- shared bits -------------------------------------------------------------
 
 fn atom_dot(a: &AtomDot) -> Markup {
@@ -1808,7 +1799,6 @@ mod tests {
             category: category.map(str::to_string),
             script_lang: None,
             private: false,
-            active: false,
         }
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -49,9 +49,6 @@ impl Painter {
     pub fn cyan(&self, s: &str) -> String {
         self.fg(s, AnsiColor::Cyan)
     }
-    pub fn red(&self, s: &str) -> String {
-        self.fg(s, AnsiColor::Red)
-    }
     pub fn dim(&self, s: &str) -> String {
         self.paint(s, Style::new().dimmed())
     }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -10,7 +10,7 @@
 //! So an agent's `template` field can name a custom per-agent body (drop a file
 //! at `templates/<id>.md.j2`); otherwise every agent shares the embedded overlay.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::config;
 
@@ -61,11 +61,6 @@ fn read_if_exists(path: &Path) -> crate::Result<Option<ResolvedTemplate>> {
 
 fn display_path(p: &Path) -> String {
     p.display().to_string()
-}
-
-/// Convenience: the global templates dir path (may not exist).
-pub fn global_templates_dir() -> Option<PathBuf> {
-    config::global_templates_dir()
 }
 
 #[cfg(test)]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -32,11 +32,6 @@ pub enum WriteAction {
 }
 
 impl WriteAction {
-    /// True if this represents (or would represent) a real change.
-    pub fn is_change(self) -> bool {
-        !matches!(self, WriteAction::Unchanged)
-    }
-
     /// Short human label.
     pub fn label(self) -> &'static str {
         match self {


### PR DESCRIPTION
## What

Removes dead, redundant, and unnecessary `pub` code surfaced by an audit. Because the crate is a `[lib]`, the compiler treats every `pub` item as potentially used by an external consumer, so `dead_code`/clippy stayed clean even where these items had **zero callers anywhere** in `src/` or `tests/`.

**Truly-dead items (zero callers):**
- `config::global_local_path`, `context::detect_context_live`
- `WriteAction::is_change`, `Painter::red`
- `templates::global_templates_dir` (redundant wrapper over the `config::` fn)
- `RenderOutput.template_source` (write-only field)
- `StagedOp::CreateTarget` enum variant + its `layer()`/`apply_op` arms — studio creates targets via `EditTarget`
- studio `/fs-status` route + `handle_fs_status` + `fs_status_fragment` view
- studio `/profiles/<name>/preview` routes + `handle_profile_preview` (unreachable — the editor preview uses the separate `/profiles/preview`)
- write-only view fields: `FragmentView.active`, `ProfileView.candidate` & `.fragments`, `Onboarding.{name,targets,caps}`, `PreviewOutcome.profile_label`

**The studio context simulator** (`Simulated`, `simulated_context`, `update_from_form`, the `sim` field + snapshot plumbing): its only mutator was never wired to a route, so `simulated_context()` always returned the detected context unchanged — an inert passthrough for a UI control that was never built. Library/pack/preview views now read `base_context` directly.

## Why

These add maintenance/cognitive cost with no behavioral contribution. Net **−249/+24** lines, no functional change.

## Validation

- `cargo build --all-targets` — clean, no warnings
- `cargo clippy --all-targets` — clean, no warnings
- `cargo test` — **301 pass, 0 fail**
- `cargo doc` — no new warnings (one fewer than main)
- Verified no embedded JS/HTML references the removed routes at runtime
- The CSRF test that posted to the removed preview route now posts to `/profiles/<name>/disable`, preserving guard coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)