### PR TITLE
fix(studio): pin machine profile to top; amber scripts in profile view; doc bun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to rosita are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
+## Unreleased
+
+### Changed
+
+- **The machine-scope profile is pinned to the top of the Studio profile list**,
+  so the off-repo profile is always first regardless of config order.
+- **Scripts read consistently in the profile view.** A profile's fragment list
+  now tints script and live-provider fragments with the same amber tile — and
+  amber run buttons — as the Fragments tab, so executable fragments stand out.
+
+### Fixed
+
+- **Documented the `bun` built-in target**, which was detected and selectable but
+  missing from the README's target list.
+
 ## 0.7.0 — 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Built-in targets include:
 ```text
 rust
 node
+bun
 nextjs
 go
 python

--- a/src/studio/assets/studio.css
+++ b/src/studio/assets/studio.css
@@ -320,8 +320,12 @@ body {
 .fragment-detail-head::-webkit-details-marker { display: none; }
 .fragment-detail-head:hover { background: var(--panel-2); }
 .fragment-detail[open] > .fragment-detail-head { background: var(--panel-2); border-bottom: 1px solid var(--border); }
-.fragment-detail .fragment-glyph { color: var(--faint); display: inline-flex; }
-.fragment-detail .fragment-glyph .icon { width: 15px; height: 15px; }
+/* Tinted tile keyed to execution type, matching the Fragments tab: markdown gets
+   the calm accent tile, scripts/live-providers the warm caution tile — so the
+   type reads at a glance (the bare amber glyph was too faint to spot). */
+.fragment-detail .fragment-glyph { flex: none; display: inline-flex; align-items: center; justify-content: center; width: 26px; height: 26px; border-radius: var(--r-sm); background: var(--accent-soft); color: var(--accent); }
+.fragment-detail .fragment-glyph.k-command, .fragment-detail .fragment-glyph.k-provider { background: var(--caution-soft); color: var(--caution); }
+.fragment-detail .fragment-glyph .icon { width: 16px; height: 16px; }
 .fragment-detail-title { font-weight: 600; font-size: 12px; color: var(--muted); }
 .fragment-detail-id { font-family: var(--mono); font-size: 11px; color: var(--faint); }
 .fragment-detail-spacer { flex: 1; }
@@ -539,9 +543,13 @@ input::placeholder, textarea::placeholder { color: var(--faint); }
 .btn-xs { padding: 2px 8px; font-size: 11px; gap: 4px; }
 .fragment-run .icon, .run-all .icon { width: 12px; height: 12px; }
 .prov-spacer { flex: 1; }
-.run-all { color: var(--accent); margin: -2px 0; }
-.fragment-detail-head .fragment-run { color: var(--muted); opacity: .85; }
+/* Script-run affordances carry the warm caution hue, tying them to the amber
+   script tiles (the buttons only ever appear on script/provider fragments). */
+.run-all { color: var(--caution); border-color: var(--caution-line); margin: -2px 0; }
+.run-all:hover { color: var(--caution); border-color: var(--caution); background: var(--caution-soft); }
+.fragment-detail-head .fragment-run { color: var(--caution); border-color: var(--caution-line); opacity: .85; }
 .fragment-detail-head:hover .fragment-run { opacity: 1; }
+.fragment-detail-head .fragment-run:hover { border-color: var(--caution); background: var(--caution-soft); }
 
 /* Failed-run body: the error banner with a retry button beneath it (replaces
    the output/run-prompt for a card whose script just failed). */

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -2447,13 +2447,12 @@ mod tests {
                    [[profiles]]\nname = \"machine\"\ntargets = [\"machine\"]\nfragments = [\"rc\"]\n";
         let d = rust_repo();
         let st = state_for(d.path(), Some(cfg));
-        let body = body_of(route(&st, &req("GET", "/tab/profiles", "", &[HOST, COOKIE], "")));
-        let machine_at = body.find(r#"data-profile="machine""#).expect("machine in rail");
-        let web_at = body.find(r#"data-profile="web""#).expect("web in rail");
-        assert!(
-            machine_at < web_at,
-            "machine profile must render before web in the rail"
-        );
+        let r = route(&st, &req("GET", "/tab/profiles", "", &[HOST, COOKIE], ""));
+        let body = body_of(r);
+        let machine_at = body.find(r#"data-profile="machine""#);
+        let web_at = body.find(r#"data-profile="web""#);
+        assert!(machine_at.is_some(), "machine profile in rail");
+        assert!(machine_at < web_at, "machine renders before web");
     }
 
     #[test]

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -2439,6 +2439,24 @@ mod tests {
     }
 
     #[test]
+    fn machine_profile_is_pinned_to_top_of_rail() {
+        // `machine` is declared *second*, but the rail pins the machine-scope
+        // profile to the top regardless of config order.
+        let cfg = "[[fragments]]\nid = \"rc\"\nguidance = \"x\"\n\n\
+                   [[profiles]]\nname = \"web\"\ntargets = [\"nextjs\"]\nfragments = [\"rc\"]\n\n\
+                   [[profiles]]\nname = \"machine\"\ntargets = [\"machine\"]\nfragments = [\"rc\"]\n";
+        let d = rust_repo();
+        let st = state_for(d.path(), Some(cfg));
+        let body = body_of(route(&st, &req("GET", "/tab/profiles", "", &[HOST, COOKIE], "")));
+        let machine_at = body.find(r#"data-profile="machine""#).expect("machine in rail");
+        let web_at = body.find(r#"data-profile="web""#).expect("web in rail");
+        assert!(
+            machine_at < web_at,
+            "machine profile must render before web in the rail"
+        );
+    }
+
+    #[test]
     fn profiles_tab_does_not_auto_select() {
         // A rust profile that *would* be the bound candidate in this repo.
         let cfg = "[[fragments]]\nid = \"rc\"\nguidance = \"x\"\n\

--- a/src/studio/state.rs
+++ b/src/studio/state.rs
@@ -80,6 +80,9 @@ pub struct PreviewCap {
     pub title: String,
     /// Glyph derived from the fragment's content type (markdown/script/provider).
     pub glyph: &'static str,
+    /// Content type (`static`/`command`/`provider`) — drives the glyph's `k-*`
+    /// color class so scripts/providers read distinctly, as in the Fragments tab.
+    pub kind: &'static str,
     /// Rendered guidance markdown (or the skip note).
     pub markdown: String,
     /// Resolved a dynamic provider/command.
@@ -306,13 +309,12 @@ fn render_profile_in_config(
             let cap = &rc.fragment;
             let owned = cfg.fragments.iter().find(|x| x.id == cap.id);
             let editable = owned.is_some();
-            let glyph = type_glyph(
-                kind_of(cap.command.is_some(), cap.provider.is_some()),
-                cap.script_lang.as_deref(),
-            );
+            let kind = kind_of(cap.command.is_some(), cap.provider.is_some());
+            let glyph = type_glyph(kind, cap.script_lang.as_deref());
             if let Some(c) = rendered.get(cap.id.as_str()) {
                 Some(PreviewCap {
                     glyph,
+                    kind,
                     editable,
                     id: c.id.clone(),
                     title: c.title.clone(),
@@ -324,6 +326,7 @@ fn render_profile_in_config(
             } else if cap.is_dynamic() {
                 Some(PreviewCap {
                     glyph,
+                    kind,
                     editable,
                     id: cap.id.clone(),
                     title: cap.title().to_string(),
@@ -502,7 +505,7 @@ pub fn library_view(snap: &Snapshot) -> crate::Result<LibraryView> {
             icon: target_icons.get(id).cloned().flatten(),
         }
     };
-    let profiles = cfg
+    let mut profiles: Vec<ProfileView> = cfg
         .profiles
         .iter()
         .map(|p| ProfileView {
@@ -517,6 +520,10 @@ pub fn library_view(snap: &Snapshot) -> crate::Result<LibraryView> {
                 .collect(),
         })
         .collect();
+    // Pin the machine-scope profile(s) to the top of the rail; everything else
+    // keeps config order (stable sort). The bare-machine profile is the one users
+    // reach for off-repo, so it's handy to have it first.
+    profiles.sort_by_key(|p| !p.targets.iter().any(|t| t.id == "machine"));
 
     Ok(LibraryView {
         yours,

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -775,7 +775,7 @@ fn preview_fragment_card(
     html! {
         details class="fragment-detail" open[open] {
             summary class="fragment-detail-head" {
-                span class="fragment-glyph" { (icon(glyph)) }
+                span class=(format!("fragment-glyph k-{}", c.kind)) { (icon(glyph)) }
                 span class="fragment-detail-title" { (c.title) }
                 span class="fragment-detail-id" { (c.id) }
                 span class="fragment-detail-spacer" {}


### PR DESCRIPTION
Small UI polish on top of v0.7.0.

### Changed
- **Machine-scope profile pinned to the top** of the profile rail (stable sort — everything else keeps config order). Regression-tested.
- **Scripts read consistently in the profile detail**: a profile's fragment list now uses the same amber glyph tile *and* amber Run / Re-run / "Run all scripts" buttons as the Fragments tab, instead of a faint colored glyph that was hard to spot.

### Fixed
- **README**: added `bun` to the built-in targets list — it was detected and selectable but undocumented (same drift the catalog-derived editor list fixed in code).

### Testing
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, full `cargo test` green (247).
- New test: machine profile pinned to top of the rail.
- Verified the profile detail visually (script tiles + amber run buttons) via headless render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)