### PR TITLE
feat: Create-a-Loadout studio + per-loadout workflows (remove global default workflow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,17 +128,18 @@ multiple loadouts match     →  ask once, then remember the choice for this pro
 
 ## Workflows
 
-A loadout carries your *context*. A **workflow** carries your *process* — the way you like to work, across every agent. Loadout exposes one fixed set of five slash commands — `/loadout:explore`, `brainstorm`, `plan`, `implement`, `verify` — and the active workflow decides what each step *means*. "Plan like Boris" and "plan spec-first" are the same `/loadout:plan`, carrying different instructions.
+A loadout carries your *context*. A **workflow** carries your *process* — the way you like to work, across every agent. Loadout exposes one fixed set of five slash commands — `/loadout:explore`, `brainstorm`, `plan`, `implement`, `verify` — and the workflow your loadout equips decides what each step *means*. "Plan like Boris" and "plan spec-first" are the same `/loadout:plan`, carrying different instructions.
 
 <p align="center">
   <img src="docs/screenshots/workflows.png" alt="load studio — the Workflows tab: a gallery of built-in processes mapped onto the fixed explore/brainstorm/plan/implement/verify spine" width="900">
 </p>
 <p align="center"><sub><i><code>load studio</code> — pick a house process, or build your own; each fills the same five-command spine.</i></sub></p>
 
-Six ship — Anthropic's lean loop, how Boris works, Superpowers, spec-driven, the Ralph loop, and Every's compound engineering — or build your own in `load studio`. A stage can hand a file to the next step (plan writes `plan.md`, implement reads it), which is what makes a workflow more than headings. Set your house process in one line:
+Six ship — Anthropic's lean loop, how Boris works, Superpowers, spec-driven, the Ralph loop, and Every's compound engineering — or build your own in `load studio`. A stage can hand a file to the next step (plan writes `plan.md`, implement reads it), which is what makes a workflow more than headings. Equip one on a loadout — in studio's **Workflow slot**, or by hand:
 
 ```toml
-[defaults]
+[[loadouts]]
+name = "machine"      # the default (no-targets) loadout → applies everywhere
 workflow = "lean"
 ```
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -108,9 +108,10 @@ is what makes a workflow more than headings.
 workflow, resolved in this order:
 
 1. `--workflow <id>` on a single run (an override; a bad id applies nothing).
-2. A per-loadout binding — `workflow = "<id>"` on a `[[loadouts]]` block (advanced).
-3. The **global active workflow** — `[defaults].workflow` — the same house
-   process in every repo. This is the primary path; `load studio` sets it.
+2. The workflow the selected loadout binds — `workflow = "<id>"` on its
+   `[[loadouts]]` block (equipped in studio's **Workflow slot**). To get a
+   workflow *everywhere*, bind it on the default (no-targets) loadout. There is
+   no separate global active workflow.
 
 **The catalog.** Six built-ins ship, each modeled on a real practice and stamped
 with provenance: `lean` (Anthropic's explore-plan-code-commit), `boris` (how

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,8 +39,10 @@ gitignored), `logs/events.jsonl` (audit, gitignored), `templates/` (overrides),
 ```toml
 [defaults]
 agent = "claude"     # agent used when --agent is omitted
-workflow = "lean"    # the global active workflow (see [[workflows]] below); omit for none
 ```
+
+(There is no global workflow setting — a workflow is bound per-loadout in its
+Workflow slot; see `[[loadouts]]` and `[[workflows]]` below.)
 
 ## `[env]` (implemented)
 
@@ -101,7 +103,7 @@ A loadout may also pin a workflow for the contexts it covers:
 name = "rust"
 targets = ["rust"]
 fragments = ["rust-conventions"]
-workflow = "boris"     # advanced: overrides [defaults].workflow where this loadout binds
+workflow = "boris"     # the workflow this loadout equips (its Workflow slot); omit for none
 ```
 
 ## `[[workflows]]` (implemented)
@@ -114,7 +116,7 @@ shadows a built-in. See [concepts](concepts.md#workflows-implemented).
 
 ```toml
 [[workflows]]
-id = "lean"                    # kebab-case, unique; how [defaults]/[[loadouts]] bind it
+id = "lean"                    # kebab-case, unique; how a [[loadouts]] block binds it
 name = "Lean"                  # gallery title + rendered heading (optional)
 description = "Read first, plan on paper, then build."   # one-line blurb (optional)
 icon = "git-branch"            # studio card glyph (optional)

--- a/skills/loadout-import-workflow/reference.md
+++ b/skills/loadout-import-workflow/reference.md
@@ -141,18 +141,14 @@ after the six. This workflow already ships as the built-in `compound` — so it
 doubles as an answer key. When you import a framework that *isn't* shipped, give
 it a fresh `id` and the same treatment.
 
-## Activating the imported workflow
+## Equipping the imported workflow
 
-A `[[workflows]]` block does nothing until it's selected. Add one of:
-
-```toml
-# Global active — applies in every repo (the common choice):
-[defaults]
-workflow = "compound"
-```
+A `[[workflows]]` block does nothing until a loadout equips it in its Workflow
+slot (`workflow = "<id>"`). There is no global active workflow — bind it on the
+loadout(s) where it should apply.
 
 ```toml
-# Per-profile — applies only where this profile binds (advanced):
+# On a stack loadout — applies in matching repos:
 [[loadouts]]
 name = "rust"
 targets = ["rust"]
@@ -160,6 +156,16 @@ fragments = ["..."]
 workflow = "compound"
 ```
 
-Then `load doctor` should report `active workflow: 'compound'` and
+```toml
+# On the default loadout (no targets) — the baseline that applies everywhere
+# nothing else matches, in any project or none. The way to get a workflow
+# "everywhere", like the old global default did:
+[[loadouts]]
+name = "machine"
+fragments = ["..."]
+workflow = "compound"
+```
+
+Then `load doctor` should report `loadout '<name>' → workflow 'compound'` and
 `load refresh` regenerates the six `/loadout:*` commands with the imported
 steps.

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -95,6 +95,8 @@ pub fn run(rt: &Runtime) -> crate::Result<()> {
     check_dangling_fragment_refs(&mut c, &prep.config);
     // Profiles binding an unknown workflow, and malformed user workflows.
     check_workflows(&mut c, &prep.config);
+    // The single-default invariant (one no-targets catch-all loadout).
+    check_default_loadout(&mut c, &prep.config);
     // Allowlist/denylist consistency.
     check_env_policy(&mut c, &prep.config);
     // Private-data leak lint over public config layers.
@@ -408,6 +410,36 @@ fn check_public_leaks(c: &mut Checks, prep: &super::Prepared) {
 /// for that entry (compose silently skips it). Surface the dangling reference —
 /// it usually means a fragment was hand-deleted without cleaning up the
 /// profile (studio's delete does this cleanup automatically).
+/// The single-default invariant: exactly one enabled loadout with no targets is
+/// the catch-all that applies when nothing else matches (in any project or none).
+/// Zero ⇒ unmatched contexts get no loadout; more than one ⇒ ambiguous.
+fn check_default_loadout(c: &mut Checks, cfg: &config::Config) {
+    let defaults: Vec<&str> = cfg
+        .profiles
+        .iter()
+        .filter(|p| !p.disabled && p.targets.is_empty())
+        .map(|p| p.name.as_str())
+        .collect();
+    match defaults.len() {
+        1 => c.line(
+            Status::Ok,
+            format!("default loadout: '{}' (applies everywhere nothing else matches)", defaults[0]),
+        ),
+        0 => c.line(
+            Status::Warn,
+            "no default loadout — nothing applies in a project that matches no loadout (or outside a project). In `load studio`, clear a loadout's targets to make it the default.",
+        ),
+        _ => c.line(
+            Status::Warn,
+            format!(
+                "{} default loadouts ({}) — only one loadout should have no targets; give the others a target so selection isn't ambiguous",
+                defaults.len(),
+                defaults.join(", ")
+            ),
+        ),
+    }
+}
+
 fn check_dangling_fragment_refs(c: &mut Checks, cfg: &config::Config) {
     let known: std::collections::HashSet<&str> =
         cfg.fragments.iter().map(|x| x.id.as_str()).collect();

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -464,20 +464,8 @@ fn check_dangling_fragment_refs(c: &mut Checks, cfg: &config::Config) {
 /// binding degrades silently at render time, so surface it here. Resolves
 /// against the same built-in + user catalog the renderer uses.
 fn check_workflows(c: &mut Checks, cfg: &config::Config) {
-    // The global active workflow ([defaults].workflow) — the one that applies in
-    // every repo. The primary way a workflow is selected.
-    if let Some(id) = &cfg.default_workflow {
-        if cfg.resolve_workflow(id).is_some() {
-            c.line(Status::Ok, format!("active workflow: '{id}'"));
-        } else {
-            c.line(
-                Status::Warn,
-                format!(
-                    "active workflow '{id}' is unknown (set [defaults].workflow to a built-in or your own, or pick one in `load studio`)"
-                ),
-            );
-        }
-    }
+    // A workflow is bound per-loadout (the Workflow slot) — there's no global
+    // default workflow anymore. Flag any loadout whose binding doesn't resolve.
     for p in &cfg.profiles {
         let Some(id) = &p.workflow else { continue };
         if cfg.resolve_workflow(id).is_some() {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -406,10 +406,6 @@ fn check_public_leaks(c: &mut Checks, prep: &super::Prepared) {
     }
 }
 
-/// A profile that references a fragment id not in the library renders nothing
-/// for that entry (compose silently skips it). Surface the dangling reference —
-/// it usually means a fragment was hand-deleted without cleaning up the
-/// profile (studio's delete does this cleanup automatically).
 /// The single-default invariant: exactly one enabled loadout with no targets is
 /// the catch-all that applies when nothing else matches (in any project or none).
 /// Zero ⇒ unmatched contexts get no loadout; more than one ⇒ ambiguous.
@@ -440,6 +436,10 @@ fn check_default_loadout(c: &mut Checks, cfg: &config::Config) {
     }
 }
 
+/// A profile that references a fragment id not in the library renders nothing
+/// for that entry (compose silently skips it). Surface the dangling reference —
+/// it usually means a fragment was hand-deleted without cleaning up the
+/// profile (studio's delete does this cleanup automatically).
 fn check_dangling_fragment_refs(c: &mut Checks, cfg: &config::Config) {
     let known: std::collections::HashSet<&str> =
         cfg.fragments.iter().map(|x| x.id.as_str()).collect();

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,12 +32,6 @@ use crate::workflow::Workflow;
 pub struct Config {
     /// Agent rendered when `--agent` is omitted.
     pub default_agent: String,
-    /// The **global active workflow** id (`[defaults].workflow`), or `None`. This
-    /// is the single house workflow that applies in *every* repo — the primary
-    /// way a workflow is selected (the studio sets it). Resolved against the
-    /// curated built-ins + your own; a per-loadout `workflow` binding, if set,
-    /// still wins over it. Global-only: a repo layer can't set it.
-    pub default_workflow: Option<String>,
     /// Environment-variable exposure policy.
     pub env: EnvConfig,
     /// Codex-adapter knobs.
@@ -272,29 +266,24 @@ impl Config {
 
     /// The workflow active for a run: an explicit `--workflow <id>` override wins
     /// outright (and resolves to `None` if it dangles — a bad override is not
-    /// silently swapped for the profile's binding); otherwise the profile named
-    /// by `profile` decides. The single resolver shared by the render engine and
-    /// `load run`'s launch-env wiring, so the overlay, the generated commands,
-    /// and the `LOADOUT_*_PATH` env vars all describe the same workflow.
+    /// silently swapped for the profile's binding); otherwise the workflow bound
+    /// by the selected loadout (`profile`) decides, or `None` if it binds none.
+    /// There is no global default workflow — the baseline lives on the default
+    /// loadout's Workflow slot like any other binding. The single resolver shared
+    /// by the render engine and `load run`'s launch-env wiring, so the overlay,
+    /// the generated commands, and the `LOADOUT_*_PATH` env vars all agree.
     pub fn resolve_active_workflow(
         &self,
         override_id: Option<&str>,
         profile: Option<&str>,
     ) -> Option<Workflow> {
         // A `--workflow` override wins outright (and resolves to None if it
-        // dangles — never silently swapped for a default).
+        // dangles — never silently swapped for the binding).
         if let Some(id) = override_id {
             return self.resolve_workflow(id);
         }
-        // Then a per-loadout binding, if one is set (the advanced, opt-in layer).
-        if let Some(w) = self.workflow_for_profile(profile) {
-            return Some(w);
-        }
-        // Otherwise the single global active workflow — the same one in every
-        // repo. This is the primary path; the studio sets `[defaults].workflow`.
-        self.default_workflow
-            .as_deref()
-            .and_then(|id| self.resolve_workflow(id))
+        // Otherwise the selected loadout's own workflow binding (or none).
+        self.workflow_for_profile(profile)
     }
 }
 
@@ -385,7 +374,10 @@ struct RawConfig {
 #[derive(Debug, Default, Deserialize)]
 struct RawDefaults {
     agent: Option<String>,
-    workflow: Option<String>,
+    // `workflow` is deprecated: the global active workflow was removed in favor of
+    // the per-loadout Workflow slot (and the default loadout for the baseline). A
+    // leftover `[defaults].workflow` is tolerated and ignored (it stays in the
+    // known-keys list so it doesn't trip the unknown-key warning).
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -489,9 +481,6 @@ impl RawConfig {
             let slot = self.defaults.get_or_insert_with(Default::default);
             if d.agent.is_some() {
                 slot.agent = d.agent;
-            }
-            if d.workflow.is_some() {
-                slot.workflow = d.workflow;
             }
         }
         if let Some(e) = other.env {
@@ -606,7 +595,6 @@ impl RawConfig {
 
         Config {
             default_agent: defaults.agent.unwrap_or_else(|| "claude".to_string()),
-            default_workflow: defaults.workflow,
             env: EnvConfig {
                 allowlist: dedup(env.allowlist.unwrap_or_else(default_env_allowlist)),
                 deny_name_patterns: dedup(
@@ -1132,8 +1120,8 @@ mod tests {
     fn unknown_settings_keys_are_tolerated_for_forward_compat() {
         // A config written by a newer loadout — an unknown `[defaults]` key plus
         // a whole unknown top-level table — must LOAD, not brick, on this binary,
-        // and the known fields still take effect. This is the regression guard
-        // for the `[defaults].workflow`-on-an-older-binary incident.
+        // and the known fields still take effect. (`workflow` is now a deprecated,
+        // ignored `[defaults]` key; it must not brick the load either.)
         use crate::fragment::Layer;
         let c = Config::from_layer_strs(vec![(
             Layer::Global,
@@ -1144,7 +1132,6 @@ mod tests {
         )])
         .expect("unknown tool-managed keys must not fail the load");
         assert_eq!(c.default_agent, "codex");
-        assert_eq!(c.default_workflow.as_deref(), Some("loop"));
     }
 
     #[test]
@@ -1423,9 +1410,10 @@ mod tests {
     }
 
     #[test]
-    fn global_default_workflow_applies_everywhere_with_precedence() {
-        // `[defaults].workflow` is the single house workflow — it applies with no
-        // per-loadout binding at all. An override and a binding still win over it.
+    fn workflow_resolves_from_the_loadout_binding_then_override() {
+        // No global default workflow exists: a loadout with no binding resolves to
+        // None; a bound loadout resolves to its binding; an override wins. A
+        // leftover `[defaults].workflow` is ignored.
         let mut base = RawConfig::default();
         let overlay: RawConfig = toml::from_str(
             "[defaults]\nworkflow = \"superpowers\"\n\n\
@@ -1435,46 +1423,21 @@ mod tests {
         .unwrap();
         base.merge(overlay);
         let c = base.finalize(vec![]);
-        assert_eq!(c.default_workflow.as_deref(), Some("superpowers"));
 
-        // No binding, no override → the global default applies.
-        assert_eq!(
-            c.resolve_active_workflow(None, Some("plain")).map(|w| w.id),
-            Some("superpowers".to_string())
-        );
-        // Off any loadout (profile = None) it still applies — same everywhere.
-        assert_eq!(
-            c.resolve_active_workflow(None, None).map(|w| w.id),
-            Some("superpowers".to_string())
-        );
-        // A per-loadout binding wins over the global default.
+        // The deprecated global key no longer applies: an unbound loadout (and the
+        // no-loadout context) get no workflow.
+        assert!(c.resolve_active_workflow(None, Some("plain")).is_none());
+        assert!(c.resolve_active_workflow(None, None).is_none());
+        // A per-loadout binding resolves.
         assert_eq!(
             c.resolve_active_workflow(None, Some("bound")).map(|w| w.id),
             Some("compound".to_string())
         );
-        // A `--workflow` override wins over everything.
+        // A `--workflow` override wins over the binding.
         assert_eq!(
             c.resolve_active_workflow(Some("spec-driven"), Some("bound"))
                 .map(|w| w.id),
             Some("spec-driven".to_string())
-        );
-    }
-
-    #[test]
-    fn repo_layer_cannot_set_the_global_active_workflow() {
-        // `[defaults].workflow` is global-only (it lives in `[defaults]`, already
-        // stripped from repo layers) — a cloned repo can't choose your workflow.
-        let repo = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(repo_dir(repo.path())).unwrap();
-        std::fs::write(
-            repo_config_path(repo.path()),
-            "[defaults]\nworkflow = \"loop\"\n",
-        )
-        .unwrap();
-        let c = Config::load_from(None, repo.path()).unwrap();
-        assert!(
-            c.default_workflow.is_none(),
-            "a repo layer must not set the active workflow"
         );
     }
 }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -29,12 +29,18 @@ pub struct Pack {
     pub recommended_for: &'static [&'static str],
     /// The name of the profile this pack creates.
     pub profile_name: &'static str,
-    /// The created profile's selection targets.
+    /// The created profile's selection targets. Empty ⇒ the no-targets catch-all
+    /// **default** loadout (the everyday pack); a stack pack always targets its
+    /// stack.
     pub targets: &'static [&'static str],
     /// The palette fragment ids this pack duplicates into the library *and*
     /// composes into the profile, in this order. Every id must exist in
     /// [`palette`](crate::fragment::palette) — guarded by a test.
     pub fragments: &'static [&'static str],
+    /// The workflow this pack's loadout binds (a built-in id), or `None`. Shipped
+    /// packs bind the house workflow so a fresh loadout has one — there's no
+    /// global default workflow to fall back on.
+    pub workflow: Option<&'static str>,
 }
 
 impl Pack {
@@ -49,7 +55,7 @@ impl Pack {
                 .iter()
                 .map(|s| FragmentRef::Id(s.to_string()))
                 .collect(),
-            workflow: None,
+            workflow: self.workflow.map(|s| s.to_string()),
             template: None,
             disabled: false,
         }
@@ -204,8 +210,11 @@ pub fn packs() -> Vec<Pack> {
             icon: "shield",
             recommended_for: &["machine"],
             profile_name: "everyday",
-            targets: &["machine"],
+            // No targets ⇒ the catch-all default loadout (applies everywhere
+            // nothing else matches). Studio pins + locks it.
+            targets: &[],
             fragments: EVERYDAY,
+            workflow: Some("superpowers"),
         },
         Pack {
             id: "rust",
@@ -218,6 +227,7 @@ pub fn packs() -> Vec<Pack> {
             profile_name: "rust",
             targets: &["rust"],
             fragments: RUST,
+            workflow: Some("superpowers"),
         },
         Pack {
             id: "node",
@@ -230,6 +240,7 @@ pub fn packs() -> Vec<Pack> {
             profile_name: "node",
             targets: &["node"],
             fragments: NODE,
+            workflow: Some("superpowers"),
         },
         Pack {
             id: "bun",
@@ -242,6 +253,7 @@ pub fn packs() -> Vec<Pack> {
             profile_name: "bun",
             targets: &["bun"],
             fragments: BUN,
+            workflow: Some("superpowers"),
         },
         Pack {
             id: "nextjs",
@@ -254,6 +266,7 @@ pub fn packs() -> Vec<Pack> {
             profile_name: "nextjs",
             targets: &["nextjs"],
             fragments: NEXTJS,
+            workflow: Some("superpowers"),
         },
         Pack {
             id: "go",
@@ -266,6 +279,7 @@ pub fn packs() -> Vec<Pack> {
             profile_name: "go",
             targets: &["go"],
             fragments: GO,
+            workflow: Some("superpowers"),
         },
         Pack {
             id: "python",
@@ -278,6 +292,7 @@ pub fn packs() -> Vec<Pack> {
             profile_name: "python",
             targets: &["python"],
             fragments: PYTHON,
+            workflow: Some("superpowers"),
         },
     ]
 }
@@ -345,15 +360,36 @@ mod tests {
     }
 
     #[test]
+    fn every_pack_binds_the_house_workflow() {
+        // No global default workflow exists anymore, so each pack's loadout must
+        // ship the house workflow itself.
+        for p in packs() {
+            assert_eq!(
+                p.profile().workflow.as_deref(),
+                Some("superpowers"),
+                "pack {} should bind the house workflow",
+                p.id
+            );
+        }
+    }
+
+    #[test]
+    fn only_the_everyday_pack_is_the_no_targets_default() {
+        for p in packs() {
+            let empty = p.profile().targets.is_empty();
+            if p.id == "everyday" {
+                assert!(empty, "the everyday pack is the no-targets default");
+            } else {
+                assert!(!empty, "stack pack {} must target its stack", p.id);
+            }
+        }
+    }
+
+    #[test]
     fn pack_profile_composes_exactly_its_caps() {
         for p in packs() {
             let prof = p.profile();
             assert_eq!(prof.name, p.profile_name);
-            assert!(
-                !prof.targets.is_empty(),
-                "pack {} profile has no targets",
-                p.id
-            );
             let prof_caps: Vec<&str> = prof.fragments.iter().map(|r| r.id()).collect();
             let pack_caps: Vec<&str> = p.fragments.to_vec();
             assert_eq!(

--- a/src/studio/assets/studio.css
+++ b/src/studio/assets/studio.css
@@ -257,6 +257,75 @@ body {
 .switch::after { content: ""; position: absolute; top: 2px; left: 2px; width: 13px; height: 13px; border-radius: 50%; background: #fff; transition: transform .15s; }
 .switch.on::after { transform: translateX(13px); }
 
+/* --- the Create-a-Loadout board ------------------------------------------- */
+.lo-board { display: flex; flex-direction: column; gap: 16px; max-width: 60rem; }
+.detail-sub { color: var(--muted); font-size: 12.5px; margin: 2px 0 6px; }
+
+/* each slot section is its own framed block with a bigger header */
+.slot-section { border: 1px solid var(--border); border-radius: var(--r-lg);
+  background: var(--panel); padding: 15px 18px; display: flex; flex-direction: column; gap: 14px; }
+.slot-head { display: flex; align-items: center; gap: 12px; }
+.slot-head-icon { flex: none; width: 32px; height: 32px; border-radius: var(--r-sm);
+  background: var(--elevated); color: var(--accent); display: inline-flex; align-items: center; justify-content: center; }
+.slot-head-icon .icon { width: 17px; height: 17px; }
+.slot-head-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.slot-head-title { font-size: 15.5px; font-weight: 600; color: var(--fg); display: flex; align-items: center; gap: 9px; line-height: 1.2; }
+.slot-head-hint { font-size: 11.5px; color: var(--faint); }
+.slot-count { font-size: 11px; font-weight: 600; color: var(--muted); background: var(--panel-2);
+  border: 1px solid var(--border); border-radius: 999px; padding: 1px 8px; }
+.slot-head-actions { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+
+.slot-row { display: flex; flex-wrap: wrap; gap: 9px; align-items: center; }
+/* removable target chip: the existing chip + a hover ✕ */
+.target-chip .tx { display: inline-flex; align-items: center; justify-content: center; width: 16px; height: 16px;
+  margin-left: 3px; padding: 0; border: none; background: transparent; color: var(--faint); cursor: pointer; border-radius: 4px; }
+.target-chip .tx:hover { color: var(--danger); background: var(--danger-soft); }
+.target-chip .tx .icon { width: 12px; height: 12px; }
+
+/* compact fragment chip — title only, ✕ on hover */
+.frag-chip { display: inline-flex; align-items: center; gap: 9px; padding: 6px 9px 6px 7px;
+  border: 1px solid var(--border); border-radius: var(--r-sm); background: var(--panel-2); transition: border-color .12s; }
+.frag-chip:hover { border-color: var(--accent-line); }
+.frag-chip .cg { flex: none; width: 26px; height: 26px; border-radius: 6px; background: var(--accent-soft);
+  color: var(--accent); display: inline-flex; align-items: center; justify-content: center; }
+.frag-chip .cg.warm { background: var(--caution-soft); color: var(--caution); }
+.frag-chip .cg .icon { width: 15px; height: 15px; }
+.frag-chip .cn { font-size: 12.5px; font-weight: 500; white-space: nowrap; }
+.frag-chip .cx { flex: none; opacity: 0; width: 18px; height: 18px; padding: 0; border: none;
+  background: transparent; color: var(--faint); cursor: pointer; border-radius: 4px; display: inline-flex; align-items: center; justify-content: center; }
+.frag-chip:hover .cx { opacity: 1; }
+.frag-chip .cx:hover { color: var(--danger); background: var(--danger-soft); }
+.frag-chip .cx .icon { width: 13px; height: 13px; }
+
+/* the single workflow slot */
+.slot { display: flex; align-items: center; gap: 11px; padding: 10px 12px; min-width: 320px;
+  border: 1px solid var(--border); border-radius: var(--r); background: var(--panel-2); transition: border-color .12s; }
+.slot:hover { border-color: var(--accent-line); }
+.slot-single { min-width: 320px; }
+.slot-glyph { flex: none; width: 32px; height: 32px; border-radius: var(--r-sm); display: inline-flex;
+  align-items: center; justify-content: center; background: var(--accent-soft); color: var(--accent); }
+.slot-glyph .icon { width: 17px; height: 17px; }
+.slot-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
+.slot-name { font-size: 13px; font-weight: 600; line-height: 1.2; }
+.slot-sub { font-size: 11px; color: var(--muted); font-family: var(--mono); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 26rem; }
+.slot-x { flex: none; width: 22px; height: 22px; } .slot-x .icon { width: 14px; height: 14px; }
+.slot-empty { border-style: dashed; color: var(--muted); cursor: pointer; background: transparent; }
+.slot-empty:hover { border-color: var(--accent); color: var(--accent); }
+.slot-empty .slot-glyph { background: transparent; color: inherit; border: 1px dashed var(--border-strong); }
+.slot-empty:hover .slot-glyph { border-color: var(--accent); }
+
+/* the default loadout's locked "Applies to" explainer */
+.applies-default { display: flex; align-items: center; gap: 11px; padding: 12px 14px;
+  border: 1px dashed var(--border-strong); border-radius: var(--r); background: var(--panel-2); }
+.applies-default .ad-glyph { flex: none; width: 32px; height: 32px; border-radius: var(--r-sm);
+  background: var(--accent-soft); color: var(--accent); display: inline-flex; align-items: center; justify-content: center; }
+.applies-default .ad-text { font-size: 12.5px; color: var(--muted); line-height: 1.5; }
+.applies-default .ad-text strong { color: var(--fg); font-weight: 600; }
+
+.chip-default { color: var(--accent); background: var(--accent-soft); border: 1px solid var(--accent-line); }
+.pick-group { padding: 8px 4px 2px; }
+.pick-current { margin-left: auto; color: var(--accent); display: inline-flex; }
+
 /* detail (selected profile) */
 .profile-main { min-width: 0; }
 .detail { display: flex; flex-direction: column; gap: 14px; }

--- a/src/studio/assets/studio.css
+++ b/src/studio/assets/studio.css
@@ -282,6 +282,18 @@ body {
 .target-chip .tx:hover { color: var(--danger); background: var(--danger-soft); }
 .target-chip .tx .icon { width: 12px; height: 12px; }
 
+/* paged fragments — a fixed 3-column grid; studio.js shows 3 rows per page and
+   pins the height (`min-height`) so flipping pages never shifts the layout. */
+.frag-paged { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px;
+  grid-auto-rows: 42px; align-content: start; }
+.frag-paged .frag-chip { width: 100%; }
+.frag-paged .frag-chip .cn { overflow: hidden; text-overflow: ellipsis; }
+.frag-pager { display: flex; align-items: center; justify-content: center; gap: 12px; margin-top: 12px; }
+.frag-pager .icon-btn { width: 26px; height: 26px; font-size: 16px; line-height: 1; }
+.pg-dots { display: inline-flex; gap: 6px; align-items: center; }
+.pg-dot { width: 7px; height: 7px; padding: 0; border: none; border-radius: 50%; background: var(--border-strong); cursor: pointer; }
+.pg-dot.on { background: var(--accent); }
+
 /* compact fragment chip — title only, ✕ on hover */
 .frag-chip { display: inline-flex; align-items: center; gap: 9px; padding: 6px 9px 6px 7px;
   border: 1px solid var(--border); border-radius: var(--r-sm); background: var(--panel-2); transition: border-color .12s; }

--- a/src/studio/assets/studio.css
+++ b/src/studio/assets/studio.css
@@ -136,11 +136,8 @@ body {
 .brand-name { font-family: var(--brand); font-size: 22px; font-weight: 400; line-height: 1; letter-spacing: .5px; text-transform: uppercase; }
 .topbar-right { flex: 1 1 0; min-width: 0; display: flex; align-items: center; justify-content: flex-end; gap: 12px; }
 
+/* Two destinations: Loadouts (assemble) and Library (the shared catalog). */
 .tabs { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
-.tab-group { display: flex; align-items: center; gap: 6px; }
-/* Primary pair (Loadouts, Workflows) = the two things you equip; secondary pair
-   (Fragments, Targets) = the parts they're built from. A thin rule separates them. */
-.tab-divider { width: 1px; height: 22px; background: var(--border); margin: 0 8px; flex: none; }
 .tab {
   display: inline-flex; align-items: center; gap: 8px;
   font: 600 15px var(--sans); color: var(--muted);
@@ -150,11 +147,15 @@ body {
 .tab .icon { width: 17px; height: 17px; }
 .tab:hover { background: var(--panel-2); color: var(--fg); }
 .tab.active { background: var(--accent-soft); color: var(--accent); }
-/* The supporting pair reads lighter so the headliners stand out. */
-.tab-group-secondary .tab { font-size: 13.5px; padding: 9px 16px; opacity: .82; }
-.tab-group-secondary .tab .icon { width: 15px; height: 15px; }
-.tab-group-secondary .tab:hover,
-.tab-group-secondary .tab.active { opacity: 1; }
+
+/* The Library's category sub-nav: a pill row at the top of each category body. */
+.lib-cats { display: flex; gap: 7px; margin: 0 0 18px; }
+.lib-cat { display: inline-flex; align-items: center; gap: 7px; padding: 6px 13px;
+  border: 1px solid var(--border); border-radius: 999px; background: var(--panel-2);
+  color: var(--muted); font: 600 12.5px var(--sans); cursor: pointer; }
+.lib-cat:hover { border-color: var(--border-strong); color: var(--fg); }
+.lib-cat.active { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
+.lib-cat .icon { width: 14px; height: 14px; }
 
 .staged-wrap { display: flex; align-items: center; gap: 8px; }
 

--- a/src/studio/assets/studio.css
+++ b/src/studio/assets/studio.css
@@ -280,7 +280,13 @@ body {
 .target-chip .tx { display: inline-flex; align-items: center; justify-content: center; width: 16px; height: 16px;
   margin-left: 3px; padding: 0; border: none; background: transparent; color: var(--faint); cursor: pointer; border-radius: 4px; }
 .target-chip .tx:hover { color: var(--danger); background: var(--danger-soft); }
+.target-chip .tx.disabled { opacity: .3; cursor: not-allowed; }
 .target-chip .tx .icon { width: 12px; height: 12px; }
+
+/* the pinned default loadout in the rail */
+.rail-item.default { border-color: var(--accent-line); background: var(--accent-wash); }
+.rail-item.default.active { border-color: var(--accent); border-left-color: var(--accent); background: var(--elevated); }
+.rail-sep { margin: 3px 2px 5px; height: 1px; background: var(--border); }
 
 /* paged fragments — a fixed 3-column grid; studio.js shows 3 rows per page and
    pins the height (`min-height`) so flipping pages never shifts the layout. */

--- a/src/studio/assets/studio.js
+++ b/src/studio/assets/studio.js
@@ -26,6 +26,7 @@
     el.innerHTML = html;
     process(el);
     enhanceCode(el);
+    enhancePager(el);
   }
 
   function methodOf(el) {
@@ -247,6 +248,70 @@
     });
   }
 
+  // --- fragment pager --------------------------------------------------------
+  // The board's Fragments section renders all chips into a fixed 3-column grid;
+  // here we page them 9 (3 rows) at a time when there's more than one page, and
+  // pin the grid height so flipping pages never shifts the Workflow section
+  // below. Pure show/hide — no innerHTML, so nothing untrusted is injected.
+  function enhancePager(root) {
+    if (!root || !root.querySelectorAll) return;
+    root.querySelectorAll(".frag-paged").forEach(function (grid) {
+      if (grid.dataset.pagerBound) return;
+      grid.dataset.pagerBound = "1";
+      var size = parseInt(grid.getAttribute("data-page-size") || "9", 10);
+      var chips = [].slice.call(grid.children).filter(function (c) {
+        return c.classList.contains("frag-chip");
+      });
+      var pages = Math.ceil(chips.length / size);
+      if (pages <= 1) return; // everything fits — no pager, natural height
+      // 3 rows: 42px auto-rows + 8px gaps. Pin it so short pages don't collapse.
+      grid.style.minHeight = 42 * 3 + 8 * 2 + "px";
+      var cur = 0;
+      var pager = document.createElement("div");
+      pager.className = "frag-pager";
+      var prev = document.createElement("button");
+      prev.type = "button";
+      prev.className = "icon-btn";
+      prev.textContent = "‹";
+      prev.setAttribute("aria-label", "Previous page");
+      var dots = document.createElement("span");
+      dots.className = "pg-dots";
+      var next = document.createElement("button");
+      next.type = "button";
+      next.className = "icon-btn";
+      next.textContent = "›";
+      next.setAttribute("aria-label", "Next page");
+      var dotEls = [];
+      for (var i = 0; i < pages; i++) {
+        (function (idx) {
+          var d = document.createElement("button");
+          d.type = "button";
+          d.className = "pg-dot";
+          d.setAttribute("aria-label", "Page " + (idx + 1));
+          d.addEventListener("click", function () { cur = idx; render(); });
+          dots.appendChild(d);
+          dotEls.push(d);
+        })(i);
+      }
+      prev.addEventListener("click", function () { cur = (cur - 1 + pages) % pages; render(); });
+      next.addEventListener("click", function () { cur = (cur + 1) % pages; render(); });
+      pager.appendChild(prev);
+      pager.appendChild(dots);
+      pager.appendChild(next);
+      grid.parentNode.insertBefore(pager, grid.nextSibling);
+      function render() {
+        for (var i = 0; i < chips.length; i++) {
+          var show = i >= cur * size && i < cur * size + size;
+          chips[i].style.display = show ? "" : "none";
+        }
+        for (var j = 0; j < dotEls.length; j++) {
+          dotEls[j].classList.toggle("on", j === cur);
+        }
+      }
+      render();
+    });
+  }
+
   // --- theme toggle ----------------------------------------------------------
   // Preference (auto/light/dark) lives in localStorage; the inline <head> script
   // already stamped <html data-theme/-pref> to avoid a flash. Here we cycle the
@@ -300,5 +365,6 @@
     wireActiveGroups();
     wireTheme();
     enhanceCode(document.body);
+    enhancePager(document.body);
   });
 })();

--- a/src/studio/edit.rs
+++ b/src/studio/edit.rs
@@ -597,6 +597,10 @@ fn profile_table(p: &LoadoutConfig) -> Result<Table> {
         let caps = toml::Value::try_from(&p.fragments).context("serializing profile fragments")?;
         t["fragments"] = to_edit_item(&caps);
     }
+    // The single per-loadout workflow binding (the board's Workflow slot).
+    if let Some(wf) = &p.workflow {
+        t["workflow"] = value(wf.as_str());
+    }
     if let Some(tmpl) = &p.template {
         t["template"] = value(tmpl.as_str());
     }

--- a/src/studio/edit.rs
+++ b/src/studio/edit.rs
@@ -68,9 +68,6 @@ pub enum StagedOp {
     },
     /// Remove the target with this id from a layer.
     DeleteTarget { layer: Layer, id: String },
-    /// Set (or clear, with `None`) the global active workflow
-    /// (`[defaults].workflow`). Always the public global layer.
-    SetActiveWorkflow { id: Option<String> },
     /// Add a new workflow to a layer (workflows are global-only, so studio
     /// always targets the public global layer).
     CreateWorkflow {
@@ -105,8 +102,6 @@ impl StagedOp {
             | StagedOp::EditWorkflow { layer, .. }
             | StagedOp::DeleteWorkflow { layer, .. } => *layer,
             StagedOp::DuplicatePaletteItem { to_layer, .. } => *to_layer,
-            // The active workflow lives in the public global `[defaults]`.
-            StagedOp::SetActiveWorkflow { .. } => Layer::Global,
         }
     }
 }
@@ -456,19 +451,6 @@ fn apply_op(doc: &mut DocumentMut, op: &StagedOp) -> Result<()> {
         StagedOp::DeleteTarget { id, .. } => {
             remove(aot_mut(doc, "targets"), "id", id);
         }
-        StagedOp::SetActiveWorkflow { id } => {
-            let defaults = table_mut(doc, "defaults");
-            match id {
-                Some(id) => defaults["workflow"] = value(id.as_str()),
-                None => {
-                    defaults.remove("workflow");
-                }
-            }
-            // Don't leave a now-empty `[defaults]` table behind.
-            if defaults.is_empty() {
-                doc.as_table_mut().remove("defaults");
-            }
-        }
         StagedOp::CreateWorkflow { workflow, .. } => {
             aot_mut(doc, "workflows").push(workflow_table(workflow)?);
         }
@@ -488,13 +470,6 @@ fn apply_op(doc: &mut DocumentMut, op: &StagedOp) -> Result<()> {
 }
 
 /// Get (or create) a plain table at `key`.
-fn table_mut<'a>(doc: &'a mut DocumentMut, key: &str) -> &'a mut Table {
-    if doc.get(key).and_then(Item::as_table).is_none() {
-        doc.insert(key, Item::Table(Table::new()));
-    }
-    doc[key].as_table_mut().expect("just inserted a table")
-}
-
 /// Get (or create) an array-of-tables at `key`.
 fn aot_mut<'a>(doc: &'a mut DocumentMut, key: &str) -> &'a mut ArrayOfTables {
     if doc.get(key).and_then(Item::as_array_of_tables).is_none() {
@@ -780,36 +755,6 @@ mod tests {
 
     fn session_global(repo: &Path, gdir: &Path) -> Session {
         Session::open(repo, Some(gdir)).unwrap()
-    }
-
-    #[test]
-    fn set_active_workflow_writes_then_clears_defaults() {
-        let (d, gdir) = repo_with_global("");
-        let mut s = session_global(d.path(), &gdir);
-        // Selecting a workflow writes `[defaults].workflow` into the global layer.
-        s.stage(StagedOp::SetActiveWorkflow {
-            id: Some("superpowers".into()),
-        })
-        .unwrap();
-        let after = s
-            .diff()
-            .into_iter()
-            .find_map(|f| {
-                f.staged_after
-                    .contains("[defaults]")
-                    .then_some(f.staged_after)
-            })
-            .expect("global layer should have changed");
-        assert!(after.contains("workflow = \"superpowers\""));
-        s.validate().unwrap();
-        // Clearing removes the key and the now-empty table (back to no change).
-        s.stage(StagedOp::SetActiveWorkflow { id: None }).unwrap();
-        assert!(
-            s.diff()
-                .iter()
-                .all(|f| !f.staged_after.contains("workflow =")),
-            "clearing removes the active-workflow key"
-        );
     }
 
     #[test]

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -138,9 +138,10 @@ pub fn route(state: &Arc<Mutex<StudioState>>, req: &Req) -> Resp {
     match (req.method.as_str(), req.path.as_str()) {
         ("GET", "/") => handle_shell(state),
         ("GET", "/tab/profiles") => handle_tab(state, "profiles"),
-        ("GET", "/tab/fragments") => handle_tab(state, "fragments"),
-        ("GET", "/tab/targets") => handle_tab(state, "targets"),
-        ("GET", "/tab/workflows") => handle_tab(state, "workflows"),
+        ("GET", "/tab/library") => handle_library(state, "fragments"),
+        ("GET", "/tab/fragments") => handle_library(state, "fragments"),
+        ("GET", "/tab/targets") => handle_library(state, "targets"),
+        ("GET", "/tab/workflows") => handle_library(state, "workflows"),
         ("GET", "/staged") => handle_staged(state),
         ("GET", "/close") => Resp::html(String::new()),
         ("GET", "/diff") => handle_diff(state),
@@ -169,6 +170,9 @@ pub fn route(state: &Arc<Mutex<StudioState>>, req: &Req) -> Resp {
             Some((body, ct)) => Resp::asset(body, ct),
             None => Resp::not_found(),
         },
+        ("GET", p) if p.starts_with("/library/") => {
+            handle_library(state, p.strip_prefix("/library/").unwrap_or("fragments"))
+        }
         (_, p) if p.starts_with("/fragments/") => handle_fragment_param(state, req),
         (_, p) if p.starts_with("/targets/") => handle_target_param(state, req),
         (_, p) if p.starts_with("/workflows/") => handle_workflow_param(state, req),
@@ -243,25 +247,29 @@ fn handle_shell(state: &Arc<Mutex<StudioState>>) -> Resp {
     }
 }
 
+/// The Loadouts destination (the only one routed through here now). Library
+/// categories go through [`handle_library`].
 fn handle_tab(state: &Arc<Mutex<StudioState>>, tab: &str) -> Resp {
     state.lock().unwrap().active_tab = tab.to_string();
-    if tab == "profiles" {
-        return profiles_tab_resp(state, None, None, false);
-    }
-    if tab == "targets" {
-        let snap = state.lock().unwrap().snapshot();
-        return Resp::html(views::targets_tab_fragment(&state::targets_view(&snap)));
-    }
-    if tab == "workflows" {
-        let snap = state.lock().unwrap().snapshot();
-        return Resp::html(views::workflows_tab_fragment(&state::workflows_view(
-            &snap, None,
-        )));
-    }
+    profiles_tab_resp(state, None, None, false)
+}
+
+/// Render a Library category body (`fragments` | `targets` | `workflows`). Each
+/// body carries its own pill sub-nav (`library_nav`), so every render — full
+/// navigation or post-mutation refresh — keeps the Library chrome. `active_tab`
+/// stays `"library"` so the top-nav Library button remains lit while browsing.
+fn handle_library(state: &Arc<Mutex<StudioState>>, cat: &str) -> Resp {
+    state.lock().unwrap().active_tab = "library".to_string();
     let snap = state.lock().unwrap().snapshot();
-    match state::library_view(&snap) {
-        Ok(lib) => Resp::html(views::fragments_tab_fragment(&lib, None)),
-        Err(e) => Resp::html(views::error_fragment(&e.to_string())),
+    match cat {
+        "targets" => Resp::html(views::targets_tab_fragment(&state::targets_view(&snap))),
+        "workflows" => {
+            Resp::html(views::workflows_tab_fragment(&state::workflows_view(&snap, None)))
+        }
+        _ => match state::library_view(&snap) {
+            Ok(lib) => Resp::html(views::fragments_tab_fragment(&lib, None)),
+            Err(e) => Resp::html(views::error_fragment(&e.to_string())),
+        },
     }
 }
 
@@ -1987,9 +1995,10 @@ mod tests {
         assert_eq!(r.status, 200);
         let body = String::from_utf8(r.body).unwrap();
         assert!(body.contains("Loadout studio"));
-        // The shell renders the Profiles tab (dashboard) by default.
+        // The shell renders the Loadouts tab by default; the top nav is the two
+        // destinations Loadouts | Library.
         assert!(body.contains("Loadouts"));
-        assert!(body.contains("Fragments"));
+        assert!(body.contains("Library"));
     }
 
     #[test]

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -325,6 +325,25 @@ fn handle_profile_target_add(state: &Arc<Mutex<StudioState>>, name: &str, id: &s
 }
 
 fn handle_profile_target_remove(state: &Arc<Mutex<StudioState>>, name: &str, id: &str) -> Resp {
+    // Guard the single-default invariant (the UI also disables the ✕): dropping
+    // the last target would make a second no-targets default.
+    {
+        let snap = state.lock().unwrap().snapshot();
+        if let Ok(cfg) = state::staged_config(&snap) {
+            if let Some(p) = cfg.profiles.iter().find(|p| p.name == name) {
+                let last = p.targets.len() == 1 && p.targets.iter().any(|t| t == id);
+                let other_default = cfg
+                    .profiles
+                    .iter()
+                    .any(|q| q.name != name && !q.disabled && q.targets.is_empty());
+                if last && other_default {
+                    return Resp::html(views::error_fragment(
+                        "a loadout needs at least one target — a default loadout already exists",
+                    ));
+                }
+            }
+        }
+    }
     let r = {
         let mut s = state.lock().unwrap();
         state::edit_profile(&mut s.session, name, |p| p.targets.retain(|t| t != id))
@@ -1382,6 +1401,25 @@ fn handle_profile_save(state: &Arc<Mutex<StudioState>>, req: &Req) -> Resp {
             &pairs,
             &format!("a loadout named “{name}” already exists — choose another name"),
         );
+    }
+    // Single-default invariant: at most one no-targets default loadout. A new (or
+    // renamed) loadout with no targets is refused when another default exists.
+    if profile.targets.is_empty() {
+        let snap = state.lock().unwrap().snapshot();
+        let other_default = state::staged_config(&snap)
+            .map(|cfg| {
+                cfg.profiles
+                    .iter()
+                    .any(|p| p.targets.is_empty() && !p.disabled && Some(p.name.as_str()) != original)
+            })
+            .unwrap_or(false);
+        if other_default {
+            return profile_editor_with_error(
+                state,
+                &pairs,
+                "a default loadout (no targets) already exists — give this one at least one target",
+            );
+        }
     }
     let key = original.unwrap_or(name.as_str()).to_string();
     // Profiles are global-only — always authored into the global config.
@@ -3356,6 +3394,69 @@ mod tests {
             .status,
             403
         );
+    }
+
+    #[test]
+    fn default_loadout_is_pinned_and_locked() {
+        // `base` has no targets → the catch-all default; `rust` is targeted.
+        let cfg = "[[fragments]]\nid = \"rc\"\nguidance = \"x\"\n\
+             \n[[loadouts]]\nname = \"base\"\nfragments = [\"rc\"]\n\
+             \n[[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\n";
+        let d = rust_repo();
+        let st = state_for(d.path(), Some(cfg));
+
+        // The default's board: locked "Applies to", a Default badge, and no
+        // rename/delete (it's always-present).
+        let base = body_of(route(
+            &st,
+            &req("GET", "/profiles/base/select", "", &[HOST, COOKIE], ""),
+        ));
+        assert!(base.contains("Applies everywhere"));
+        assert!(base.contains("chip-default"));
+        assert!(!base.contains("/profiles/base/edit"), "default isn't renamable");
+        assert!(!base.contains("hx-delete=\"/profiles/base\""), "default isn't deletable");
+
+        // The rail pins the default (its own class) above a separator.
+        let tab = body_of(route(
+            &st,
+            &req("GET", "/tab/profiles", "", &[HOST, COOKIE], ""),
+        ));
+        assert!(tab.contains("rail-item default"));
+        assert!(tab.contains("rail-sep"));
+
+        // `rust`'s lone target can't be removed while a default exists: the ✕ is
+        // disabled in the UI, and a direct DELETE is refused.
+        let rustb = body_of(route(
+            &st,
+            &req("GET", "/profiles/rust/select", "", &[HOST, COOKIE], ""),
+        ));
+        assert!(rustb.contains("tx disabled"));
+        let blocked = body_of(route(
+            &st,
+            &req("DELETE", "/profiles/rust/targets/rust", "", &[HOST, COOKIE, ORIGIN], ""),
+        ));
+        assert!(blocked.contains("at least one target"));
+    }
+
+    #[test]
+    fn last_target_clears_to_create_the_default_when_none_exists() {
+        // No default yet → clearing rust's only target converts it to the default.
+        let cfg = "[[fragments]]\nid = \"rc\"\nguidance = \"x\"\n\
+             \n[[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\n";
+        let d = rust_repo();
+        let st = state_for(d.path(), Some(cfg));
+        // The lone target's ✕ is enabled (no default exists to conflict).
+        let before = body_of(route(
+            &st,
+            &req("GET", "/profiles/rust/select", "", &[HOST, COOKIE], ""),
+        ));
+        assert!(!before.contains("tx disabled"));
+        // Remove it → rust becomes the no-targets default (locked Applies-to).
+        let after = body_of(route(
+            &st,
+            &req("DELETE", "/profiles/rust/targets/rust", "", &[HOST, COOKIE, ORIGIN], ""),
+        ));
+        assert!(after.contains("Applies everywhere"));
     }
 
     #[test]

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -271,7 +271,12 @@ fn staged_profile<T>(
     let snap = state.lock().unwrap().snapshot();
     state::staged_config(&snap)
         .ok()
-        .and_then(|c| c.profiles.into_iter().find(|p| p.name == name).map(|p| f(&p)))
+        .and_then(|c| {
+            c.profiles
+                .into_iter()
+                .find(|p| p.name == name)
+                .map(|p| f(&p))
+        })
         .unwrap_or(default)
 }
 
@@ -367,7 +372,9 @@ fn handle_profile_fragment_add(state: &Arc<Mutex<StudioState>>, name: &str, id: 
 fn handle_profile_fragment_remove(state: &Arc<Mutex<StudioState>>, name: &str, id: &str) -> Resp {
     let r = {
         let mut s = state.lock().unwrap();
-        state::edit_profile(&mut s.session, name, |p| p.fragments.retain(|fr| fr.id() != id))
+        state::edit_profile(&mut s.session, name, |p| {
+            p.fragments.retain(|fr| fr.id() != id)
+        })
     };
     finish_slot_edit(state, name, r)
 }
@@ -389,11 +396,7 @@ fn handle_profile_workflow_clear(state: &Arc<Mutex<StudioState>>, name: &str) ->
 }
 
 /// Re-render the board on a successful slot edit, or surface the staging error.
-fn finish_slot_edit(
-    state: &Arc<Mutex<StudioState>>,
-    name: &str,
-    r: crate::Result<()>,
-) -> Resp {
+fn finish_slot_edit(state: &Arc<Mutex<StudioState>>, name: &str, r: crate::Result<()>) -> Resp {
     match r {
         Ok(()) => board_resp(state, name),
         Err(e) => Resp::html(views::error_fragment(&e.to_string())),
@@ -443,9 +446,9 @@ fn handle_library(state: &Arc<Mutex<StudioState>>, cat: &str) -> Resp {
     let snap = state.lock().unwrap().snapshot();
     match cat {
         "targets" => Resp::html(views::targets_tab_fragment(&state::targets_view(&snap))),
-        "workflows" => {
-            Resp::html(views::workflows_tab_fragment(&state::workflows_view(&snap, None)))
-        }
+        "workflows" => Resp::html(views::workflows_tab_fragment(&state::workflows_view(
+            &snap, None,
+        ))),
         _ => match state::library_view(&snap) {
             Ok(lib) => Resp::html(views::fragments_tab_fragment(&lib, None)),
             Err(e) => Resp::html(views::error_fragment(&e.to_string())),
@@ -1384,9 +1387,9 @@ fn handle_profile_save(state: &Arc<Mutex<StudioState>>, req: &Req) -> Resp {
         let snap = state.lock().unwrap().snapshot();
         let other_default = state::staged_config(&snap)
             .map(|cfg| {
-                cfg.profiles
-                    .iter()
-                    .any(|p| p.targets.is_empty() && !p.disabled && Some(p.name.as_str()) != original)
+                cfg.profiles.iter().any(|p| {
+                    p.targets.is_empty() && !p.disabled && Some(p.name.as_str()) != original
+                })
             })
             .unwrap_or(false);
         if other_default {
@@ -2343,7 +2346,10 @@ mod tests {
         );
         // The bound workflow shows an "equipped on a loadout" marker — there's no
         // global "active workflow" concept anymore.
-        assert!(body.contains("equipped on"), "binding marker for spec-driven");
+        assert!(
+            body.contains("equipped on"),
+            "binding marker for spec-driven"
+        );
         assert!(
             body.contains(r#"<span class="cmd-name">explore</span>"#),
             "the canonical `explore` slot command is shown"
@@ -2359,7 +2365,10 @@ mod tests {
             .body,
         )
         .unwrap();
-        assert!(!sp.contains("Use this workflow"), "no global activate action");
+        assert!(
+            !sp.contains("Use this workflow"),
+            "no global activate action"
+        );
         for (cmd, name) in [
             ("explore", "Explore"),
             ("brainstorm", "Brainstorm"),
@@ -2377,8 +2386,14 @@ mod tests {
                 "slot shows its step name `{name}`"
             );
         }
-        assert!(sp.contains("skipped"), "an unfilled canonical slot is skipped");
-        assert!(sp.contains("wf-value-mark"), "workflow icon marks the value");
+        assert!(
+            sp.contains("skipped"),
+            "an unfilled canonical slot is skipped"
+        );
+        assert!(
+            sp.contains("wf-value-mark"),
+            "workflow icon marks the value"
+        );
         assert!(
             sp.contains("Refine the rough idea"),
             "superpowers' take on the brainstorm slot is shown when focused"
@@ -2403,7 +2418,13 @@ mod tests {
         assert_eq!(
             route(
                 &st,
-                &req("POST", "/workflows/superpowers/activate", "", &[HOST, COOKIE, ORIGIN], "")
+                &req(
+                    "POST",
+                    "/workflows/superpowers/activate",
+                    "",
+                    &[HOST, COOKIE, ORIGIN],
+                    ""
+                )
             )
             .status,
             404
@@ -3300,13 +3321,23 @@ mod tests {
             &req("GET", "/profiles/rust/select", "", &[HOST, COOKIE], ""),
         ));
         assert!(board.contains("lo-board"));
-        assert!(board.contains("Applies to") && board.contains("Fragments") && board.contains("Workflow"));
+        assert!(
+            board.contains("Applies to")
+                && board.contains("Fragments")
+                && board.contains("Workflow")
+        );
         assert!(board.contains("/profiles/rust/fragments/rc")); // rc chip's remove
 
         // Equip the second fragment → it stages and the readout counts both.
         let after = body_of(route(
             &st,
-            &req("POST", "/profiles/rust/fragments/tc", "", &[HOST, COOKIE, ORIGIN], ""),
+            &req(
+                "POST",
+                "/profiles/rust/fragments/tc",
+                "",
+                &[HOST, COOKIE, ORIGIN],
+                "",
+            ),
         ));
         assert!(after.contains("/profiles/rust/fragments/tc"));
         assert!(after.contains("2 fragments"));
@@ -3314,25 +3345,52 @@ mod tests {
         // Bind a workflow (a plain string ref; resolution is lazy) → slot fills.
         let bound = body_of(route(
             &st,
-            &req("POST", "/profiles/rust/workflow/superpowers", "", &[HOST, COOKIE, ORIGIN], ""),
+            &req(
+                "POST",
+                "/profiles/rust/workflow/superpowers",
+                "",
+                &[HOST, COOKIE, ORIGIN],
+                "",
+            ),
         ));
-        assert!(bound.contains("superpowers"), "workflow slot fills; got:\n{bound}");
+        assert!(
+            bound.contains("superpowers"),
+            "workflow slot fills; got:\n{bound}"
+        );
         // Clear it → the empty "Equip a workflow" slot returns.
         let cleared = body_of(route(
             &st,
-            &req("DELETE", "/profiles/rust/workflow", "", &[HOST, COOKIE, ORIGIN], ""),
+            &req(
+                "DELETE",
+                "/profiles/rust/workflow",
+                "",
+                &[HOST, COOKIE, ORIGIN],
+                "",
+            ),
         ));
         assert!(cleared.contains("Equip a workflow"));
 
         // Add then remove a target.
         let added = body_of(route(
             &st,
-            &req("POST", "/profiles/rust/targets/go", "", &[HOST, COOKIE, ORIGIN], ""),
+            &req(
+                "POST",
+                "/profiles/rust/targets/go",
+                "",
+                &[HOST, COOKIE, ORIGIN],
+                "",
+            ),
         ));
         assert!(added.contains("/profiles/rust/targets/go"));
         let removed = body_of(route(
             &st,
-            &req("DELETE", "/profiles/rust/targets/go", "", &[HOST, COOKIE, ORIGIN], ""),
+            &req(
+                "DELETE",
+                "/profiles/rust/targets/go",
+                "",
+                &[HOST, COOKIE, ORIGIN],
+                "",
+            ),
         ));
         assert!(!removed.contains("/profiles/rust/targets/go"));
 
@@ -3340,7 +3398,13 @@ mod tests {
         assert_eq!(
             route(
                 &st,
-                &req("POST", "/profiles/rust/fragments/tc", "", &[HOST, COOKIE], "")
+                &req(
+                    "POST",
+                    "/profiles/rust/fragments/tc",
+                    "",
+                    &[HOST, COOKIE],
+                    ""
+                )
             )
             .status,
             403
@@ -3364,8 +3428,14 @@ mod tests {
         ));
         assert!(base.contains("Applies everywhere"));
         assert!(base.contains("chip-default"));
-        assert!(!base.contains("/profiles/base/edit"), "default isn't renamable");
-        assert!(!base.contains("hx-delete=\"/profiles/base\""), "default isn't deletable");
+        assert!(
+            !base.contains("/profiles/base/edit"),
+            "default isn't renamable"
+        );
+        assert!(
+            !base.contains("hx-delete=\"/profiles/base\""),
+            "default isn't deletable"
+        );
 
         // The rail pins the default (its own class) above a separator.
         let tab = body_of(route(
@@ -3384,7 +3454,13 @@ mod tests {
         assert!(rustb.contains("tx disabled"));
         let blocked = body_of(route(
             &st,
-            &req("DELETE", "/profiles/rust/targets/rust", "", &[HOST, COOKIE, ORIGIN], ""),
+            &req(
+                "DELETE",
+                "/profiles/rust/targets/rust",
+                "",
+                &[HOST, COOKIE, ORIGIN],
+                "",
+            ),
         ));
         assert!(blocked.contains("at least one target"));
     }
@@ -3405,7 +3481,13 @@ mod tests {
         // Remove it → rust becomes the no-targets default (locked Applies-to).
         let after = body_of(route(
             &st,
-            &req("DELETE", "/profiles/rust/targets/rust", "", &[HOST, COOKIE, ORIGIN], ""),
+            &req(
+                "DELETE",
+                "/profiles/rust/targets/rust",
+                "",
+                &[HOST, COOKIE, ORIGIN],
+                "",
+            ),
         ));
         assert!(after.contains("Applies everywhere"));
     }

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -210,13 +210,174 @@ fn handle_fragment_param(state: &Arc<Mutex<StudioState>>, req: &Req) -> Resp {
 
 fn handle_profile_param(state: &Arc<Mutex<StudioState>>, req: &Req) -> Resp {
     let (name, action) = id_and_action(&req.path, "/profiles/");
-    match (req.method.as_str(), action) {
-        ("GET", "edit") => handle_profile_edit(state, &name),
-        ("GET", "select") => handle_profile_select(state, &name),
-        ("POST", "disable") => handle_profile_disable(state, &name),
-        ("POST", "run") => handle_profile_run(state, &name),
-        ("DELETE", "") => handle_profile_delete(state, &name),
+    let (head, rest) = action.split_once('/').unwrap_or((action, ""));
+    match (req.method.as_str(), head, rest) {
+        ("GET", "edit", "") => handle_profile_edit(state, &name),
+        // `select` renders the Create-a-Loadout board; `preview` swaps in the
+        // composed-document view (the rendered guidance).
+        ("GET", "select", "") => board_resp(state, &name),
+        ("GET", "preview", "") => handle_profile_select(state, &name),
+        ("POST", "disable", "") => handle_profile_disable(state, &name),
+        ("POST", "run", "") => handle_profile_run(state, &name),
+        ("DELETE", "", "") => handle_profile_delete(state, &name),
+        // Applies-to (targets) slot.
+        ("GET", "targets", "new") => handle_target_picker(state, &name),
+        ("POST", "targets", id) if !id.is_empty() => {
+            handle_profile_target_add(state, &name, &state::percent_decode(id))
+        }
+        ("DELETE", "targets", id) if !id.is_empty() => {
+            handle_profile_target_remove(state, &name, &state::percent_decode(id))
+        }
+        // Fragments slots.
+        ("GET", "fragments", "new") => handle_fragment_picker(state, &name),
+        ("POST", "fragments", id) if !id.is_empty() => {
+            handle_profile_fragment_add(state, &name, &state::percent_decode(id))
+        }
+        ("DELETE", "fragments", id) if !id.is_empty() => {
+            handle_profile_fragment_remove(state, &name, &state::percent_decode(id))
+        }
+        // Workflow slot (one per loadout).
+        ("GET", "workflow", "new") => handle_workflow_picker(state, &name),
+        ("POST", "workflow", id) if !id.is_empty() => {
+            handle_profile_workflow_set(state, &name, &state::percent_decode(id))
+        }
+        ("DELETE", "workflow", "") => handle_profile_workflow_clear(state, &name),
         _ => Resp::not_found(),
+    }
+}
+
+/// Re-render the board into `#profile-main` after a slot edit, closing any open
+/// picker modal and refreshing the staged-changes indicator.
+fn board_resp(state: &Arc<Mutex<StudioState>>, name: &str) -> Resp {
+    let snap = state.lock().unwrap().snapshot();
+    match state::board_view(&snap, name) {
+        Ok(b) => {
+            let mut html = views::loadout_board_fragment(&b);
+            html.push_str(&views::modal_close_loader());
+            html.push_str(&views::staged_indicator_loader());
+            Resp::html(html)
+        }
+        Err(e) => Resp::html(views::error_fragment(&e.to_string())),
+    }
+}
+
+/// Current targets / fragment ids / workflow of the staged loadout `name`.
+fn staged_profile<T>(
+    state: &Arc<Mutex<StudioState>>,
+    name: &str,
+    f: impl FnOnce(&crate::profile::LoadoutConfig) -> T,
+    default: T,
+) -> T {
+    let snap = state.lock().unwrap().snapshot();
+    state::staged_config(&snap)
+        .ok()
+        .and_then(|c| c.profiles.into_iter().find(|p| p.name == name).map(|p| f(&p)))
+        .unwrap_or(default)
+}
+
+fn handle_target_picker(state: &Arc<Mutex<StudioState>>, name: &str) -> Resp {
+    let snap = state.lock().unwrap().snapshot();
+    let lib = match state::library_view(&snap) {
+        Ok(l) => l,
+        Err(e) => return Resp::html(views::error_fragment(&e.to_string())),
+    };
+    let current = staged_profile(state, name, |p| p.targets.clone(), Vec::new());
+    let options: Vec<_> = lib
+        .targets
+        .into_iter()
+        .filter(|t| !current.iter().any(|c| c == &t.id))
+        .collect();
+    Resp::html(views::target_picker(name, &options))
+}
+
+fn handle_fragment_picker(state: &Arc<Mutex<StudioState>>, name: &str) -> Resp {
+    let snap = state.lock().unwrap().snapshot();
+    let lib = match state::library_view(&snap) {
+        Ok(l) => l,
+        Err(e) => return Resp::html(views::error_fragment(&e.to_string())),
+    };
+    let equipped = staged_profile(
+        state,
+        name,
+        |p| p.fragments.iter().map(|fr| fr.id().to_string()).collect(),
+        Vec::new(),
+    );
+    Resp::html(views::fragment_picker(name, &lib, &equipped))
+}
+
+fn handle_workflow_picker(state: &Arc<Mutex<StudioState>>, name: &str) -> Resp {
+    let snap = state.lock().unwrap().snapshot();
+    let options = state::board_workflow_options(&snap);
+    let current = staged_profile(state, name, |p| p.workflow.clone(), None);
+    Resp::html(views::workflow_picker(name, &options, current.as_deref()))
+}
+
+fn handle_profile_target_add(state: &Arc<Mutex<StudioState>>, name: &str, id: &str) -> Resp {
+    let r = {
+        let mut s = state.lock().unwrap();
+        state::edit_profile(&mut s.session, name, |p| {
+            if !p.targets.iter().any(|t| t == id) {
+                p.targets.push(id.to_string());
+            }
+        })
+    };
+    finish_slot_edit(state, name, r)
+}
+
+fn handle_profile_target_remove(state: &Arc<Mutex<StudioState>>, name: &str, id: &str) -> Resp {
+    let r = {
+        let mut s = state.lock().unwrap();
+        state::edit_profile(&mut s.session, name, |p| p.targets.retain(|t| t != id))
+    };
+    finish_slot_edit(state, name, r)
+}
+
+fn handle_profile_fragment_add(state: &Arc<Mutex<StudioState>>, name: &str, id: &str) -> Resp {
+    let r = {
+        let mut s = state.lock().unwrap();
+        state::edit_profile(&mut s.session, name, |p| {
+            if !p.fragments.iter().any(|fr| fr.id() == id) {
+                p.fragments
+                    .push(crate::profile::FragmentRef::Id(id.to_string()));
+            }
+        })
+    };
+    finish_slot_edit(state, name, r)
+}
+
+fn handle_profile_fragment_remove(state: &Arc<Mutex<StudioState>>, name: &str, id: &str) -> Resp {
+    let r = {
+        let mut s = state.lock().unwrap();
+        state::edit_profile(&mut s.session, name, |p| p.fragments.retain(|fr| fr.id() != id))
+    };
+    finish_slot_edit(state, name, r)
+}
+
+fn handle_profile_workflow_set(state: &Arc<Mutex<StudioState>>, name: &str, id: &str) -> Resp {
+    let r = {
+        let mut s = state.lock().unwrap();
+        state::edit_profile(&mut s.session, name, |p| p.workflow = Some(id.to_string()))
+    };
+    finish_slot_edit(state, name, r)
+}
+
+fn handle_profile_workflow_clear(state: &Arc<Mutex<StudioState>>, name: &str) -> Resp {
+    let r = {
+        let mut s = state.lock().unwrap();
+        state::edit_profile(&mut s.session, name, |p| p.workflow = None)
+    };
+    finish_slot_edit(state, name, r)
+}
+
+/// Re-render the board on a successful slot edit, or surface the staging error.
+fn finish_slot_edit(
+    state: &Arc<Mutex<StudioState>>,
+    name: &str,
+    r: crate::Result<()>,
+) -> Resp {
+    match r {
+        Ok(()) => board_resp(state, name),
+        Err(e) => Resp::html(views::error_fragment(&e.to_string())),
     }
 }
 
@@ -2579,11 +2740,12 @@ mod tests {
         let d = rust_repo();
         let st = state_for(d.path(), Some(cfg));
 
-        // Selecting a profile renders the detail: one expandable card per
-        // composed fragment, each carrying its rendered guidance.
+        // Preview renders the composed document: one expandable card per
+        // composed fragment, each carrying its rendered guidance. (Plain select
+        // renders the board; Preview is the composed-doc view.)
         let body = body_of(route(
             &st,
-            &req("GET", "/profiles/rust/select", "", &[HOST, COOKIE], ""),
+            &req("GET", "/profiles/rust/preview", "", &[HOST, COOKIE], ""),
         ));
         assert!(body.contains("<h1>rust</h1>")); // the detail names the profile
         assert!(body.contains("fragment-detail")); // expandable cards
@@ -2777,7 +2939,7 @@ mod tests {
         let st = state_for(d.path(), Some(cfg));
         let body = body_of(route(
             &st,
-            &req("GET", "/profiles/rust/select", "", &[HOST, COOKIE], ""),
+            &req("GET", "/profiles/rust/preview", "", &[HOST, COOKIE], ""),
         ));
         assert!(body.contains("fragment-detail"), "renders the card");
         assert!(
@@ -3123,12 +3285,77 @@ mod tests {
         assert!(body.contains("Select a loadout to see what it composes."));
         assert!(!body.contains("fragment-detail"));
         assert!(!body.contains("<h1>rust</h1>"));
-        // Explicitly selecting one still renders its detail.
+        // Explicitly selecting one renders its board (Applies to / Fragments /
+        // Workflow slots), not the composed-document cards.
         let detail = body_of(route(
             &st,
             &req("GET", "/profiles/rust/select", "", &[HOST, COOKIE], ""),
         ));
-        assert!(detail.contains("<h1>rust</h1>") && detail.contains("fragment-detail"));
+        assert!(detail.contains("<h1>rust</h1>") && detail.contains("lo-board"));
+        assert!(detail.contains("Applies to") && detail.contains("Workflow"));
+        assert!(!detail.contains("fragment-detail"));
+    }
+
+    #[test]
+    fn board_inline_edits_stage_changes() {
+        let cfg = "[[fragments]]\nid = \"rc\"\nguidance = \"x\"\n\
+             \n[[fragments]]\nid = \"tc\"\nguidance = \"y\"\n\
+             \n[[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\n";
+        let d = rust_repo();
+        let st = state_for(d.path(), Some(cfg));
+
+        // Select renders the board: the three slot sections + the one equipped
+        // fragment (with its remove control).
+        let board = body_of(route(
+            &st,
+            &req("GET", "/profiles/rust/select", "", &[HOST, COOKIE], ""),
+        ));
+        assert!(board.contains("lo-board"));
+        assert!(board.contains("Applies to") && board.contains("Fragments") && board.contains("Workflow"));
+        assert!(board.contains("/profiles/rust/fragments/rc")); // rc chip's remove
+
+        // Equip the second fragment → it stages and the readout counts both.
+        let after = body_of(route(
+            &st,
+            &req("POST", "/profiles/rust/fragments/tc", "", &[HOST, COOKIE, ORIGIN], ""),
+        ));
+        assert!(after.contains("/profiles/rust/fragments/tc"));
+        assert!(after.contains("2 fragments"));
+
+        // Bind a workflow (a plain string ref; resolution is lazy) → slot fills.
+        let bound = body_of(route(
+            &st,
+            &req("POST", "/profiles/rust/workflow/superpowers", "", &[HOST, COOKIE, ORIGIN], ""),
+        ));
+        assert!(bound.contains("superpowers"), "workflow slot fills; got:\n{bound}");
+        // Clear it → the empty "Equip a workflow" slot returns.
+        let cleared = body_of(route(
+            &st,
+            &req("DELETE", "/profiles/rust/workflow", "", &[HOST, COOKIE, ORIGIN], ""),
+        ));
+        assert!(cleared.contains("Equip a workflow"));
+
+        // Add then remove a target.
+        let added = body_of(route(
+            &st,
+            &req("POST", "/profiles/rust/targets/go", "", &[HOST, COOKIE, ORIGIN], ""),
+        ));
+        assert!(added.contains("/profiles/rust/targets/go"));
+        let removed = body_of(route(
+            &st,
+            &req("DELETE", "/profiles/rust/targets/go", "", &[HOST, COOKIE, ORIGIN], ""),
+        ));
+        assert!(!removed.contains("/profiles/rust/targets/go"));
+
+        // State-changing slot edits are CSRF-guarded (no Origin → rejected).
+        assert_eq!(
+            route(
+                &st,
+                &req("POST", "/profiles/rust/fragments/tc", "", &[HOST, COOKIE], "")
+            )
+            .status,
+            403
+        );
     }
 
     #[test]
@@ -3230,7 +3457,7 @@ mod tests {
         let st = state_for(d.path(), Some(cfg));
         let body = body_of(route(
             &st,
-            &req("GET", "/profiles/rust/select", "", &[HOST, COOKIE], ""),
+            &req("GET", "/profiles/rust/preview", "", &[HOST, COOKIE], ""),
         ));
         assert!(body.contains("fragment-detail")); // the card is present
         assert!(body.contains("fragment-run-prompt") && body.contains("Run script")); // centered prompt
@@ -3248,7 +3475,7 @@ mod tests {
         // Read-only preview: a run prompt, no real output yet.
         let before = body_of(route(
             &st,
-            &req("GET", "/profiles/m/select", "", &[HOST, COOKIE], ""),
+            &req("GET", "/profiles/m/preview", "", &[HOST, COOKIE], ""),
         ));
         assert!(before.contains("fragment-run-prompt") && !before.contains("fragment-output"));
 

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -844,8 +844,6 @@ fn handle_workflow_param(state: &Arc<Mutex<StudioState>>, req: &Req) -> Resp {
                 Some(&id),
             )))
         }
-        // Make it the global active workflow (staged like any other edit).
-        ("POST", "activate") => handle_workflow_activate(state, &id),
         // Edit an owned workflow in place.
         ("GET", "edit") => handle_workflow_open(state, &id, false),
         // Duplicate a workflow into a new, editable copy (original untouched).
@@ -954,28 +952,6 @@ fn handle_workflow_delete(state: &Arc<Mutex<StudioState>>, id: &str) -> Resp {
         &state::workflows_view(&snap, None),
         &format!("staged removal of workflow “{id}”"),
     ))
-}
-
-/// Stage setting `[defaults].workflow` to `id`, then re-render the tab focused on
-/// it with a flash + a staged-changes refresh.
-fn handle_workflow_activate(state: &Arc<Mutex<StudioState>>, id: &str) -> Resp {
-    let res = state
-        .lock()
-        .unwrap()
-        .session
-        .stage(StagedOp::SetActiveWorkflow {
-            id: Some(id.to_string()),
-        });
-    match res {
-        Ok(()) => {
-            let snap = state.lock().unwrap().snapshot();
-            Resp::html(views::workflows_result(
-                &state::workflows_view(&snap, Some(id)),
-                &format!("“{id}” is now your active workflow — Apply to save"),
-            ))
-        }
-        Err(e) => Resp::html(views::error_fragment(&e.to_string())),
-    }
 }
 
 /// Re-render the Targets tab (with a flash) after a staged change.
@@ -2341,43 +2317,40 @@ mod tests {
     }
 
     #[test]
-    fn workflows_tab_gallery_focus_and_activate() {
+    fn workflows_gallery_focus_and_binding() {
         let d = rust_repo();
-        // `lean` is the global active workflow; a loadout also pins spec-driven.
+        // A loadout pins spec-driven — the per-loadout Workflow slot is the only
+        // way to "use" a workflow now (no global active workflow).
         let st = state_for(
             d.path(),
             Some(
-                "[defaults]\nworkflow = \"compound\"\n\n\
-                 [[fragments]]\nid = \"rc\"\nguidance = \"Rust.\"\n\n\
+                "[[fragments]]\nid = \"rc\"\nguidance = \"Rust.\"\n\n\
                  [[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\nworkflow = \"spec-driven\"\n",
             ),
         );
 
-        // The tab: a gallery of named cards; the active one (compound) is focused.
+        // The Library's Workflows category: a gallery of named cards.
         let r = route(&st, &req("GET", "/tab/workflows", "", &[HOST, COOKIE], ""));
         assert_eq!(r.status, 200);
         let body = String::from_utf8(r.body).unwrap();
         assert!(body.contains("Workflows"), "tab heading");
-        // The gallery cards show the display names (only frameworks with a real
-        // vendorable repo ship).
         for name in ["Superpowers", "Spec-driven", "Compound engineering"] {
             assert!(body.contains(name), "gallery lists '{name}'");
         }
-        // …with a marketing blurb on each.
         assert!(
             body.contains("Every's loop where each cycle makes the next one easier."),
             "card blurb shown"
         );
-        assert!(body.contains("active workflow"), "active marker");
-        // The command name is the key item: a light `/loadout:` prefix + the
-        // bold step name (so the literal isn't contiguous in the markup).
+        // The bound workflow shows an "equipped on a loadout" marker — there's no
+        // global "active workflow" concept anymore.
+        assert!(body.contains("equipped on"), "binding marker for spec-driven");
         assert!(
             body.contains(r#"<span class="cmd-name">explore</span>"#),
             "the canonical `explore` slot command is shown"
         );
 
-        // Focusing another card shows the SAME fixed spine filled by ITS stages,
-        // plus a 'Use this workflow' action.
+        // Focusing a card shows the SAME fixed spine filled by ITS stages, with no
+        // "Use this workflow" action (the Library is browse/edit only).
         let sp = String::from_utf8(
             route(
                 &st,
@@ -2386,9 +2359,7 @@ mod tests {
             .body,
         )
         .unwrap();
-        assert!(sp.contains("Use this workflow"));
-        // The fixed canonical commands + named slots are present regardless of
-        // workflow; each slot carries its own step name.
+        assert!(!sp.contains("Use this workflow"), "no global activate action");
         for (cmd, name) in [
             ("explore", "Explore"),
             ("brainstorm", "Brainstorm"),
@@ -2406,56 +2377,36 @@ mod tests {
                 "slot shows its step name `{name}`"
             );
         }
-        // Superpowers has no explore stage → that slot renders skipped.
-        assert!(
-            sp.contains("skipped"),
-            "an unfilled canonical slot is skipped"
-        );
-        // The active workflow's icon marks each filled value as its contribution.
-        assert!(
-            sp.contains("wf-value-mark"),
-            "workflow icon marks the value"
-        );
+        assert!(sp.contains("skipped"), "an unfilled canonical slot is skipped");
+        assert!(sp.contains("wf-value-mark"), "workflow icon marks the value");
         assert!(
             sp.contains("Refine the rough idea"),
             "superpowers' take on the brainstorm slot is shown when focused"
         );
-        // Handoff artifacts show as plain chips on the slot (no connector lines).
         assert!(sp.contains("design.md"), "design.md handoff chip shown");
         assert!(sp.contains("plan.md"), "plan.md handoff chip shown");
 
-        // Activating it stages the change (re-render confirms it's now active).
-        let act = String::from_utf8(
+        // Focusing the bound workflow shows which loadout pins it.
+        let spec = String::from_utf8(
             route(
                 &st,
-                &req(
-                    "POST",
-                    "/workflows/superpowers/activate",
-                    "",
-                    &[HOST, COOKIE, ORIGIN],
-                    "",
-                ),
+                &req("GET", "/workflows/spec-driven", "", &[HOST, COOKIE], ""),
             )
             .body,
         )
         .unwrap();
-        assert!(act.contains("now your active workflow"));
-
-        // Applying stays on the Workflows tab (doesn't bounce to Profiles) and
-        // persists `[defaults].workflow = "superpowers"`.
-        let applied = String::from_utf8(
-            route(&st, &req("POST", "/apply", "", &[HOST, COOKIE, ORIGIN], "")).body,
-        )
-        .unwrap();
         assert!(
-            applied.contains("tab-workflows"),
-            "stays on the Workflows tab"
+            spec.contains("Pinned on loadout") && spec.contains("rust"),
+            "the bound workflow names its loadout"
         );
-        assert!(applied.contains("applied"), "shows the applied flash");
-        let saved = std::fs::read_to_string(global_config_path(d.path())).unwrap();
-        assert!(
-            saved.contains("workflow = \"superpowers\""),
-            "persisted to config"
+        // The deprecated global activate route is gone.
+        assert_eq!(
+            route(
+                &st,
+                &req("POST", "/workflows/superpowers/activate", "", &[HOST, COOKIE, ORIGIN], "")
+            )
+            .status,
+            404
         );
     }
 

--- a/src/studio/state.rs
+++ b/src/studio/state.rs
@@ -1190,6 +1190,22 @@ pub fn staged_summary(session: &Session) -> StagedSummary {
 /// Everything is staged — the user reviews the diff and Applies like any edit.
 /// Used by both the gallery's per-pack Apply and the recommended-pack quick start.
 pub fn apply_pack(session: &mut Session, pack: &Pack) -> crate::Result<()> {
+    // Single-default invariant: the everyday pack is the no-targets default, so
+    // applying it when a different default already exists would make a second one.
+    if pack.targets.is_empty() {
+        if let Ok(cfg) = session.staged_config() {
+            if let Some(existing) = cfg
+                .profiles
+                .iter()
+                .find(|p| p.targets.is_empty() && !p.disabled && p.name != pack.profile_name)
+            {
+                return Err(anyhow::anyhow!(
+                    "a default loadout ('{}') already exists — only one loadout can be the no-targets default",
+                    existing.name
+                ));
+            }
+        }
+    }
     let owned: std::collections::HashSet<String> = session
         .staged_config()
         .map(|cfg| cfg.fragments.iter().map(|c| c.id.clone()).collect())

--- a/src/studio/state.rs
+++ b/src/studio/state.rs
@@ -275,6 +275,165 @@ pub fn staged_config(snap: &Snapshot) -> crate::Result<Config> {
     Config::from_layer_strs(snap.layer_texts.clone())
 }
 
+// --- the Create-a-Loadout board ---------------------------------------------
+
+/// One equipped fragment chip on the board.
+pub struct BoardFrag {
+    pub id: String,
+    pub title: String,
+    pub kind: &'static str,
+}
+
+/// The loadout's single workflow slot, when bound.
+pub struct BoardWorkflow {
+    pub id: String,
+    /// The filled stage spine (`Brainstorm → Plan → …`), for the slot subtitle.
+    pub spine: String,
+}
+
+/// Everything the board needs to render one loadout as slots: its targets
+/// ("Applies to"), equipped fragments, and the single workflow binding. Built
+/// from the *staged* config so it reflects unsaved edits.
+pub struct BoardView {
+    pub name: String,
+    pub disabled: bool,
+    /// No targets ⇒ the catch-all default loadout (locked "Applies to").
+    pub is_default: bool,
+    pub targets: Vec<TargetChip>,
+    pub fragments: Vec<BoardFrag>,
+    pub workflow: Option<BoardWorkflow>,
+    /// A plain-language "where this applies" line for the readout.
+    pub where_summary: String,
+}
+
+/// Build the board for the loadout named `name` from the staged config. Fragment
+/// titles/kinds come from the library view; target icons from the catalog; the
+/// workflow spine from the resolved workflow catalog.
+pub fn board_view(snap: &Snapshot, name: &str) -> crate::Result<BoardView> {
+    let cfg = staged_config(snap)?;
+    let p = cfg
+        .profiles
+        .iter()
+        .find(|p| p.name == name)
+        .ok_or_else(|| anyhow::anyhow!("unknown loadout '{name}'"))?;
+    let lib = library_view(snap)?;
+    let meta = |id: &str| {
+        lib.yours
+            .iter()
+            .chain(lib.palette.iter())
+            .find(|f| f.id == id)
+    };
+    let fragments = p
+        .fragments
+        .iter()
+        .map(|fr| {
+            let id = fr.id();
+            match meta(id) {
+                Some(f) => BoardFrag {
+                    id: id.to_string(),
+                    title: f.title.clone(),
+                    kind: f.kind,
+                },
+                None => BoardFrag {
+                    id: id.to_string(),
+                    title: id.to_string(),
+                    kind: "unknown",
+                },
+            }
+        })
+        .collect();
+    let targets = p
+        .targets
+        .iter()
+        .map(|t| TargetChip {
+            id: t.clone(),
+            icon: lib
+                .targets
+                .iter()
+                .find(|c| &c.id == t)
+                .and_then(|c| c.icon.clone())
+                .or_else(|| crate::target::builtin_icon(t).map(str::to_string)),
+        })
+        .collect::<Vec<_>>();
+    let workflow = p.workflow.as_ref().map(|id| {
+        let spine = workflows_view(snap, None)
+            .workflows
+            .iter()
+            .find(|w| &w.id == id)
+            .map(|w| {
+                w.slots
+                    .iter()
+                    .filter(|s| s.filled)
+                    .map(|s| s.name.clone())
+                    .collect::<Vec<_>>()
+                    .join(" → ")
+            })
+            .unwrap_or_default();
+        BoardWorkflow {
+            id: id.clone(),
+            spine,
+        }
+    });
+    let is_default = p.targets.is_empty();
+    let where_summary = if is_default {
+        "everywhere — the catch-all".to_string()
+    } else {
+        format!("any {} repo", p.targets.join(" / "))
+    };
+    Ok(BoardView {
+        name: name.to_string(),
+        disabled: p.disabled,
+        is_default,
+        targets,
+        fragments,
+        workflow,
+        where_summary,
+    })
+}
+
+/// The workflows a loadout can equip (the resolved catalog), as `(id, title,
+/// spine)` rows for the workflow picker.
+pub fn board_workflow_options(snap: &Snapshot) -> Vec<(String, String, String)> {
+    workflows_view(snap, None)
+        .workflows
+        .into_iter()
+        .map(|w| {
+            let spine = w
+                .slots
+                .iter()
+                .filter(|s| s.filled)
+                .map(|s| s.name.clone())
+                .collect::<Vec<_>>()
+                .join(" → ");
+            (w.id, w.title, spine)
+        })
+        .collect()
+}
+
+/// Stage an edit to a single field of the loadout named `name`: load it from the
+/// staged config, mutate it in `f`, and stage the whole profile back as an
+/// `EditProfile`. The board's inline edits (equip a fragment, add a target, bind
+/// a workflow) all go through here.
+pub fn edit_profile<F: FnOnce(&mut LoadoutConfig)>(
+    session: &mut Session,
+    name: &str,
+    f: F,
+) -> crate::Result<()> {
+    let cfg = session.staged_config()?;
+    let mut p = cfg
+        .profiles
+        .iter()
+        .find(|p| p.name == name)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("unknown loadout '{name}'"))?;
+    f(&mut p);
+    session.stage(StagedOp::EditProfile {
+        layer: Layer::Global,
+        name: name.to_string(),
+        profile: Box::new(p),
+    })
+}
+
 /// Select the profile for `(cfg, ctx)` honoring the on-disk binding. `select`
 /// also resolves the no-targets catch-all default, so the preview reflects what
 /// a real render would apply.

--- a/src/studio/state.rs
+++ b/src/studio/state.rs
@@ -304,6 +304,10 @@ pub struct BoardView {
     pub workflow: Option<BoardWorkflow>,
     /// A plain-language "where this applies" line for the readout.
     pub where_summary: String,
+    /// True when this loadout has exactly one target *and* another no-targets
+    /// default already exists — so removing it (which would make a second
+    /// default) is blocked. Drives the disabled remove-✕ on the lone chip.
+    pub target_remove_locked: bool,
 }
 
 /// Build the board for the loadout named `name` from the staged config. Fragment
@@ -380,6 +384,13 @@ pub fn board_view(snap: &Snapshot, name: &str) -> crate::Result<BoardView> {
     } else {
         format!("any {} repo", p.targets.join(" / "))
     };
+    // The single-default invariant: you can't remove a loadout's last target
+    // once some other loadout is already the no-targets default.
+    let target_remove_locked = p.targets.len() == 1
+        && cfg
+            .profiles
+            .iter()
+            .any(|q| q.name != name && !q.disabled && q.targets.is_empty());
     Ok(BoardView {
         name: name.to_string(),
         disabled: p.disabled,
@@ -388,6 +399,7 @@ pub fn board_view(snap: &Snapshot, name: &str) -> crate::Result<BoardView> {
         fragments,
         workflow,
         where_summary,
+        target_remove_locked,
     })
 }
 

--- a/src/studio/state.rs
+++ b/src/studio/state.rs
@@ -256,8 +256,6 @@ pub struct WorkflowView {
     pub artifacts: Vec<String>,
     /// Names of the loadouts that bind this workflow (empty = bound by none).
     pub bound_by: Vec<String>,
-    /// Whether this is the global **active** workflow (`[defaults].workflow`).
-    pub active: bool,
     /// Validation problems (malformed workflow); empty when well-formed.
     pub problems: Vec<String>,
 }
@@ -983,7 +981,6 @@ fn stage_content_differs(
 /// to the active workflow, then the first card.
 pub fn workflows_view(snap: &Snapshot, focus: Option<&str>) -> WorkflowsView {
     let cfg = staged_config(snap).ok();
-    let active_id = cfg.as_ref().and_then(|c| c.default_workflow.clone());
     let effective = cfg
         .as_ref()
         .map(|c| c.effective_workflows())
@@ -1025,7 +1022,6 @@ pub fn workflows_view(snap: &Snapshot, focus: Option<&str>) -> WorkflowsView {
                 icon: w.icon.clone(),
                 builtin: w.origin == Layer::BuiltIn,
                 private: matches!(w.origin, Layer::GlobalLocal),
-                active: active_id.as_deref() == Some(w.id.as_str()),
                 modeled_on: w.modeled_on.clone(),
                 source: w.source.clone(),
                 id: w.id,
@@ -1037,12 +1033,11 @@ pub fn workflows_view(snap: &Snapshot, focus: Option<&str>) -> WorkflowsView {
         })
         .collect();
 
-    // Focus the requested card if it exists, else the active one, else the first.
+    // Focus the requested card if it exists, else the first.
     let exists = |id: &str| workflows.iter().any(|w| w.id == id);
     let focused_id = focus
         .filter(|id| exists(id))
         .map(str::to_string)
-        .or_else(|| active_id.filter(|id| exists(id)))
         .or_else(|| workflows.first().map(|w| w.id.clone()));
 
     WorkflowsView {

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -395,19 +395,32 @@ pub fn shell(main: Markup, staged: usize, active_tab: &str) -> String {
     .into_string()
 }
 
+/// Top nav: two destinations. **Loadouts** is where you assemble a loadout;
+/// **Library** is the shared catalog of gear a loadout binds (fragments, targets,
+/// workflows). Anything reached *inside* the Library keeps `active_tab ==
+/// "library"`, so the Library button stays lit while you browse its categories.
 fn tab_bar(active: &str) -> Markup {
     let cls = |name: &str| if name == active { "tab active" } else { "tab" };
     html! {
         nav class="tabs" {
-            span class="tab-group tab-group-primary" {
-                button class=(cls("profiles")) data-tab="profiles" hx-get="/tab/profiles" hx-target="#main" { (icon("layers")) "Loadouts" }
-                button class=(cls("workflows")) data-tab="workflows" hx-get="/tab/workflows" hx-target="#main" { (icon("git-branch")) "Workflows" }
-            }
-            span class="tab-divider" {}
-            span class="tab-group tab-group-secondary" {
-                button class=(cls("fragments")) data-tab="fragments" hx-get="/tab/fragments" hx-target="#main" { (icon("box")) "Fragments" }
-                button class=(cls("targets")) data-tab="targets" hx-get="/tab/targets" hx-target="#main" { (icon("target")) "Targets" }
-            }
+            button class=(cls("profiles")) data-tab="profiles" hx-get="/tab/profiles" hx-target="#main" { (icon("layers")) "Loadouts" }
+            button class=(cls("library")) data-tab="library" hx-get="/tab/library" hx-target="#main" { (icon("book")) "Library" }
+        }
+    }
+}
+
+/// The Library's category sub-nav (a pill row). Baked into the top of every
+/// category body (`fragments_tab`/`targets_tab`/`workflows_tab`), so it survives
+/// every re-render — full navigation *and* post-mutation refresh — without the
+/// handlers having to re-wrap anything. Pills swap `#main` with the chosen
+/// category body, which renders this same nav with its own pill marked active.
+fn library_nav(active: &str) -> Markup {
+    let cls = |name: &str| if name == active { "lib-cat active" } else { "lib-cat" };
+    html! {
+        nav class="lib-cats" {
+            button class=(cls("fragments")) hx-get="/library/fragments" hx-target="#main" { (icon("box")) "Fragments" }
+            button class=(cls("targets")) hx-get="/library/targets" hx-target="#main" { (icon("target")) "Targets" }
+            button class=(cls("workflows")) hx-get="/library/workflows" hx-target="#main" { (icon("git-branch")) "Workflows" }
         }
     }
 }
@@ -863,6 +876,7 @@ fn profile_pick_prompt() -> Markup {
 pub fn fragments_tab(lib: &LibraryView, flash: Option<&str>) -> Markup {
     html! {
         div class="tab-fragments" {
+            (library_nav("fragments"))
             div class="dash-head" {
                 h1 { "Fragments" }
                 div class="head-actions" {
@@ -906,6 +920,7 @@ pub fn fragments_tab_fragment(lib: &LibraryView, flash: Option<&str>) -> String 
 pub fn targets_tab(view: &TargetsView, flash: Option<&str>) -> Markup {
     html! {
         div class="tab-targets" {
+            (library_nav("targets"))
             div class="dash-head" {
                 h1 { "Targets" }
                 div class="head-actions" {
@@ -941,6 +956,7 @@ pub fn workflows_tab(view: &WorkflowsView, flash: Option<&str>) -> Markup {
         .and_then(|id| view.workflows.iter().find(|w| w.id == id));
     html! {
         div class="tab-workflows" {
+            (library_nav("workflows"))
             div class="dash-head" {
                 h1 { "Workflows" }
             }

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -419,7 +419,13 @@ fn tab_bar(active: &str) -> Markup {
 /// handlers having to re-wrap anything. Pills swap `#main` with the chosen
 /// category body, which renders this same nav with its own pill marked active.
 fn library_nav(active: &str) -> Markup {
-    let cls = |name: &str| if name == active { "lib-cat active" } else { "lib-cat" };
+    let cls = |name: &str| {
+        if name == active {
+            "lib-cat active"
+        } else {
+            "lib-cat"
+        }
+    };
     html! {
         nav class="lib-cats" {
             button class=(cls("fragments")) hx-get="/library/fragments" hx-target="#main" { (icon("box")) "Fragments" }
@@ -881,7 +887,10 @@ fn board_section(
 fn board_applies(b: &BoardView, e: &str) -> Markup {
     if b.is_default {
         board_section(
-            "globe", "Applies to", None, "the default — applies when no other loadout matches",
+            "globe",
+            "Applies to",
+            None,
+            "the default — applies when no other loadout matches",
             None,
             html! {
                 div class="applies-default" {
@@ -895,8 +904,13 @@ fn board_applies(b: &BoardView, e: &str) -> Markup {
         )
     } else {
         board_section(
-            "target", "Applies to", Some(b.targets.len()), "repos this loadout is detected on",
-            Some(html! { button class="btn btn-sm" hx-get=(format!("/profiles/{e}/targets/new")) hx-target="#modal" { (icon("plus")) "Add" } }),
+            "target",
+            "Applies to",
+            Some(b.targets.len()),
+            "repos this loadout is detected on",
+            Some(
+                html! { button class="btn btn-sm" hx-get=(format!("/profiles/{e}/targets/new")) hx-target="#modal" { (icon("plus")) "Add" } },
+            ),
             html! {
                 div class="slot-row" {
                     @for t in &b.targets { (board_target_chip(e, t, b.target_remove_locked)) }
@@ -1026,7 +1040,11 @@ pub fn fragment_picker(name: &str, lib: &LibraryView, equipped: &[String]) -> St
 
 /// The workflow picker (a modal): the resolved workflow catalog (built-ins + your
 /// own), single-select. `current` marks the one already bound.
-pub fn workflow_picker(name: &str, options: &[(String, String, String)], current: Option<&str>) -> String {
+pub fn workflow_picker(
+    name: &str,
+    options: &[(String, String, String)],
+    current: Option<&str>,
+) -> String {
     let e = enc(name);
     html! {
         div class="modal-backdrop" hx-get="/close" hx-target="#modal" {}

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -54,6 +54,7 @@ fn icon(name: &str) -> Markup {
             r#"<path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>"#
         }
         "arrow-right" => r#"<path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>"#,
+        "arrow-left" => r#"<path d="M19 12H5"/><path d="m12 19-7-7 7-7"/>"#,
         "arrow-down" => r#"<path d="M12 5v14"/><path d="m19 12-7 7-7-7"/>"#,
         "layers" => {
             r#"<path d="M12 2 2 7l10 5 10-5-10-5Z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/>"#
@@ -726,6 +727,9 @@ pub fn profile_detail(d: &ProfileDetail) -> Markup {
                     @if d.disabled { span class="tag off-tag" { "disabled" } }
                 }
                 div class="detail-actions" {
+                    // Preview is reached from the board; offer the way back.
+                    button class="btn btn-ghost btn-sm" title="Back to the loadout board"
+                        hx-get=(format!("/profiles/{e}/select")) hx-target="#profile-main" { (icon("arrow-left")) "Board" }
                     @if !p.agent.is_empty() { span class="chip chip-agent" title="rendered for this agent" { (p.agent.as_str()) } }
                     button class="toggle" title=(if d.disabled { "Enable loadout" } else { "Disable loadout" }) aria-label="Toggle loadout"
                         hx-post=(format!("/profiles/{e}/disable")) hx-target="#main" {

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -519,8 +519,13 @@ pub fn profiles_tab(
                 @if lib.profiles.is_empty() {
                     p class="rail-empty muted" { "No loadouts yet." }
                 } @else {
+                    // The no-targets default is pinned to the top, above a divider.
+                    @let (defaults, rest): (Vec<&ProfileView>, Vec<&ProfileView>) =
+                        lib.profiles.iter().partition(|p| p.targets.is_empty());
                     nav class="rail-list" {
-                        @for p in &lib.profiles { (profile_rail_item(p, sel_name == Some(p.name.as_str()))) }
+                        @for p in &defaults { (profile_rail_item(p, sel_name == Some(p.name.as_str()))) }
+                        @if !defaults.is_empty() && !rest.is_empty() { div class="rail-sep" {} }
+                        @for p in &rest { (profile_rail_item(p, sel_name == Some(p.name.as_str()))) }
                     }
                 }
             }
@@ -667,7 +672,11 @@ pub fn welcome_fragment(o: &Onboarding, packs: &[PackView]) -> String {
 fn profile_rail_item(p: &ProfileView, active: bool) -> Markup {
     let name = p.name.as_str();
     let e = enc(name);
+    let is_default = p.targets.is_empty();
     let mut cls = String::from("rail-item");
+    if is_default {
+        cls.push_str(" default");
+    }
     if active {
         cls.push_str(" active");
     }
@@ -680,8 +689,12 @@ fn profile_rail_item(p: &ProfileView, active: bool) -> Markup {
             span class="rail-top" {
                 span class="rail-name" { (name) }
                 @if p.disabled { span class="tag off-tag" { "off" } }
-                // Target icons (no labels) cluster at the card's top-right.
-                @if !p.targets.is_empty() {
+                @if is_default { span class="tag rec-tag" { "Default" } }
+                // Target icons (no labels) cluster at the card's top-right — or a
+                // globe for the catch-all default.
+                @if is_default {
+                    span class="rail-icons" { span class="rail-icon" title="applies everywhere" { (icon("globe")) } }
+                } @else if !p.targets.is_empty() {
                     span class="rail-icons" { @for t in &p.targets { (target_icon_only(&t.id, t.icon.as_deref())) } }
                 }
             }
@@ -780,9 +793,11 @@ pub fn loadout_board(b: &BoardView) -> Markup {
                         hx-post=(format!("/profiles/{e}/disable")) hx-target="#main" {
                         span class=(if b.disabled { "switch off" } else { "switch on" }) {}
                     }
-                    button class="icon-btn" title="Rename" aria-label=(format!("Rename {}", b.name))
-                        hx-get=(format!("/profiles/{e}/edit")) hx-target="#main" { (icon("pencil")) }
+                    // The default loadout is always-present: not renamable (its
+                    // name/targets are fixed) and not deletable.
                     @if !b.is_default {
+                        button class="icon-btn" title="Rename" aria-label=(format!("Rename {}", b.name))
+                            hx-get=(format!("/profiles/{e}/edit")) hx-target="#main" { (icon("pencil")) }
                         button class="icon-btn danger" title="Delete" aria-label=(format!("Delete {}", b.name))
                             hx-delete=(format!("/profiles/{e}")) hx-target="#main"
                             hx-confirm=(format!("Stage deletion of loadout \"{}\"?", b.name)) { (icon("trash")) }
@@ -880,7 +895,7 @@ fn board_applies(b: &BoardView, e: &str) -> Markup {
             Some(html! { button class="btn btn-sm" hx-get=(format!("/profiles/{e}/targets/new")) hx-target="#modal" { (icon("plus")) "Add" } }),
             html! {
                 div class="slot-row" {
-                    @for t in &b.targets { (board_target_chip(e, t)) }
+                    @for t in &b.targets { (board_target_chip(e, t, b.target_remove_locked)) }
                     @if b.targets.is_empty() { span class="target-chip muted" { "no targets yet — Add one" } }
                 }
             },
@@ -888,13 +903,18 @@ fn board_applies(b: &BoardView, e: &str) -> Markup {
     }
 }
 
-fn board_target_chip(e: &str, t: &TargetChip) -> Markup {
+fn board_target_chip(e: &str, t: &TargetChip, locked: bool) -> Markup {
     let ti = resolve_target_icon(t.icon.as_deref(), &t.id);
     html! {
         span class="target-chip" {
             (target_icon_markup(&ti)) (t.id)
-            button class="tx" type="button" title="Remove target" aria-label=(format!("Remove target {}", t.id))
-                hx-delete=(format!("/profiles/{e}/targets/{}", enc(&t.id))) hx-target="#profile-main" { (icon("x")) }
+            @if locked {
+                // Can't drop the last target while another default exists.
+                span class="tx disabled" title="a loadout needs at least one target (a default already exists)" { (icon("x")) }
+            } @else {
+                button class="tx" type="button" title="Remove target" aria-label=(format!("Remove target {}", t.id))
+                    hx-delete=(format!("/profiles/{e}/targets/{}", enc(&t.id))) hx-target="#profile-main" { (icon("x")) }
+            }
         }
     }
 }

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -19,9 +19,9 @@ use crate::fragment::{Fragment, Layer};
 use crate::profile::LoadoutConfig;
 use crate::studio::edit::FileDiff;
 use crate::studio::state::{
-    AtomDot, AtomState, FragmentView, LibraryView, Onboarding, PackView, PreviewCap,
-    PreviewOutcome, ProfileView, TargetView, TargetsView, WorkflowSlotView, WorkflowView,
-    WorkflowsView,
+    AtomDot, AtomState, BoardFrag, BoardView, FragmentView, LibraryView, Onboarding, PackView,
+    PreviewCap, PreviewOutcome, ProfileView, TargetChip, TargetView, TargetsView, WorkflowSlotView,
+    WorkflowView, WorkflowsView,
 };
 use crate::target::{TargetDef, TargetRule};
 
@@ -68,6 +68,9 @@ fn icon(name: &str) -> Markup {
             r#"<path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/>"#
         }
         "check" => r#"<path d="M20 6 9 17l-5-5"/>"#,
+        "swap" => {
+            r#"<path d="m16 3 4 4-4 4"/><path d="M20 7H4"/><path d="m8 21-4-4 4-4"/><path d="M4 17h16"/>"#
+        }
         "x" => r#"<path d="M18 6 6 18M6 6l12 12"/>"#,
         "chevron-down" => r#"<path d="m6 9 6 6 6-6"/>"#,
         "power" => r#"<path d="M12 2v10"/><path d="M18.4 6.6a9 9 0 1 1-12.8 0"/>"#,
@@ -752,6 +755,274 @@ pub fn profile_detail(d: &ProfileDetail) -> Markup {
 
 pub fn profile_detail_fragment(d: &ProfileDetail) -> String {
     profile_detail(d).into_string()
+}
+
+// --- the Create-a-Loadout board ---------------------------------------------
+
+/// The board: the selected loadout shown as editable slots — Applies to
+/// (targets), Fragments, and a single Workflow — plus a readout. Fills
+/// `#profile-main` (the rail's select renders this). A "Preview" action swaps in
+/// the composed-document view ([`profile_detail`]).
+pub fn loadout_board(b: &BoardView) -> Markup {
+    let e = enc(&b.name);
+    html! {
+        div class="detail" {
+            div class="detail-head" {
+                div class="detail-title" {
+                    h1 { (b.name) }
+                    @if b.is_default { span class="chip chip-default" { (icon("globe")) "Default" } }
+                    @if b.disabled { span class="tag off-tag" { "disabled" } }
+                }
+                div class="detail-actions" {
+                    button class="btn btn-ghost btn-sm" title="Preview the composed guidance"
+                        hx-get=(format!("/profiles/{e}/preview")) hx-target="#profile-main" { (icon("eye")) "Preview" }
+                    button class="toggle" title=(if b.disabled { "Enable loadout" } else { "Disable loadout" }) aria-label="Toggle loadout"
+                        hx-post=(format!("/profiles/{e}/disable")) hx-target="#main" {
+                        span class=(if b.disabled { "switch off" } else { "switch on" }) {}
+                    }
+                    button class="icon-btn" title="Rename" aria-label=(format!("Rename {}", b.name))
+                        hx-get=(format!("/profiles/{e}/edit")) hx-target="#main" { (icon("pencil")) }
+                    @if !b.is_default {
+                        button class="icon-btn danger" title="Delete" aria-label=(format!("Delete {}", b.name))
+                            hx-delete=(format!("/profiles/{e}")) hx-target="#main"
+                            hx-confirm=(format!("Stage deletion of loadout \"{}\"?", b.name)) { (icon("trash")) }
+                    }
+                }
+            }
+            p class="detail-sub" {
+                @if b.is_default { "The always-on baseline — carried everywhere, beneath whatever else matches." }
+                @else { "Configure this loadout — the gear it carries into a matching repo." }
+            }
+            div class="lo-board" {
+                (board_applies(b, &e))
+                (board_section(
+                    "box", "Fragments", Some(b.fragments.len()), "the guidance it composes",
+                    Some(html! { button class="btn btn-sm" hx-get=(format!("/profiles/{e}/fragments/new")) hx-target="#modal" { (icon("plus")) "Equip" } }),
+                    html! {
+                        div class="slot-row" {
+                            @for f in &b.fragments { (board_frag_chip(&e, f)) }
+                            @if b.fragments.is_empty() { span class="muted small" { "No fragments yet — Equip one from the library." } }
+                        }
+                    },
+                ))
+                (board_section(
+                    "git-branch", "Workflow", None, "a single multi-step process, optional",
+                    None, board_workflow_slot(b, &e),
+                ))
+                div class="provenance" {
+                    span class="prov-node" { (b.fragments.len()) " " (if b.fragments.len() == 1 { "fragment" } else { "fragments" }) }
+                    @if let Some(w) = &b.workflow {
+                        span class="prov-arrow" { (icon("plus")) }
+                        span class="prov-node" { (w.id) }
+                    }
+                    span class="prov-arrow" { (icon("arrow-right")) }
+                    span { (b.where_summary) }
+                }
+            }
+        }
+    }
+}
+
+pub fn loadout_board_fragment(b: &BoardView) -> String {
+    loadout_board(b).into_string()
+}
+
+/// One framed board section: an icon tile + bold title + optional count + hint,
+/// optional header actions, then the body.
+fn board_section(
+    icon_name: &str,
+    title: &str,
+    count: Option<usize>,
+    hint: &str,
+    actions: Option<Markup>,
+    body: Markup,
+) -> Markup {
+    html! {
+        div class="slot-section" {
+            div class="slot-head" {
+                span class="slot-head-icon" { (icon(icon_name)) }
+                div class="slot-head-text" {
+                    span class="slot-head-title" { (title) @if let Some(n) = count { span class="slot-count" { (n) } } }
+                    span class="slot-head-hint" { (hint) }
+                }
+                @if let Some(a) = actions { div class="slot-head-actions" { (a) } }
+            }
+            (body)
+        }
+    }
+}
+
+/// The "Applies to" section — a locked explainer for the default loadout, or the
+/// editable target chips + Add for a targeted one.
+fn board_applies(b: &BoardView, e: &str) -> Markup {
+    if b.is_default {
+        board_section(
+            "globe", "Applies to", None, "the default — applies when no other loadout matches",
+            None,
+            html! {
+                div class="applies-default" {
+                    span class="ad-glyph" { (icon("globe")) }
+                    span class="ad-text" {
+                        strong { "Applies everywhere." }
+                        " This is the default loadout — it’s used whenever no other loadout matches, in any project or none at all, so there are no targets to set."
+                    }
+                }
+            },
+        )
+    } else {
+        board_section(
+            "target", "Applies to", Some(b.targets.len()), "repos this loadout is detected on",
+            Some(html! { button class="btn btn-sm" hx-get=(format!("/profiles/{e}/targets/new")) hx-target="#modal" { (icon("plus")) "Add" } }),
+            html! {
+                div class="slot-row" {
+                    @for t in &b.targets { (board_target_chip(e, t)) }
+                    @if b.targets.is_empty() { span class="target-chip muted" { "no targets yet — Add one" } }
+                }
+            },
+        )
+    }
+}
+
+fn board_target_chip(e: &str, t: &TargetChip) -> Markup {
+    let ti = resolve_target_icon(t.icon.as_deref(), &t.id);
+    html! {
+        span class="target-chip" {
+            (target_icon_markup(&ti)) (t.id)
+            button class="tx" type="button" title="Remove target" aria-label=(format!("Remove target {}", t.id))
+                hx-delete=(format!("/profiles/{e}/targets/{}", enc(&t.id))) hx-target="#profile-main" { (icon("x")) }
+        }
+    }
+}
+
+fn board_frag_chip(e: &str, f: &BoardFrag) -> Markup {
+    let warm = matches!(f.kind, "command" | "provider");
+    html! {
+        span class="frag-chip" {
+            span class=(if warm { "cg warm" } else { "cg" }) { (icon(if warm { "terminal" } else { "box" })) }
+            span class="cn" { (f.title) }
+            button class="cx" type="button" title="Remove fragment" aria-label=(format!("Remove fragment {}", f.id))
+                hx-delete=(format!("/profiles/{e}/fragments/{}", enc(&f.id))) hx-target="#profile-main" { (icon("x")) }
+        }
+    }
+}
+
+fn board_workflow_slot(b: &BoardView, e: &str) -> Markup {
+    match &b.workflow {
+        Some(w) => html! {
+            div class="slot slot-single" {
+                span class="slot-glyph" { (icon("git-branch")) }
+                div class="slot-body" {
+                    span class="slot-name" { (w.id) }
+                    @if !w.spine.is_empty() { span class="slot-sub" { (w.spine) } }
+                }
+                button class="icon-btn slot-x" type="button" title="Swap workflow"
+                    hx-get=(format!("/profiles/{e}/workflow/new")) hx-target="#modal" { (icon("swap")) }
+                button class="icon-btn slot-x" type="button" title="Remove workflow"
+                    hx-delete=(format!("/profiles/{e}/workflow")) hx-target="#profile-main" { (icon("x")) }
+            }
+        },
+        None => html! {
+            div class="slot slot-single slot-empty" role="button" tabindex="0"
+                hx-get=(format!("/profiles/{e}/workflow/new")) hx-target="#modal" {
+                span class="slot-glyph" { (icon("plus")) }
+                div class="slot-body" {
+                    span class="slot-name" { "Equip a workflow" }
+                    span class="slot-sub" { "optional · one per loadout" }
+                }
+            }
+        },
+    }
+}
+
+/// The target picker (a modal): the catalog targets not already on this loadout.
+pub fn target_picker(name: &str, options: &[TargetChip]) -> String {
+    let e = enc(name);
+    html! {
+        div class="modal-backdrop" hx-get="/close" hx-target="#modal" {}
+        div class="modal" {
+            div class="modal-head" { h2 { "Add a target" } (close_btn()) }
+            div class="modal-body" {
+                div class="pick-list" {
+                    @if options.is_empty() { p class="muted" { "Every target is already on this loadout." } }
+                    @for t in options {
+                        div class="pick" role="button" tabindex="0"
+                            hx-post=(format!("/profiles/{e}/targets/{}", enc(&t.id))) hx-target="#profile-main" {
+                            span class="pick-glyph" { (target_icon_markup(&resolve_target_icon(t.icon.as_deref(), &t.id))) }
+                            span class="pick-main" { span class="pick-title" { (t.id) } }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    .into_string()
+}
+
+/// The fragment picker (a modal): your owned fragments not already equipped,
+/// grouped by category (the same grouping the Library uses).
+pub fn fragment_picker(name: &str, lib: &LibraryView, equipped: &[String]) -> String {
+    let e = enc(name);
+    let is_equipped = |id: &str| equipped.iter().any(|x| x == id);
+    let groups = group_fragments(&lib.yours);
+    let any = lib.yours.iter().any(|f| !is_equipped(&f.id));
+    html! {
+        div class="modal-backdrop" hx-get="/close" hx-target="#modal" {}
+        div class="modal" {
+            div class="modal-head" { h2 { "Equip a fragment" } (close_btn()) }
+            div class="modal-body" {
+                @if !any { p class="muted" { "Every fragment in your library is already equipped. Create more in the Library." } }
+                div class="pick-list" {
+                    @for (label, frags) in &groups {
+                        @let avail: Vec<&&FragmentView> = frags.iter().filter(|f| !is_equipped(&f.id)).collect();
+                        @if !avail.is_empty() {
+                            div class="frag-group-head pick-group" { (label) }
+                            @for f in avail {
+                                div class="pick" role="button" tabindex="0"
+                                    hx-post=(format!("/profiles/{e}/fragments/{}", enc(&f.id))) hx-target="#profile-main" {
+                                    span class="pick-glyph" { (icon(if matches!(f.kind, "command" | "provider") { "terminal" } else { "box" })) }
+                                    span class="pick-main" {
+                                        span class="pick-title" { (f.title) }
+                                        span class="pick-id" { (f.id) }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    .into_string()
+}
+
+/// The workflow picker (a modal): the resolved workflow catalog (built-ins + your
+/// own), single-select. `current` marks the one already bound.
+pub fn workflow_picker(name: &str, options: &[(String, String, String)], current: Option<&str>) -> String {
+    let e = enc(name);
+    html! {
+        div class="modal-backdrop" hx-get="/close" hx-target="#modal" {}
+        div class="modal" {
+            div class="modal-head" { h2 { "Equip a workflow" } (close_btn()) }
+            div class="modal-body" {
+                div class="pick-list" {
+                    @for (id, title, spine) in options {
+                        div class="pick" role="button" tabindex="0"
+                            hx-post=(format!("/profiles/{e}/workflow/{}", enc(id))) hx-target="#profile-main" {
+                            span class="pick-glyph" { (icon("git-branch")) }
+                            span class="pick-main" {
+                                span class="pick-title" { (title) }
+                                @if !spine.is_empty() { span class="pick-id" { (spine) } }
+                            }
+                            @if current == Some(id.as_str()) {
+                                span class="pick-current" { (icon("check")) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    .into_string()
 }
 
 /// One collapsible fragment section inside the profile "document": a compact

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -799,9 +799,14 @@ pub fn loadout_board(b: &BoardView) -> Markup {
                     "box", "Fragments", Some(b.fragments.len()), "the guidance it composes",
                     Some(html! { button class="btn btn-sm" hx-get=(format!("/profiles/{e}/fragments/new")) hx-target="#modal" { (icon("plus")) "Equip" } }),
                     html! {
-                        div class="slot-row" {
-                            @for f in &b.fragments { (board_frag_chip(&e, f)) }
-                            @if b.fragments.is_empty() { span class="muted small" { "No fragments yet — Equip one from the library." } }
+                        @if b.fragments.is_empty() {
+                            div class="slot-row" { span class="muted small" { "No fragments yet — Equip one from the library." } }
+                        } @else {
+                            // A fixed 3×3 grid; studio.js paginates (and pins the
+                            // height) when there are more than one page of chips.
+                            div class="frag-paged" data-page-size="9" {
+                                @for f in &b.fragments { (board_frag_chip(&e, f)) }
+                            }
                         }
                     },
                 ))

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -1305,13 +1305,15 @@ pub fn workflows_result(view: &WorkflowsView, flash: &str) -> String {
     .into_string()
 }
 
-/// One tiny gallery card: the workflow name + an active marker; click to focus.
+/// One tiny gallery card: the workflow name + an "in use" marker (equipped on at
+/// least one loadout); click to focus.
 fn workflow_gallery_card(w: &WorkflowView, focused: bool) -> Markup {
+    let in_use = !w.bound_by.is_empty();
     let mut cls = String::from("wf-card");
     if focused {
         cls.push_str(" focused");
     }
-    if w.active {
+    if in_use {
         cls.push_str(" active");
     }
     let glyph = w.icon.as_deref().unwrap_or("git-branch");
@@ -1320,7 +1322,7 @@ fn workflow_gallery_card(w: &WorkflowView, focused: bool) -> Markup {
             span class="wf-card-top" {
                 span class="wf-card-glyph" { (icon(glyph)) }
                 span class="wf-card-name" { (w.title) }
-                @if w.active { span class="wf-card-dot" title="active workflow" { (icon("check")) } }
+                @if in_use { span class="wf-card-dot" title=(format!("equipped on {} loadout(s)", w.bound_by.len())) { (icon("check")) } }
                 @else if !w.builtin { span class="wf-card-tag" { "yours" } }
             }
             @if let Some(b) = &w.blurb { span class="wf-card-blurb" { (b) } }
@@ -1350,21 +1352,16 @@ fn workflow_detail(w: &WorkflowView) -> Markup {
                     }
                 }
                 div class="wf-detail-actions" {
-                    // Built-in → "Customize" (opens the editor prefilled; saving
-                    // makes an owned copy). Owned → "Edit" + "Delete". Built-ins
-                    // are never removable. Secondary styling, so the primary
-                    // action stays "Use this workflow".
+                    // The Library is browse/edit only — a workflow is *used* by
+                    // equipping it in a loadout's Workflow slot, not activated
+                    // globally. Built-in → "Customize" (opens the editor prefilled;
+                    // saving makes an owned copy). Owned → "Edit" + "Delete".
                     @if w.builtin {
                         button class="btn btn-ghost" hx-get=(format!("/workflows/{}/customize", enc(&w.id))) hx-target="#modal" title="Duplicate into a workflow you can edit" { (icon("copy")) "Customize" }
                     } @else {
                         button class="btn btn-ghost" hx-get=(format!("/workflows/{}/edit", enc(&w.id))) hx-target="#modal" { (icon("pencil")) "Edit" }
                         button class="btn btn-danger-ghost" hx-delete=(format!("/workflows/{}", enc(&w.id))) hx-target="#main"
                             hx-confirm=(format!("Delete your workflow “{}”? This stages its removal.", w.title)) title="Remove this custom workflow" { (icon("trash")) "Delete" }
-                    }
-                    @if w.active {
-                        span class="tag rec-tag wf-active-pill" { (icon("check")) "active workflow" }
-                    } @else {
-                        button class="btn btn-primary" hx-post=(format!("/workflows/{}/activate", enc(&w.id))) hx-target="#main" { (icon("check")) "Use this workflow" }
                     }
                 }
             }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -235,16 +235,15 @@ fn run_workflow_override_sets_handoff_env_in_dry_run() {
 }
 
 #[test]
-fn global_active_workflow_renders_without_any_binding() {
+fn bound_workflow_renders_for_its_loadout() {
     let fx = Fixture::new();
     fx.rust_project();
     fx.git_init();
-    // A rust loadout with NO workflow binding, plus a global active workflow.
-    // The single house workflow should still render for this repo.
+    // The rust loadout binds the compound workflow in its Workflow slot — the
+    // only way a workflow renders now (no global default workflow).
     fx.author(
-        "[defaults]\nworkflow = \"compound\"\n\n\
-         [[fragments]]\nid = \"rc\"\nguidance = \"Rust.\"\n\n\
-         [[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\n",
+        "[[fragments]]\nid = \"rc\"\nguidance = \"Rust.\"\n\n\
+         [[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\nworkflow = \"compound\"\n",
     );
     fx.cmd()
         .args(["refresh", "--agent", "claude"])

--- a/tests/skill_examples.rs
+++ b/tests/skill_examples.rs
@@ -94,12 +94,16 @@ fn import_workflow_skill_reference_toml_examples_are_valid_config() {
         .expect("the plan stage demonstrates an instructions body");
     assert!(instr.contains("Planning is where most of the work happens"));
 
-    // An activation snippet must set the global active workflow.
+    // An equipping snippet must bind the workflow on a loadout (the only way to
+    // use a workflow now that the global default is gone).
     assert!(
         blocks.iter().any(|b| parse_global(b)
-            .map(|c| c.default_workflow.as_deref() == Some("compound"))
+            .map(|c| c
+                .profiles
+                .iter()
+                .any(|p| p.workflow.as_deref() == Some("compound")))
             .unwrap_or(false)),
-        "an activation example should set [defaults].workflow"
+        "an example should equip the workflow on a loadout"
     );
 }
 

--- a/tests/studio.rs
+++ b/tests/studio.rs
@@ -192,8 +192,8 @@ fn studio_binds_and_serves_secured_spine() {
     );
     assert!(shell.contains("Loadout studio"), "shell renders the page");
     assert!(
-        shell.contains("Loadouts") && shell.contains("Fragments"),
-        "shell renders the Profiles/Fragments tabs"
+        shell.contains("Loadouts") && shell.contains("Library"),
+        "shell renders the two destinations: Loadouts | Library"
     );
 
     assert!(
@@ -373,11 +373,11 @@ fn studio_first_run_lands_on_profiles_and_guides_through_pack() {
         "fresh config lands on the Profiles welcome; got head:\n{}",
         head(&shell)
     );
-    let (pi, fi) = (
+    let (pi, li) = (
         shell.find("data-tab=\"profiles\"").unwrap_or(usize::MAX),
-        shell.find("data-tab=\"fragments\"").unwrap_or(0),
+        shell.find("data-tab=\"library\"").unwrap_or(0),
     );
-    assert!(pi < fi, "Profiles tab comes before Fragments in the nav");
+    assert!(pi < li, "Loadouts comes before Library in the nav");
 
     // Beat 2: the friendly review, not the normal "staged the … pack" flash.
     assert!(


### PR DESCRIPTION
Reorganizes loadout studio around the loadout metaphor (a game "Create-a-Class" screen) and makes the per-loadout workflow binding first-class — then removes the global active workflow in favor of it.

## Why
The old top nav had four flat peers (Loadouts, Workflows, Fragments, Targets), implying four co-equal concepts. Fragments, Targets, and Workflows aren't peers of a loadout — they're the reusable **gear a loadout binds**. And `Profile.workflow` already existed in the model but had no UI.

## What changed (by slice)
1. **Nav → `Loadouts | Library`** (`83b80d6`). Fragments/Targets/Workflows become a pill sub-nav baked into each Library body (survives every re-render).
2. **The loadout detail is a Create-a-Loadout board** (`d9fae1e`): editable slots — Applies to (targets), Fragments, and a single **Workflow slot** — with inline add/remove/equip via `EditProfile`. Composed-doc view moves behind a "Preview" action. **Also fixes `profile_table` dropping the `workflow` field on write** — without it `Profile.workflow` never persisted.
3. **Paged fragments** (`a6665b6`): fixed 3×3 grid, height pinned so paging never shifts the layout.
4. **One canonical default** (`5622243`): the no-targets catch-all is THE default — pinned, badged, locked "Applies to", no rename/delete; every other loadout needs ≥1 target; `doctor` warns on 0/>1 defaults.
5. **Polish** (`73381de`): "← Board" back-button on Preview.
6. **Starter packs** (`e3fe102`): each pack binds a workflow (`superpowers`); the everyday pack is now the no-targets default; `apply_pack` guards the single-default rule.
7. **Remove the global active workflow** (`9e16be1`, **BREAKING**): `[defaults].workflow` + `Config.default_workflow` gone; `resolve_active_workflow` = override → the selected loadout's binding. Studio drops the "activate"/`SetActiveWorkflow` concept (gallery shows "equipped on N loadout(s)"); docs + the import-workflow skill teach per-loadout binding. A leftover `[defaults].workflow` is tolerated and ignored.

## Breaking change & migration
A config relying on `[defaults].workflow` no longer applies it — bind the workflow on the relevant loadout(s), and on the default (no-targets) loadout for "everywhere". (My own global config has already been migrated this way: every loadout binds superpowers, `machine` is the no-targets default.)

## Verification
- `cargo build` + `cargo clippy --all-targets` clean.
- Green: 301 lib + 71 cli + 8 integration + 4 skill_examples tests (incl. new board / default-invariant / paging / pack / workflow-binding tests).
- Each slice verified live against the running studio via a headless-Chromium screenshot pass.

## Notes for review
- Design + plan: `.loadout/workflow/artifacts/{design,plan}.md` (untracked, local).
- The `docs/` hero screenshot still shows the old 4-tab nav — intended to regenerate at release time, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)