### PR TITLE
feat(workflow): recognize "audit" and "check" as verify-slot synonyms

### DIFF
--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -285,7 +285,7 @@ pub fn canonical_slot(stage_name: &str) -> Option<&'static str> {
         "brainstorm" | "specify" | "spec" | "design" | "ideate" | "discovery" => "brainstorm",
         "plan" | "planning" | "decompose" => "plan",
         "implement" | "iterate" | "code" | "build" | "execute" | "develop" => "implement",
-        "verify" | "review" | "test" | "validate" | "qa" => "verify",
+        "verify" | "review" | "test" | "validate" | "qa" | "audit" | "check" => "verify",
         "ship" | "commit" | "pr" | "push" | "deliver" | "release" | "deploy" | "merge"
         | "finish" | "finishing" => "ship",
         _ => return None,


### PR DESCRIPTION
Adds `"audit"` and `"check"` as synonyms for the **`verify`** slot in `canonical_slot()` (`src/workflow.rs`).

Please confirm against the code at this PR head:
- The two new synonyms are wired into the `verify` arm of `canonical_slot()` and nowhere else.
- They do not collide with any other slot's synonyms, and they remain consistent with the six entries in `CANONICAL_SLOTS` (no new slot was added).
- The matching stays case-insensitive (read the full function, not just the diff hunk).

_Note: temporary verification PR for Savio's live-head-read fix (#190). Will be closed unmerged._