### PR TITLE
docs: catch README + docs up to the six-slot workflow spine; Cursor doc gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.swp
 CLAUDE.local.md
 AGENTS.override.md
+.claude/commands/loadout/

--- a/README.md
+++ b/README.md
@@ -128,19 +128,19 @@ multiple loadouts match     →  ask once, then remember the choice for this pro
 
 ## Workflows
 
-A loadout carries your *context*. A **workflow** carries your *process* — the way you like to work, across every agent. Loadout exposes one fixed set of five slash commands — `/loadout:explore`, `brainstorm`, `plan`, `implement`, `verify` — and the workflow your loadout equips decides what each step *means*. "Plan like Boris" and "plan spec-first" are the same `/loadout:plan`, carrying different instructions.
+A loadout carries your *context*. A **workflow** carries your *process* — the way you like to work, across every agent. Loadout exposes one fixed set of six slash commands — `/loadout:explore`, `brainstorm`, `plan`, `implement`, `verify`, `ship` — and the workflow your loadout equips decides what each step *means*. "Plan like spec-kit" and "plan compound-style" are the same `/loadout:plan`, carrying different instructions.
 
 <p align="center">
-  <img src="docs/screenshots/workflows.png" alt="load studio — the Workflows tab: a gallery of built-in processes mapped onto the fixed explore/brainstorm/plan/implement/verify spine" width="900">
+  <img src="docs/screenshots/workflows.png" alt="load studio — the Workflows tab: a gallery of built-in processes mapped onto the fixed explore/brainstorm/plan/implement/verify/ship spine" width="900">
 </p>
-<p align="center"><sub><i><code>load studio</code> — pick a house process, or build your own; each fills the same five-command spine.</i></sub></p>
+<p align="center"><sub><i><code>load studio</code> — pick a house process, or build your own; each fills the same six-command spine.</i></sub></p>
 
-Six ship — Anthropic's lean loop, how Boris works, Superpowers, spec-driven, the Ralph loop, and Every's compound engineering — or build your own in `load studio`. A stage can hand a file to the next step (plan writes `plan.md`, implement reads it), which is what makes a workflow more than headings. Equip one on a loadout — in studio's **Workflow slot**, or by hand:
+Three ship — Superpowers (obra/superpowers), spec-driven (Spec Kit / Kiro), and Every's compound engineering — each modeled on a real framework whose actual skill files are vendored verbatim. Or build your own in `load studio`. A stage can hand a file to the next step (plan writes `plan.md`, implement reads it), which is what makes a workflow more than headings. Equip one on a loadout — in studio's **Workflow slot**, or by hand:
 
 ```toml
 [[loadouts]]
 name = "machine"      # the default (no-targets) loadout → applies everywhere
-workflow = "lean"
+workflow = "superpowers"
 ```
 
 Workflows are global-only and never enforced — guidance rendered into each agent, not a runtime. (One naming nuance: Cursor delivers the spine as Skills, so there the commands are invoked `/loadout-explore` — dash, not colon — since Cursor names a skill after its folder.) Full detail in [docs/concepts.md](docs/concepts.md#workflows-implemented).

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ name = "machine"      # the default (no-targets) loadout → applies everywhere
 workflow = "lean"
 ```
 
-Workflows are global-only and never enforced — guidance rendered into each agent, not a runtime. Full detail in [docs/concepts.md](docs/concepts.md#workflows-implemented).
+Workflows are global-only and never enforced — guidance rendered into each agent, not a runtime. (One naming nuance: Cursor delivers the spine as Skills, so there the commands are invoked `/loadout-explore` — dash, not colon — since Cursor names a skill after its folder.) Full detail in [docs/concepts.md](docs/concepts.md#workflows-implemented).
 
 ---
 
@@ -201,7 +201,7 @@ load skill install
 
 Then, in an agent session, run `/loadout-migrate` or just ask *"Import my CLAUDE.md into Loadout."*
 
-Two more ship: [`loadout-remember`](skills/loadout-remember/SKILL.md) saves a durable cross-project preference as a fragment when you mention one mid-session — instead of leaving it stranded in one agent's memory — and [`loadout-import-workflow`](skills/loadout-import-workflow/SKILL.md) turns another repo's command/skill suite into a loadout [workflow](#workflows). The skills follow the cross-agent `SKILL.md` format, so the same install works in Claude Code, Codex, Gemini, and opencode.
+Two more ship: [`loadout-remember`](skills/loadout-remember/SKILL.md) saves a durable cross-project preference as a fragment when you mention one mid-session — instead of leaving it stranded in one agent's memory — and [`loadout-import-workflow`](skills/loadout-import-workflow/SKILL.md) turns another repo's command/skill suite into a loadout [workflow](#workflows). The skills follow the cross-agent `SKILL.md` format, so the same install works in Claude Code, Codex, Gemini, opencode, and Cursor.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,8 @@ cwd → repo_base → Config::load → detect_context → select (one loadout by
    cross-loadout union.
 5. **Render** produces one agent-neutral overlay (header + a `###` section per
    fragment), filtering fragments restricted to other agents. If a workflow is
-   active (`resolve_active_workflow`), it also contributes a `## Workflow` section
-   and per-agent `/loadout:<slot>` slash-command files for the fixed spine.
+   active (`Config::resolve_active_workflow`), it also contributes a `## Workflow`
+   section and per-agent `/loadout:<slot>` slash-command files for the fixed spine.
 6. **Delivery** is per-agent, driven by an `AgentDescriptor`.
 7. **Audit** appends a JSONL event (skipped on `--dry-run`).
 
@@ -44,7 +44,7 @@ cwd → repo_base → Config::load → detect_context → select (one loadout by
 | `fragment` | `Fragment` (reusable guidance atom) + `Risk` + the read-only shipped `palette()` (starters to duplicate from, never auto-composed). |
 | `loadout` | `LoadoutConfig` (with `targets`), `Rule`/`Field`/`Op` (fragment `when`), `FragmentRef`, pick-one `select()`, and `compose_loadout()` → `Composition` of `ResolvedFragment`s. |
 | `binding` | the per-project remembered loadout choice: repo `local.toml` `[binding]` (via `toml_edit`) + a global path-keyed store; records only *which* loadout (no opt-out — a legacy `none = true` is parsed but ignored). |
-| `workflow` | the house-process model: `Workflow`/`WorkflowStage`, the fixed five-slot `canonical_layout()` (the single source of truth shared by the command channel, the context section, and studio), handoff-artifact paths, the built-in catalog, and `resolve_workflow`/`resolve_active_workflow`. Global-only like fragments/loadouts. |
+| `workflow` | the house-process model: `Workflow`/`WorkflowStage`, the fixed six-slot `canonical_layout()` (the single source of truth shared by the command channel, the context section, and studio), handoff-artifact paths, the built-in catalog, and `resolve_workflow` (the active-workflow resolution `Config::resolve_active_workflow` lives in `config`). Global-only like fragments/loadouts. |
 | `providers/` | `EnvProvider` trait + built-ins (`host`/`toolchain`/`ai-tools`/`tailnet`/`docker`), `gather()`/`probe_one()`/`run_command()`, TTL cache; output redacted and excluded from the context hash. |
 | `dynamic` | resolves a dynamic fragment's `provider`/`command` output at render time (`DynamicMode` Live/ReadOnly); a `command` runs unless `allow_exec = false`. |
 | `render/` | `TemplateRenderer` trait (minijinja impl) + `header` (the self-healing banner) + the high-level `render()`. |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -188,7 +188,9 @@ in `~/.gemini/settings.json`), `copilot` (`load run` sets
 `cursor-agent` CLI — plus a user-level `sessionStart` hook in `~/.cursor/hooks.json`
 that keeps repos fresh — and auto-adopts a git repo some loadout applies to on
 first open, no prior `load refresh` needed — since IDE sessions never pass
-through `load run`),
+through `load run`; workflow commands land as Cursor Skills,
+`.cursor/skills/loadout/loadout-<slot>/SKILL.md`, invoked `/loadout-<slot>`
+rather than `/loadout:<slot>`),
 `opencode` (registers
 the overlay path in `~/.config/opencode/opencode.json` `instructions`), `generic`
 (emit-only). All overridable / extendable via `[[agents]]`.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -79,24 +79,31 @@ stale binding is dropped and selection re-runs.
 ## Workflows **(implemented)**
 
 A **workflow** is loadout's house *process* — the named way you like to work
-(explore-plan-code-commit, spec-first, a long autonomous loop), carried across
+(explore-plan-code-commit, spec-first, a compounding loop), carried across
 every agent the same way a loadout carries your context. Where a loadout answers
 *"what context applies here?"*, a workflow answers *"what's the process for doing
 the work?"*
 
-**One fixed command spine.** loadout always exposes the same five slash commands
+**One fixed command spine.** loadout always exposes the same six slash commands
 to your agent — `/loadout:explore`, `/loadout:brainstorm`, `/loadout:plan`,
-`/loadout:implement`, `/loadout:verify`. Picking a workflow does **not** add or
-rename commands; it changes what each step *means*. "Plan like Boris" and "plan
-spec-first" are the same `/loadout:plan` command carrying different instructions.
+`/loadout:implement`, `/loadout:verify`, `/loadout:ship`. Picking a workflow does
+**not** add or rename commands; it changes what each step *means*. "Plan
+spec-first" and "plan compound-style" are the same `/loadout:plan` command
+carrying different instructions.
 
 - A workflow is an ordered list of **stages**, each a free-form `name` plus a
-  short `purpose`. Each stage maps onto one of the five canonical slots by its
-  name (`research`→explore, `specify`→brainstorm, `review`/`commit`→verify, …);
-  the **first** stage to claim a slot wins. A workflow may fill all five or skip
-  some.
+  short `purpose`. Each stage maps onto one of the six canonical slots by its
+  name (`research`→explore, `specify`→brainstorm, `review`→verify,
+  `commit`/`pr`→ship, …); the **first** stage to claim a slot wins. A workflow
+  may fill all six or skip some. (Review and shipping are separate slots:
+  `verify` is "check the result", `ship` is "commit, push, open the PR".)
+- A stage may also carry deeper, on-demand `instructions` — the full prescriptive
+  guidance baked into that step's `/loadout:<slot>` command body, loaded only when
+  the step actually runs. The always-on `## Workflow` context section stays terse
+  (it uses just `purpose`), so depth in `instructions` costs nothing until you
+  invoke the step.
 - A stage whose name matches no slot becomes an **extra** — rendered after the
-  five (e.g. compound engineering's "capture what you learned" step).
+  six (e.g. compound engineering's "capture what you learned" step).
 
 **Handoff artifacts** are the load-bearing part. A stage can `write` a file (e.g.
 `plan.md`) and a later stage can `read` it; the file lives under
@@ -111,15 +118,16 @@ workflow, resolved in this order:
 2. The workflow the selected loadout binds — `workflow = "<id>"` on its
    `[[loadouts]]` block (equipped in studio's **Workflow slot**). To get a
    workflow *everywhere*, bind it on the default (no-targets) loadout. There is
-   no separate global active workflow.
+   no separate global active workflow. (The shipped **starter packs** bind a
+   house workflow for you, so a fresh loadout already has one.)
 
-**The catalog.** Six built-ins ship, each modeled on a real practice and stamped
-with provenance: `lean` (Anthropic's explore-plan-code-commit), `boris` (how
-Claude Code's creator works), `superpowers` (the obra/superpowers framework),
-`spec-driven` (Spec Kit / Kiro), `loop` (the Ralph single-prompt loop), and
-`compound` (Every's compounding loop). Bind one directly, or copy it into your
-own `[[workflows]]` and hand-edit — a user workflow of the same id shadows the
-built-in.
+**The catalog.** Three built-ins ship, each modeled on a real,
+permissively-licensed framework whose actual skill/command files are vendored
+verbatim (so binding one gives you that framework's real guidance, not a
+paraphrase), and stamped with provenance: `superpowers` (the obra/superpowers
+framework), `spec-driven` (Spec Kit / Kiro), and `compound` (Every's compounding
+loop). Bind one directly, or copy it into your own `[[workflows]]` and hand-edit —
+a user workflow of the same id shadows the built-in.
 
 **Global-only**, exactly like fragments and loadouts: a repo's `.loadout/` may
 *declare* `[[workflows]]` but the loader strips them (and `load doctor` flags
@@ -128,9 +136,10 @@ owns the artifact-path convention, but it never enforces a step, judges
 completion, or tracks a live "current stage" — this is guidance, not policy, with
 no runtime and no LLM.
 
-**Building your own.** The `load studio` **Workflows** tab is a gallery of the
-built-ins plus your own; you can build a workflow from scratch or customize a
-built-in (which duplicates it to a new id), editing each step as plain markdown.
+**Building your own.** The `load studio` **Library → Workflows** tab is a gallery
+of the built-ins plus your own; you can build a workflow from scratch or customize
+a built-in (which duplicates it to a new id), editing each step as plain markdown
+(its summary `purpose` plus the optional deeper `instructions`).
 The [`loadout-import-workflow`](../skills/loadout-import-workflow/SKILL.md) skill
 imports another repo's command/skill suite into a workflow. Schema in
 [configuration](configuration.md#workflows-implemented).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,21 +103,22 @@ A loadout may also pin a workflow for the contexts it covers:
 name = "rust"
 targets = ["rust"]
 fragments = ["rust-conventions"]
-workflow = "boris"     # the workflow this loadout equips (its Workflow slot); omit for none
+workflow = "superpowers"   # the workflow this loadout equips (its Workflow slot); omit for none
 ```
 
 ## `[[workflows]]` (implemented)
 
-A workflow is your house *process*, mapped onto loadout's fixed five-command
-spine (`explore`, `brainstorm`, `plan`, `implement`, `verify`). **Global-only**
-like fragments and loadouts — a repo declaring `[[workflows]]` is stripped at
-load (`load doctor` flags it). Six built-ins ship; your own of the same `id`
-shadows a built-in. See [concepts](concepts.md#workflows-implemented).
+A workflow is your house *process*, mapped onto loadout's fixed six-command
+spine (`explore`, `brainstorm`, `plan`, `implement`, `verify`, `ship`).
+**Global-only** like fragments and loadouts — a repo declaring `[[workflows]]` is
+stripped at load (`load doctor` flags it). Three built-ins ship (`superpowers`,
+`spec-driven`, `compound`); your own of the same `id` shadows a built-in. See
+[concepts](concepts.md#workflows-implemented).
 
 ```toml
 [[workflows]]
-id = "lean"                    # kebab-case, unique; how a [[loadouts]] block binds it
-name = "Lean"                  # gallery title + rendered heading (optional)
+id = "my-flow"                 # kebab-case, unique; how a [[loadouts]] block binds it
+name = "My flow"               # gallery title + rendered heading (optional)
 description = "Read first, plan on paper, then build."   # one-line blurb (optional)
 icon = "git-branch"            # studio card glyph (optional)
 # modeled_on / researched / source — display-only provenance (optional)
@@ -131,6 +132,7 @@ purpose = "Read the code paths and tests before changing anything."
 name = "plan"
 purpose = "Write a short plan: objective, approach, risks, validation."
 writes = "plan.md"             # handoff artifact this stage produces
+# instructions = "…"           # optional deep guidance baked into /loadout:plan (see below)
 
 [[workflows.stages]]
 name = "implement"
@@ -138,16 +140,27 @@ purpose = "Build the change following the plan."
 reads = "plan.md"              # …consumed by a later stage
 
 [[workflows.stages]]
-name = "commit"                # `commit` maps onto the `verify` slot
-purpose = "Run build, tests, and linter, then commit at a logical checkpoint."
+name = "verify"
+purpose = "Run build, tests, and linter; review the diff before shipping."
 gate = true                    # a checkpoint to review before moving on (guidance only)
-exit = ["build, tests, and linter pass", "commit follows Conventional Commits"]
+exit = ["build, tests, and linter pass", "diff reviewed"]
+
+[[workflows.stages]]
+name = "commit"                # `commit` maps onto the `ship` slot
+purpose = "Commit at a logical checkpoint, push, and open the PR."
 ```
 
 - **`name` → slot:** matched case-insensitively against synonyms —
-  `research`/`investigate`→explore, `specify`/`spec`/`design`→brainstorm,
-  `iterate`/`code`/`build`→implement, `review`/`commit`/`ship`/`test`→verify. The
-  first stage to claim a slot wins; the rest of that slot's claimants are skipped.
+  `research`/`investigate`/`understand`/`scope`→explore,
+  `specify`/`spec`/`design`/`ideate`→brainstorm, `planning`/`decompose`→plan,
+  `iterate`/`code`/`build`/`execute`→implement, `review`/`test`/`validate`/`qa`→verify,
+  `commit`/`pr`/`push`/`deploy`/`release`/`merge`→ship. The first stage to claim a
+  slot wins; the rest of that slot's claimants are skipped.
+- **`purpose` vs `instructions`:** `purpose` is the one-line contract that goes in
+  the always-on `## Workflow` context section *and* the command body. `instructions`
+  is optional, deeper markdown injected **only** into that step's generated
+  `/loadout:<slot>` command — loaded on demand when the step runs, so its length is
+  free until then. The built-ins put each framework's full vendored skill here.
 - **`reads`/`writes`:** a bare filename (no path separators) under
   `.loadout/workflow/artifacts/`; pair a producer's `writes` with a consumer's
   `reads` to form a handoff.


### PR DESCRIPTION
## What

Docs-only (plus one gitignore line). Three commits:

- **docs(workflows): catch docs up to the six-slot spine and vendored catalog** — README, concepts, configuration, and architecture still described the five-command spine and the six-workflow catalog. They now match what v0.10/v0.11 actually ship: the `ship` slot (commit/push/PR split out of `verify`), the three vendored-verbatim built-ins (`superpowers`, `spec-driven`, `compound`; `lean`/`boris`/`loop` dropped), the per-stage `instructions` field (deep guidance only in the on-demand command body), the expanded slot-synonym table, starter packs binding a house workflow, and studio's **Library → Workflows** naming.
- **docs(cursor): skills install covers Cursor; note `/loadout-<slot>` naming** — Cursor reads `~/.agents/skills/` globally, so the embedded skills work there too; and the workflow spine lands as Cursor Skills, invoked `/loadout-explore` (dash, folder-derived) rather than `/loadout:explore`.
- **chore: gitignore the generated `.claude/commands/loadout/` dir**

## Verification

Prose checked against the code on main: `CANONICAL_SLOTS` has six entries incl. `ship` (`src/workflow.rs:272`), `commit`/`pr`/`push`/… map to `ship` (`src/workflow.rs:289`), built-ins are exactly `superpowers`/`spec-driven`/`compound` with `boris`/`lean`/`loop` gone (asserted in tests, `src/workflow.rs:775-778`), and active-workflow resolution lives at `Config::resolve_active_workflow` (`src/config.rs:275`). No code changes, so no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)