### PR TITLE
fix: don't warn when the default loadout applies off-repo

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -178,9 +178,12 @@ pub fn prepare_with_live(
     let selection = profile::select(&context, &config.profiles, remembered.as_ref());
     // On a real render (not a read-only inspection), tell the user when nothing
     // matched — either falling back to a no-targets default profile, or noting
-    // the empty overlay and how to fix it.
+    // the empty overlay and how to fix it. Off-repo the default fallback IS the
+    // expected path (running in $HOME etc.), so only in-repo warrants a warning;
+    // the render step line already names the loadout used either way.
     if live {
         match &selection {
+            Selection::Default(_) if context.scope() == context::Scope::Machine => {}
             Selection::Default(p) => crate::warn_user!(
                 "no loadout targets this project ({}); using the default loadout '{}' \
                  (it declares no targets).",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -300,6 +300,57 @@ fn refresh_in_non_repo_writes_overlay_but_no_gitignore() {
 }
 
 #[test]
+fn refresh_off_repo_uses_default_loadout_quietly() {
+    // Off-repo, falling back to the no-targets default loadout is the expected
+    // path (e.g. `load claude` in $HOME) — no warning, just the render line.
+    let fx = Fixture::new(); // deliberately NOT a git repo
+    fx.rust_project(); // detection still finds languages/stacks off-repo
+    fx.author(
+        "[[fragments]]\n\
+         id = \"machine-basics\"\n\
+         guidance = \"Machine-wide guidance.\"\n\
+         \n\
+         [[loadouts]]\n\
+         name = \"machine\"\n\
+         fragments = [\"machine-basics\"]\n",
+    );
+
+    fx.cmd()
+        .args(["refresh", "--agent", "claude"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("machine"))
+        .stderr(predicate::str::contains("no loadout targets").not());
+}
+
+#[test]
+fn refresh_in_repo_warns_when_falling_back_to_default() {
+    // In a repo the same fallback IS worth a warning: detection found stacks
+    // but no loadout targets them, which may be a misconfiguration.
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.git_init();
+    fx.author(
+        "[[fragments]]\n\
+         id = \"machine-basics\"\n\
+         guidance = \"Machine-wide guidance.\"\n\
+         \n\
+         [[loadouts]]\n\
+         name = \"machine\"\n\
+         fragments = [\"machine-basics\"]\n",
+    );
+
+    fx.cmd()
+        .args(["refresh", "--agent", "claude"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "no loadout targets this project",
+        ))
+        .stderr(predicate::str::contains("default loadout 'machine'"));
+}
+
+#[test]
 fn refresh_at_home_withholds_the_bleeding_importer() {
     // When repo_base is $HOME, a managed CLAUDE.local.md there would be inherited
     // by every repo underneath it (agents walk the tree upward) — the "bleed".

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -344,9 +344,7 @@ fn refresh_in_repo_warns_when_falling_back_to_default() {
         .args(["refresh", "--agent", "claude"])
         .assert()
         .success()
-        .stderr(predicate::str::contains(
-            "no loadout targets this project",
-        ))
+        .stderr(predicate::str::contains("no loadout targets this project"))
         .stderr(predicate::str::contains("default loadout 'machine'"));
 }
 


### PR DESCRIPTION
## Problem

Every live render (`run`/`refresh`) printed a `warning:` whenever selection fell back to the no-targets default loadout — including off-repo, where that fallback is exactly the designed behavior:

```
~ ❯ load claude
warning: no loadout targets this project (language Go/JavaScript/…, off-repo); using the default loadout 'machine' (it declares no targets).
  ✓ render  machine → claude · sha256:ba5110fe9e20…
```

Off-repo there is no project for a loadout to target, so warning about the default kicking in is noise. The render step line already names the loadout used.

## Fix

Skip the default-fallback warning when the detected scope is off-repo (`Scope::Machine`). In-repo the warning stays — there it genuinely signals "detection found stacks but no loadout targets them," which may be a config gap.

## Tests

- `refresh_off_repo_uses_default_loadout_quietly` — off-repo render with a no-targets default stays quiet
- `refresh_in_repo_warns_when_falling_back_to_default` — in-repo fallback still warns

Full suite green (310 lib + 90 cli), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)