### PR TITLE
feat(workflow): plan-slot commands always carry the visual-preview flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to loadout are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
+## Unreleased
+
+### Added
+
+- **Every workflow's plan stage now produces the visual plan preview.** The
+  generated plan-slot command (`/loadout:plan`, whatever the workflow names
+  the stage) tells the agent to also emit `plan.json`, validate it with
+  `load plan check`, and open the review page with `load plan render` —
+  including the sibling-file recipe when `plan.json` already holds a
+  different pending plan. Previously this flow lived only in the
+  `loadout-plan-preview` skill, and silently disappeared in sessions where
+  the skill didn't surface. The always-on workflow section adds a one-line
+  offer covering plans written outside the workflow commands.
+
 ## 0.14.1 — 2026-07-09
 
 Follow-ups from the first real-world use of the plan preview (a 23-task plan

--- a/src/adapters/commands.rs
+++ b/src/adapters/commands.rs
@@ -30,6 +30,20 @@ pub(crate) const SECURITY_CHECKLIST_INTRO: &str =
     "Also run a security review of the change. The checklist below is a vendored security-review prompt — gather the branch's git status/diff/log yourself where it references them, then work through it:";
 /// Vendored security-review prompt — see vendored/sources.toml (`security-review`).
 const SECURITY_CHECKLIST: &str = include_str!("../../vendored/security-review/security-review.md");
+/// Appended to every plan-slot command body (channel 2), whatever the stage is
+/// named — so each workflow's plan step also produces the visual plan preview.
+/// Depends only on the `load` binary, deliberately NOT on the
+/// `loadout-plan-preview` skill being surfaced: the observed failure mode is a
+/// session where the skill never enters the agent's context, and this line is
+/// what keeps the flow alive there.
+pub(crate) const PLAN_PREVIEW_EPILOGUE: &str = "\
+Also produce the visual plan preview: emit `.loadout/workflow/artifacts/plan.json` \
+(the format is printed by `load plan schema`), run `load plan check --json` and fix \
+errors until clean, then `load plan render` to open the review page in the user's \
+browser. If plan.json already holds a different pending plan, don't overwrite it — \
+write a sibling `plan-<topic>.json` instead and render it with `load plan render \
+.loadout/workflow/artifacts/plan-<topic>.json --out .loadout/generated/plan-<topic>.html`. \
+The `loadout-plan-preview` skill carries the full authoring guidance when available.";
 
 /// On-disk format for an agent's command files.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -220,6 +234,13 @@ fn stage_body(
         }
         s.push('\n');
     }
+    // Visual-plan enrichment for the plan slot: the stage also emits the
+    // machine-readable plan and renders the review page. Keyed off the
+    // canonical command, so a workflow's "planning"/"decompose" stage gets it
+    // too (channel 2 only, by the same standing rule as verify below).
+    if command == "plan" {
+        let _ = writeln!(s, "{PLAN_PREVIEW_EPILOGUE}\n");
+    }
     // Security enrichment for the verify slot: prefer the agent's native
     // review commands; otherwise embed the vendored checklist (channel 2
     // only — the always-on context carries summaries, by standing rule).
@@ -372,6 +393,53 @@ mod tests {
         assert!(!verify.content.contains("second verify claimant")); // qa folded away
         let ship = cmds.iter().find(|c| c.filename == "ship.md").unwrap();
         assert!(ship.content.contains("commit and push")); // commit kept its own slot
+    }
+
+    #[test]
+    fn plan_slot_commands_carry_the_visual_preview_epilogue() {
+        // Built-ins: every workflow's plan-slot command gets the epilogue…
+        for id in ["superpowers", "spec-driven"] {
+            let cmds = stage_commands(&builtin(id), CommandFormat::Markdown, &[]);
+            let plan = cmds.iter().find(|c| c.filename == "plan.md").unwrap();
+            assert!(
+                plan.content.contains(PLAN_PREVIEW_EPILOGUE),
+                "{id} plan command must carry the preview epilogue"
+            );
+            // …and only the plan slot does.
+            for c in cmds.iter().filter(|c| c.filename != "plan.md") {
+                assert!(
+                    !c.content.contains("load plan check"),
+                    "{} must not carry the plan epilogue",
+                    c.filename
+                );
+            }
+        }
+        // A custom workflow whose plan stage is named `decompose` still fills
+        // the plan slot, so it gets the epilogue too — that's the point of
+        // keying off the canonical command, not the stage name.
+        let wf = Workflow {
+            id: "x".into(),
+            name: Some("X".into()),
+            description: None,
+            icon: None,
+            stages: vec![WorkflowStage {
+                name: "decompose".into(),
+                purpose: Some("break it down".into()),
+                instructions: None,
+                reads: None,
+                writes: None,
+                gate: false,
+                exit: vec![],
+            }],
+            modeled_on: None,
+            researched: None,
+            source: None,
+            disabled: false,
+            origin: crate::fragment::Layer::Global,
+        };
+        let cmds = stage_commands(&wf, CommandFormat::Markdown, &[]);
+        let plan = cmds.iter().find(|c| c.filename == "plan.md").unwrap();
+        assert!(plan.content.contains(PLAN_PREVIEW_EPILOGUE));
     }
 
     #[test]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -441,6 +441,16 @@ pub fn render_workflow_section(wf: &Workflow) -> String {
             let _ = writeln!(s, "   - done when: {item}");
         }
     }
+    // The catch-all for plans produced OUTSIDE the plan-stage command (plan
+    // mode, ad-hoc asks): one always-on sentence offering the visual preview.
+    // The plan-slot command body carries the full directive (channel 2); this
+    // is deliberately just an offer, kept to a single line.
+    let _ = writeln!(
+        s,
+        "\nWhenever you produce an implementation plan — via these stages or not — \
+         offer the user a visual plan preview: emit plan.json per `load plan schema`, \
+         validate with `load plan check`, then open it with `load plan render`."
+    );
     s.trim_end().to_string()
 }
 
@@ -683,6 +693,11 @@ mod tests {
         assert!(out.content.contains("**plan**"));
         assert!(out.content.contains("writes `plan.md`"));
         assert!(out.content.contains("reads `plan.md`"));
+        // The always-on catch-all: plans produced outside the plan-stage
+        // command still get offered the visual preview (one line, an offer —
+        // the full directive lives in the plan command body, channel 2).
+        assert!(out.content.contains("offer the user a visual plan preview"));
+        assert!(out.content.contains("`load plan schema`"));
         // It rides inside profile_guidance, after the fragment conventions.
         assert!(out.profile_guidance.contains("### baseline"));
         let frag_at = out.profile_guidance.find("### baseline").unwrap();


### PR DESCRIPTION
## What

Every workflow's generated plan-stage command (`/loadout:plan`, whatever the stage is named — `plan`/`planning`/`decompose` all fill the canonical slot) now instructs the agent to also emit `plan.json`, validate it with `load plan check --json`, and open the review page with `load plan render` — including the sibling-file recipe when `plan.json` already holds a different pending plan. The always-on `## Workflow` context section adds a one-line offer covering plans written outside the stage commands.

## Why

The visual-plan flow previously lived only in the `loadout-plan-preview` skill ("the skill owns this flow", plan-visualizer design Q2). Observed failure mode: a session where the skill never surfaced produced a markdown-only plan in this repo — the flow silently degraded. The command epilogue depends only on the `load` binary, so it survives skill discovery failing; the skill remains the deep authoring reference.

Channel discipline is preserved: the full directive lives in the per-stage command body (channel 2, zero always-on cost — same pattern as the verify slot's security enrichment); the always-on section carries exactly one sentence, phrased as an offer.

## Testing

- New test: plan-slot commands across built-ins (superpowers, spec-driven) AND a custom workflow whose plan stage is named `decompose` all carry the epilogue; non-plan stages don't.
- Workflow-section test asserts the always-on offer line.
- Full suite green (389 lib at the time of the branch + all integration suites), clippy `-D warnings`, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016amFfPpPPpSGTpSRpYTE3p