### PR TITLE
fix(render): bump HEADER_VERSION so the workflow-section wording deploys

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -174,7 +174,7 @@ pub fn overlay_fingerprint(
 /// of the context, so without this a wording change would never reach
 /// already-rendered overlays — the hash-skip would keep them forever.
 /// Bumping re-renders every overlay exactly once.
-const HEADER_VERSION: u32 = 2;
+const HEADER_VERSION: u32 = 3;
 
 /// Render an overlay for `req`.
 pub fn render(req: &RenderRequest) -> crate::Result<RenderOutput> {


### PR DESCRIPTION
PR #24's always-on visual-preview offer line sits in the generated `## Workflow` section, behind the overlay fingerprint — which covers context/composition/workflow definition, not generator wording. `HEADER_VERSION` exists for exactly this case (its own doc comment says so); bumping 2→3 makes every overlay re-render exactly once on the next refresh, deploying the new section text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016amFfPpPPpSGTpSRpYTE3p