### PR TITLE
feat(studio): Recents rows carry a kind chip

### DIFF
--- a/src/studio/assets/studio.css
+++ b/src/studio/assets/studio.css
@@ -915,3 +915,4 @@ pre.error { color: var(--error-fg); padding: 16px; font-family: var(--mono); whi
 .recent-badge.stale { color: var(--warn, #b45309); border-color: currentColor; }
 .recent-badge.missing { color: var(--muted, #888); }
 .recent-remove { flex: none; }
+.recent-kind-label { font-size: 0.7em; text-transform: uppercase; letter-spacing: 0.06em; padding: 0.15em 0.55em; border: 1px solid var(--border); border-radius: 999px; color: var(--muted); flex: none; }

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -2599,6 +2599,10 @@ mod tests {
         let r = route(&st, &req("GET", "/tab/recents", "", &[HOST, COOKIE], ""));
         let body = String::from_utf8(r.body).unwrap();
         assert!(body.contains("Demo plan"));
+        // The kind renders as text, not just an icon — with several artifact
+        // kinds side by side the chip is what tells them apart.
+        assert!(body.contains("recent-kind-label"));
+        assert!(body.contains(">plan</span>"));
         assert!(body.contains(&format!("/artifacts/{id}")));
         assert!(body.contains("target=\"_blank\""));
         assert!(body.contains("rel=\"noopener\""));

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -1405,6 +1405,12 @@ pub fn recents_tab_fragment(rows: &[RecentRow], readonly: bool) -> String {
                     @for r in rows {
                         li class=(if r.available { "recent-row" } else { "recent-row recent-unavailable" }) {
                             span class="recent-kind" { (icon(if r.kind == "plan" { "layers" } else { "file" })) }
+                            // The kind, as TEXT — the icon alone is illegible
+                            // as an indicator once several artifact kinds
+                            // (plans, design docs, …) live side by side.
+                            // Unknown kinds label themselves automatically:
+                            // this renders the entry's own kind string.
+                            span class="recent-kind-label" { (r.kind) }
                             @if r.available {
                                 a class="recent-title" href={ "/artifacts/" (r.id) } target="_blank" rel="noopener" { (r.title) }
                             } @else {


### PR DESCRIPTION
The Recents row's only kind indicator was the small leading icon — illegible as a discriminator once several artifact kinds (plans, design docs, …) sit side by side. Each row now renders a text chip with the entry's own `kind` string (the registry has carried `kind` since day one, exactly for this). Unknown/future kinds label themselves automatically — a `design` renderer that records `kind: "design"` gets a labeled, served, listed row with zero UI changes.

Route test extended to assert the chip renders. Verified visually with a seeded two-kind registry (plan + design side by side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016amFfPpPPpSGTpSRpYTE3p