### PR TITLE
test(cli): cover launch arg passthrough for bare and run forms

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -441,3 +441,93 @@ pub struct CleanArgs {
     #[arg(long)]
     pub agent: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_launch_captures_everything_after_agent_verbatim() {
+        // `load claude agents --resume …`: nothing after the agent token is
+        // parsed by load — even flags that collide with RunArgs' own.
+        let cli = Cli::try_parse_from([
+            "load",
+            "claude",
+            "agents",
+            "--resume",
+            "--workflow",
+            "w",
+            "--skip-render",
+        ])
+        .unwrap();
+        let Command::Launch(argv) = cli.command else {
+            panic!("expected Command::Launch, got {:?}", cli.command);
+        };
+        assert_eq!(
+            argv,
+            [
+                "claude",
+                "agents",
+                "--resume",
+                "--workflow",
+                "w",
+                "--skip-render"
+            ]
+        );
+    }
+
+    #[test]
+    fn from_launch_splits_agent_from_passthrough_args() {
+        let args = RunArgs::from_launch(vec![
+            "claude".to_string(),
+            "agents".to_string(),
+            "--resume".to_string(),
+        ]);
+        assert_eq!(args.agent, "claude");
+        assert_eq!(args.args, ["agents", "--resume"]);
+        assert!(!args.skip_render);
+        assert!(args.workflow.is_none());
+    }
+
+    #[test]
+    fn from_launch_tolerates_empty_argv() {
+        let args = RunArgs::from_launch(Vec::new());
+        assert_eq!(args.agent, "");
+        assert!(args.args.is_empty());
+    }
+
+    #[test]
+    fn run_form_parses_own_flags_after_agent() {
+        // Unlike the bare form, `load run <agent>` still parses RunArgs flags
+        // placed after the agent id — they do NOT pass through …
+        let cli = Cli::try_parse_from(["load", "run", "claude", "--workflow", "w"]).unwrap();
+        let Command::Run(args) = cli.command else {
+            panic!("expected Command::Run, got {:?}", cli.command);
+        };
+        assert_eq!(args.agent, "claude");
+        assert_eq!(args.workflow.as_deref(), Some("w"));
+        assert!(args.args.is_empty());
+    }
+
+    #[test]
+    fn run_form_double_dash_forwards_colliding_flags() {
+        // … and `--` is the escape hatch that forwards them to the agent.
+        let cli = Cli::try_parse_from(["load", "run", "claude", "--", "--workflow", "w"]).unwrap();
+        let Command::Run(args) = cli.command else {
+            panic!("expected Command::Run, got {:?}", cli.command);
+        };
+        assert_eq!(args.agent, "claude");
+        assert!(args.workflow.is_none());
+        assert_eq!(args.args, ["--workflow", "w"]);
+    }
+
+    #[test]
+    fn run_form_passes_unknown_flags_through() {
+        // Flags load doesn't define reach the agent even without `--`.
+        let cli = Cli::try_parse_from(["load", "run", "claude", "--resume"]).unwrap();
+        let Command::Run(args) = cli.command else {
+            panic!("expected Command::Run, got {:?}", cli.command);
+        };
+        assert_eq!(args.args, ["--resume"]);
+    }
+}

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -656,3 +656,103 @@ fn launch(
         std::process::exit(status.code().unwrap_or(1));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::commands::Prepared;
+    use crate::config::Config;
+    use crate::context::{ProjectCommands, SystemContext};
+
+    /// A minimal `Prepared` — no profile applies (label "none"), which is all
+    /// `build_launch_args` reads from it.
+    fn prepared() -> Prepared {
+        Prepared {
+            repo_base: PathBuf::from("/repo"),
+            config: Config::defaults(),
+            context: Context {
+                cwd: PathBuf::from("/repo"),
+                repo_base: PathBuf::from("/repo"),
+                repo_name: None,
+                git: None,
+                languages: Vec::new(),
+                stacks: Vec::new(),
+                package_managers: Vec::new(),
+                custom_targets: Vec::new(),
+                commands: ProjectCommands::default(),
+                system: SystemContext {
+                    os: "test-os".to_string(),
+                    arch: "test-arch".to_string(),
+                    hostname: "test-host".to_string(),
+                    user: "test-user".to_string(),
+                    parent_process: None,
+                    host_class: None,
+                },
+                env: Default::default(),
+            },
+            composition: Default::default(),
+        }
+    }
+
+    fn descriptor(id: &str) -> AgentDescriptor {
+        adapters::builtin_agents()
+            .into_iter()
+            .find(|d| d.id == id)
+            .unwrap_or_else(|| panic!("no built-in agent '{id}'"))
+    }
+
+    fn rendered() -> ApplyResult {
+        ApplyResult {
+            files: Vec::new(),
+            warnings: Vec::new(),
+            notes: Vec::new(),
+            context_hash: "sha256:test".to_string(),
+            profile_guidance: String::new(),
+            wiring_suppressed: false,
+        }
+    }
+
+    #[test]
+    fn user_args_follow_the_injected_freshness_flag() {
+        let d = descriptor("claude");
+        let flag = d
+            .append_prompt_flag
+            .clone()
+            .expect("claude injects a prompt flag");
+        let user = vec!["agents".to_string(), "--resume".to_string()];
+        let out = build_launch_args(
+            &d,
+            &prepared(),
+            Some(&rendered()),
+            "2026-07-11T00:00:00Z",
+            &user,
+        );
+        assert_eq!(out[0], flag);
+        assert!(
+            out[1].contains("context refreshed"),
+            "expected the freshness note, got: {}",
+            out[1]
+        );
+        assert_eq!(out[2..], user[..]);
+    }
+
+    #[test]
+    fn agents_without_prompt_flag_get_pure_passthrough() {
+        let d = descriptor("codex");
+        assert!(d.append_prompt_flag.is_none());
+        let user = vec!["exec".to_string(), "--full-auto".to_string()];
+        let out = build_launch_args(&d, &prepared(), Some(&rendered()), "t", &user);
+        assert_eq!(out, user);
+    }
+
+    #[test]
+    fn skipped_render_still_passes_user_args() {
+        // `--skip-render` → no ApplyResult → no injected note, args intact.
+        let d = descriptor("claude");
+        let user = vec!["--resume".to_string()];
+        let out = build_launch_args(&d, &prepared(), None, "t", &user);
+        assert_eq!(out, user);
+    }
+}


### PR DESCRIPTION
## What

Adds regression tests (no production changes) for how `load` forwards arguments to launched agents:

**`src/cli.rs`** — parsing behavior:
- `load claude agents --resume --workflow w --skip-render` → the external subcommand captures everything after the agent id verbatim, even flags that collide with `RunArgs`' own.
- `RunArgs::from_launch` splits the agent id from passthrough args; tolerates empty argv.
- The explicit `load run <agent>` form diverges from the bare form: flags load defines (`--workflow`, …) are consumed after the agent id, unknown flags (`--resume`) pass through, and `--` forwards everything after it.

**`src/commands/run.rs`** — `build_launch_args` ordering:
- The injected `--append-system-prompt` freshness note comes first; user args follow unmodified.
- Agents without a prompt flag (codex) get pure passthrough.
- `--skip-render` (no `ApplyResult`) still passes user args intact.

## Why

`load claude agents` (and any flags after the agent id) must keep reaching the agent untouched — this is now load's primary launch path. The behavior existed since `7688331` but had zero test coverage, and the bare-form/run-form divergence was undocumented. These tests pin both down so a future clap upgrade or `RunArgs` change can't silently break them.

## Validation

- `cargo test --lib` — 421 passed (9 new)
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133HbopAWSHkC77HTqZ8Di9