### PR TITLE
feat: npx @ellery/loadout — consent-gated npm bootstrapper + studio exit epilogue

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,46 @@
+# Publishes the @ellery/loadout npx bootstrapper when npm/ changes on main.
+# The package is version-independent of the CLI (it always installs the latest
+# release via the shell installer), so it only needs republishing when the
+# bootstrapper itself changes — bump npm/package.json's version to trigger it.
+# Publishing is idempotent: an already-published version is skipped, not an error.
+name: npm-publish
+
+on:
+  push:
+    branches: [main]
+    paths: ["npm/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - name: Smoke-test the bootstrapper
+        working-directory: npm
+        run: |
+          node --check bin/loadout.js
+          # Non-interactive + not installed must refuse politely (exit 1) and
+          # point at the manual curl command — never attempt a silent install.
+          if HOME="$(mktemp -d)" CARGO_HOME="$(mktemp -d)" node bin/loadout.js studio </dev/null; then
+            echo "expected a refusal in non-interactive mode" && exit 1
+          fi
+      - name: Publish if this version is not on the registry yet
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          PKG="$(node -p "require('./package.json').name")"
+          VER="$(node -p "require('./package.json').version")"
+          if npm view "$PKG@$VER" version >/dev/null 2>&1; then
+            echo "$PKG@$VER is already published — skipping."
+          else
+            npm publish
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ All notable changes to loadout are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
+## Unreleased
+
+### Added
+
+- **`npx @ellery/loadout`** — a new npm bootstrapper package (in `npm/`). One
+  command tries loadout without a prior install: if the `load` binary is
+  present it delegates straight to it; if not, it states exactly what the
+  official installer will do (binary into `~/.cargo/bin`, PATH entry, update
+  receipt) and asks for consent before installing — never silently, and never
+  in non-interactive terminals, where it prints the manual `curl` command
+  instead. `npx @ellery/loadout studio` is the advertised one-liner: install
+  (with consent) and open the studio in one step.
+- **Studio exit epilogue** — stopping the studio (Ctrl-C or idle timeout) now
+  prints what to type next (`load claude`, and how to reopen the studio)
+  instead of dead-ending at an empty prompt. Ctrl-C is now a clean shutdown:
+  the per-port runtime file is removed instead of leaked.
+
+### Changed
+
+- The studio's guided-onboarding finish card now shows the short launch form
+  (`load claude`) instead of `load run claude` — one spelling everywhere.
+
 ## 0.16.0 — 2026-07-12
 
 Loadout can now learn from your own agent sessions. **Ambient learning** is

--- a/README.md
+++ b/README.md
@@ -21,13 +21,19 @@ Works with **Claude, Codex, Gemini, Cursor, opencode, and Copilot**. Your contex
 
 ## Quick start
 
-Install the prebuilt binary — no Rust toolchain needed:
+If you have Node, one command installs the CLI (it asks first) and opens the studio:
+
+```bash
+npx @ellery/loadout studio
+```
+
+Or install the prebuilt binary directly — no Rust toolchain needed:
 
 ```bash
 curl -LsSf https://github.com/elleryfamilia/loadout/releases/latest/download/loadout-installer.sh | sh
 ```
 
-Open the studio and equip a **starter pack** — it detects your stack and recommends one, so you have a working loadout before you've written a word:
+In the studio, equip a **starter pack** — it detects your stack and recommends one, so you have a working loadout before you've written a word. Reopen it anytime:
 
 ```bash
 load studio
@@ -292,6 +298,12 @@ Prebuilt binary — no Rust toolchain needed (macOS and Linux; on Windows use WS
 curl -LsSf https://github.com/elleryfamilia/loadout/releases/latest/download/loadout-installer.sh | sh
 ```
 
+Via npm — [`@ellery/loadout`](https://www.npmjs.com/package/@ellery/loadout) is a thin bootstrapper that runs the same installer after showing you what it will do and asking for consent, then hands off to the `load` CLI (so `npx @ellery/loadout studio` on a machine that already has loadout just opens the studio):
+
+```bash
+npx @ellery/loadout studio
+```
+
 Installer-based installs update in place with `load update`. From source:
 
 ```bash
@@ -302,8 +314,9 @@ cargo install --git https://github.com/elleryfamilia/loadout
 
 - **GitHub releases** — <https://github.com/elleryfamilia/loadout/releases>: the prebuilt binaries and the installer script above, built by cargo-dist from tagged commits of this repo.
 - **This repo, from source** — the `cargo install --git …` line above, or a clone and `cargo build`.
+- **npm** — [`@ellery/loadout`](https://www.npmjs.com/package/@ellery/loadout): contains no binaries; with your consent it runs the installer script from the GitHub releases above, then delegates to the installed `load`.
 
-An npm installer is planned and will be announced here when it ships. There is no official Homebrew tap or third-party package today.
+There is no official Homebrew tap or other third-party package today.
 
 ---
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,28 @@
+# @ellery/loadout
+
+npx installer and launcher for [loadout](https://github.com/elleryfamilia/loadout) —
+the adaptive context layer for AI coding agents (Claude Code, Cursor, Codex,
+Gemini, opencode).
+
+```bash
+npx @ellery/loadout studio
+```
+
+If the `load` binary is already installed, this delegates to it directly. If it
+isn't, it explains what the official installer will do — download the prebuilt
+`load` binary from GitHub Releases, place it in `~/.cargo/bin`, add that
+directory to your PATH if needed, and write an install receipt so `load update`
+works — and asks for consent before doing anything. In non-interactive
+terminals it installs nothing and prints the manual `curl` command instead.
+
+After the one-time install, use `load` directly — no npx needed:
+
+```bash
+load studio    # set up your loadout in the browser
+load claude    # launch Claude Code with your context equipped
+```
+
+This package contains no binaries and has no dependencies; it is a thin
+bootstrapper for the real CLI. macOS and Linux only (on Windows, use WSL).
+
+Docs, source, and issues: https://github.com/elleryfamilia/loadout

--- a/npm/bin/loadout.js
+++ b/npm/bin/loadout.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// npx bootstrapper for loadout. If the `load` binary is already installed,
+// delegate to it. If not, explain exactly what the official installer will do,
+// ask for consent (interactive terminals only), install, then delegate.
+//
+// This package deliberately contains no binaries and has no dependencies: it
+// is an installer/launcher, not the product. The product is the `load` CLI.
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const readline = require('node:readline');
+
+const INSTALLER_URL =
+  'https://github.com/elleryfamilia/loadout/releases/latest/download/loadout-installer.sh';
+
+// Install locations the official installer uses (cargo-home layout today;
+// ~/.local/bin kept as a fallback in case the dist config changes).
+function candidateDirs() {
+  const home = os.homedir();
+  const cargoHome = process.env.CARGO_HOME || path.join(home, '.cargo');
+  return [path.join(cargoHome, 'bin'), path.join(home, '.local', 'bin')];
+}
+
+// PATH first; then the known install dirs, which covers the fresh-install case
+// where the current shell hasn't picked up the PATH change yet.
+function findLoad() {
+  const which = spawnSync('which', ['load'], { encoding: 'utf8' });
+  if (which.status === 0) {
+    const p = which.stdout.trim().split('\n')[0];
+    if (p) return p;
+  }
+  for (const dir of candidateDirs()) {
+    const p = path.join(dir, 'load');
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+// Hand off to the real binary. SIGINT must reach only the child (e.g. Ctrl-C
+// stopping `load studio` prints its exit message); a no-op listener keeps this
+// wrapper alive until the child exits, then the child's status is mirrored.
+function delegate(bin, args) {
+  process.on('SIGINT', () => {});
+  const r = spawnSync(bin, args, { stdio: 'inherit' });
+  process.exit(r.status === null ? 1 : r.status);
+}
+
+function fail(msg) {
+  process.stderr.write(`${msg}\n`);
+  process.exit(1);
+}
+
+function confirm(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      const a = answer.trim().toLowerCase();
+      resolve(a === '' || a === 'y' || a === 'yes');
+    });
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const manual = `To install manually instead:\n\n  curl -LsSf ${INSTALLER_URL} | sh\n`;
+
+  if (process.platform === 'win32') {
+    fail('loadout is unix-only today (macOS and Linux). On Windows, run it inside WSL.');
+  }
+
+  const existing = findLoad();
+  if (existing) delegate(existing, args);
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    fail(
+      'loadout is not installed, and this is not an interactive terminal, ' +
+        `so no consent prompt can be shown.\n${manual}`
+    );
+  }
+
+  const installDir = candidateDirs()[0];
+  process.stdout.write(
+    `loadout is not installed yet. This runs the official installer, which:\n\n` +
+      `  - downloads the prebuilt \`load\` binary for your platform (GitHub Releases)\n` +
+      `  - places it in ${installDir}\n` +
+      `  - adds that directory to your PATH (shell rc files) if it isn't already\n` +
+      `  - writes an install receipt so \`load update\` can update it in place\n\n` +
+      `Remove later with: rm ${path.join(installDir, 'load')}\n\n`
+  );
+  const ok = await confirm('Install load? [Y/n] ');
+  if (!ok) {
+    process.stdout.write(`\nNothing installed.\n${manual}`);
+    process.exit(1);
+  }
+  process.stdout.write('\n');
+
+  const inst = spawnSync('sh', ['-c', `curl -LsSf ${INSTALLER_URL} | sh`], { stdio: 'inherit' });
+  if (inst.status !== 0) {
+    fail('\nThe installer did not complete. Nothing was launched.');
+  }
+
+  const bin = findLoad();
+  if (!bin) {
+    fail(
+      'Install finished, but the `load` binary was not found in the expected ' +
+        `locations (${candidateDirs().join(', ')}). Open a new shell and try \`load --help\`.`
+    );
+  }
+
+  process.stdout.write(
+    `\nInstalled: ${bin}\n` +
+      'From now on, use `load` directly — no npx needed. New shells have it on PATH.\n\n'
+  );
+
+  if (args.length === 0) {
+    process.stdout.write(
+      'Next steps:\n\n' +
+        '  load studio    set up your loadout in the browser\n' +
+        '  load claude    launch Claude Code with your context equipped\n' +
+        '                 (also: load cursor, load codex, load gemini, load opencode)\n'
+    );
+    process.exit(0);
+  }
+  delegate(bin, args);
+}
+
+main();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@ellery/loadout",
+  "version": "0.1.0",
+  "description": "Installer and launcher for loadout — the adaptive context layer for AI coding agents (Claude Code, Cursor, Codex, Gemini, opencode). Asks before installing the `load` binary, then delegates to it.",
+  "bin": {
+    "loadout": "bin/loadout.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elleryfamilia/loadout.git",
+    "directory": "npm"
+  },
+  "homepage": "https://github.com/elleryfamilia/loadout#readme",
+  "bugs": {
+    "url": "https://github.com/elleryfamilia/loadout/issues"
+  },
+  "keywords": [
+    "claude",
+    "claude-code",
+    "cursor",
+    "codex",
+    "gemini",
+    "opencode",
+    "ai-agents",
+    "context",
+    "agents-md",
+    "claude-md",
+    "cli"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -1954,7 +1954,7 @@ fn handle_apply(state: &Arc<Mutex<StudioState>>) -> Resp {
     match result {
         Ok(written) => {
             // Guided first-run: a profile actually landed → show the "you're set"
-            // finish card (names `load run <agent>`), then disarm the flow. If
+            // finish card (names `load <agent>`), then disarm the flow. If
             // nothing composed a profile, fall through to the normal flash.
             if let Some(summary) = onboarding {
                 state.lock().unwrap().onboarding_active = false;
@@ -2162,9 +2162,22 @@ pub fn serve(rt: &Runtime, args: &StudioArgs) -> crate::Result<()> {
         None => {}
     }
 
+    install_shutdown_handler();
     serve_loop(&server, &state, idle);
     remove_runtime_file(port);
+    print_next_steps();
     Ok(())
+}
+
+/// The terminal is the first thing a user sees after closing the studio; say
+/// what to type next so setup doesn't dead-end at an empty prompt.
+fn print_next_steps() {
+    println!();
+    println!("Your loadout is saved. Launch an agent with it from any project:");
+    println!();
+    println!("  load claude    (also: load cursor, load codex, load gemini, load opencode)");
+    println!();
+    println!("Reopen the studio anytime: load studio");
 }
 
 // --- runtime file: re-attach to an already-running instance ------------------
@@ -2317,30 +2330,50 @@ fn probe_studio(port: u16, token: &str) -> bool {
     status_ok && sets_cookie
 }
 
-/// The request loop. With a zero `idle` window it blocks until Ctrl-C; otherwise
-/// it polls so it can notice inactivity and shut the server down on its own. Any
+/// Set by the SIGINT/SIGTERM handler and polled by [`serve_loop`], so Ctrl-C
+/// exits through the normal path — runtime-file cleanup and the next-steps
+/// epilogue — instead of killing the process mid-request.
+static SHUTDOWN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+extern "C" fn on_shutdown_signal(sig: libc::c_int) {
+    SHUTDOWN.store(true, std::sync::atomic::Ordering::SeqCst);
+    // Restore the default disposition so a second Ctrl-C force-kills rather
+    // than being swallowed. Both calls here are async-signal-safe.
+    unsafe { libc::signal(sig, libc::SIG_DFL) };
+}
+
+/// Route Ctrl-C (and `kill`) through [`SHUTDOWN`]. Only [`serve`] installs
+/// this — tests drive [`serve_loop`]'s internals directly and must not have
+/// their signal dispositions changed.
+fn install_shutdown_handler() {
+    let handler = on_shutdown_signal as *const () as libc::sighandler_t;
+    unsafe {
+        libc::signal(libc::SIGINT, handler);
+        libc::signal(libc::SIGTERM, handler);
+    }
+}
+
+/// The request loop. Wakes about once a second — often enough that a Ctrl-C
+/// (which only sets [`SHUTDOWN`]; the handler can't do the cleanup itself) is
+/// noticed promptly, cheap enough to not matter — and, when an `idle` window is
+/// set, shuts the server down on its own after that much inactivity. Any
 /// handled request resets the clock — there's no background browser polling, so
 /// "no requests" genuinely means the user has stepped away.
 fn serve_loop(server: &tiny_http::Server, state: &Arc<Mutex<StudioState>>, idle: Duration) {
+    use std::sync::atomic::Ordering;
     use std::time::Instant;
     let handle = |request: &mut tiny_http::Request| {
         let req = read_request(request);
         route(state, &req)
     };
 
-    if idle.is_zero() {
-        for mut request in server.incoming_requests() {
-            let resp = handle(&mut request);
-            let _ = respond(request, resp);
-        }
-        return;
-    }
-
-    // Wake at least once a minute (and never coarser than the window itself) so a
-    // 30-minute timeout fires within ~a minute of the deadline.
-    let poll = idle.min(Duration::from_secs(60));
+    let poll = Duration::from_secs(1);
     let mut last = Instant::now();
     loop {
+        if SHUTDOWN.load(Ordering::SeqCst) {
+            println!("\nload studio: stopped.");
+            return;
+        }
         match server.recv_timeout(poll) {
             Ok(Some(mut request)) => {
                 last = Instant::now();
@@ -2348,13 +2381,19 @@ fn serve_loop(server: &tiny_http::Server, state: &Arc<Mutex<StudioState>>, idle:
                 let _ = respond(request, resp);
             }
             Ok(None) => {
-                if last.elapsed() >= idle {
+                if !idle.is_zero() && last.elapsed() >= idle {
                     println!("load studio: idle — shutting down.");
                     return;
                 }
             }
-            // A receive error means the listener is unusable; stop rather than spin.
+            // A receive error normally means the listener is unusable — but the
+            // shutdown signal itself can interrupt the receive, and that's a
+            // clean exit, not a failure.
             Err(e) => {
+                if SHUTDOWN.load(Ordering::SeqCst) {
+                    println!("\nload studio: stopped.");
+                    return;
+                }
                 eprintln!("load studio: server error ({e}); shutting down.");
                 return;
             }

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -2275,7 +2275,8 @@ pub fn onboarding_review(summary: &crate::studio::state::StagedSummary) -> Strin
 
 /// Beat 3 of the guided first-run: after Apply, confirm the setup is live and —
 /// the piece that was missing — name the one command that actually uses it
-/// (`load run <agent>`) plus how to reopen the studio.
+/// (`load <agent>`, the advertised short form of `run`) plus how to reopen the
+/// studio.
 pub fn onboarding_done(summary: &crate::studio::state::StagedSummary, agent: &str) -> String {
     let targets: Vec<&String> = summary
         .profiles
@@ -2302,7 +2303,7 @@ pub fn onboarding_done(summary: &crate::studio::state::StagedSummary, agent: &st
             }
             div class="cmd-block" {
                 span class="muted small" { "Use it in any agent session:" }
-                code { "load run " (agent) }
+                code { "load " (agent) }
             }
             div class="cmd-block" {
                 span class="muted small" { "Reopen this studio anytime:" }

--- a/tests/studio.rs
+++ b/tests/studio.rs
@@ -392,9 +392,10 @@ fn studio_first_run_lands_on_profiles_and_guides_through_pack() {
         "review summarizes the staged profile; got:\n{review}"
     );
 
-    // Beat 3: the finish card with the run command.
+    // Beat 3: the finish card with the launch command (the short form, which is
+    // the one spelling advertised everywhere: `load <agent>`, not `load run`).
     assert!(
-        done.contains("You're set") && done.contains("load run"),
+        done.contains("You're set") && done.contains("load claude") && !done.contains("load run"),
         "apply lands on the you're-set finish card; got:\n{done}"
     );
 


### PR DESCRIPTION
## What

**`npx @ellery/loadout studio`** is now a one-command way to try loadout: if the `load` binary is installed it delegates straight to it; if not, it explains exactly what the official installer will do (binary into `~/.cargo/bin`, PATH entry, update receipt) and asks for consent before installing. Non-interactive terminals get the manual `curl` command and exit 1 — never a silent install.

- **`npm/`** — the bootstrapper package. No binaries, no dependencies: it runs the same cargo-dist shell installer as the README, then hands off to the installed CLI. A no-op SIGINT listener keeps the wrapper alive through Ctrl-C so the child's shutdown output reaches the terminal and its exit status is mirrored.
- **`.github/workflows/npm-publish.yml`** — publishes on `npm/**` changes to main using the `NPM_TOKEN` repo secret (already set). Idempotent: an already-published version is skipped. Runs a non-interactive smoke test (consent gate must refuse without a TTY) before publishing. No event-derived inputs are interpolated into run steps.
- **Studio: graceful Ctrl-C + next-steps epilogue** — stopping the studio (Ctrl-C, SIGTERM, or idle) now removes the per-port runtime file (previously leaked on Ctrl-C) and prints what to type next (`load claude`, reopen with `load studio`) instead of dead-ending at an empty prompt. The handler only sets a flag; the serve loop polls ~1×/s. Second Ctrl-C force-kills.
- **Wording**: the guided-onboarding finish card now shows `load claude` instead of `load run claude` — one spelling everywhere the funnel touches.
- README (quick start, install, verified-channels) + CHANGELOG (Unreleased).

## Why

The curl installer asks JS developers to trust a shell pipe before they've seen the product. npx is the zero-commitment entry they already trust — but a bare npx that silently installs would violate its run-don't-install convention, so the install is consent-gated and fully described up front. The epilogue closes the onboarding loop: the npx user's journey ends back at a terminal prompt, which is exactly where the next command needs to be visible.

## Validation

- 864 Rust tests green; clippy `--all-targets` and `rustfmt` clean.
- Bootstrapper live-tested in a real PTY with an isolated $HOME: delegation to an installed `load`; non-TTY refusal (exit 1 + curl fallback); consent decline (nothing installed); consent accept → real 0.16.0 download from GitHub Releases → delegation works.
- Ctrl-C live-tested: new binary prints stop line + epilogue and removes the runtime file; under the npx wrapper the epilogue reaches the terminal and the wrapper exits 0. (Against the released 0.16.0 binary the wrapper still exits cleanly; the epilogue itself ships with the next release.)

## Notes for after merge

- Merging this triggers the first `@ellery/loadout` publish. It requires the `ellery` npm org to exist and the token to have publish rights to it — if the org isn't created yet, the workflow fails visibly and can be re-run via workflow_dispatch after fixing.
- The NPM_TOKEN was shared in a chat session and should be rotated on npmjs.com once publishing is confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016amFfPpPPpSGTpSRpYTE3p