### PR TITLE
feat(npm): npx flow offers to update an existing install (bootstrapper 0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to loadout are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
+## Unreleased
+
+### Changed
+
+- **npm bootstrapper 0.2.0** — running `npx @ellery/loadout …` with `load`
+  already installed now checks the latest GitHub release and, when yours is
+  older, offers to run `load update` before delegating (consent-prompted, like
+  the install; non-interactive runs get a one-line hint on stderr instead).
+  The check times out after 2.5s and is skipped when offline — it never blocks
+  the run. npm-package-only change; the `load` CLI itself is unchanged.
+
 ## 0.17.0 — 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Prebuilt binary — no Rust toolchain needed (macOS and Linux; on Windows use WS
 curl -LsSf https://github.com/elleryfamilia/loadout/releases/latest/download/loadout-installer.sh | sh
 ```
 
-Via npm — [`@ellery/loadout`](https://www.npmjs.com/package/@ellery/loadout) is a thin bootstrapper that runs the same installer after showing you what it will do and asking for consent, then hands off to the `load` CLI (so `npx @ellery/loadout studio` on a machine that already has loadout just opens the studio):
+Via npm — [`@ellery/loadout`](https://www.npmjs.com/package/@ellery/loadout) is a thin bootstrapper that runs the same installer after showing you what it will do and asking for consent, then hands off to the `load` CLI. On a machine that already has loadout it checks for a newer release and offers to update (again asking first), then runs your command:
 
 ```bash
 npx @ellery/loadout studio

--- a/npm/README.md
+++ b/npm/README.md
@@ -8,12 +8,16 @@ Gemini, opencode).
 npx @ellery/loadout studio
 ```
 
-If the `load` binary is already installed, this delegates to it directly. If it
-isn't, it explains what the official installer will do — download the prebuilt
-`load` binary from GitHub Releases, place it in `~/.cargo/bin`, add that
-directory to your PATH if needed, and write an install receipt so `load update`
-works — and asks for consent before doing anything. In non-interactive
-terminals it installs nothing and prints the manual `curl` command instead.
+If the `load` binary is already installed, this checks the latest release
+first and, when yours is older, offers to run `load update` before delegating —
+so running npx means you're on the latest, but never without being asked. If
+`load` isn't installed, it explains what the official installer will do —
+download the prebuilt `load` binary from GitHub Releases, place it in
+`~/.cargo/bin`, add that directory to your PATH if needed, and write an install
+receipt so `load update` works — and asks for consent before doing anything.
+In non-interactive terminals it never installs or updates: it prints the manual
+`curl` command (or a one-line update hint) instead. The version check times out
+after a couple of seconds and is skipped entirely when offline.
 
 After the one-time install, use `load` directly — no npx needed:
 

--- a/npm/bin/loadout.js
+++ b/npm/bin/loadout.js
@@ -95,6 +95,10 @@ async function maybeOfferUpdate(bin, args) {
   }
   const ok = await confirm(`${msg} Update now? [Y/n] `);
   if (!ok) return;
+  // Same contract as delegate(): Ctrl-C must reach only the child, so the
+  // wrapper survives to report and fall through to delegation. Registered
+  // only now — a global listener would swallow Ctrl-C at the consent prompts.
+  process.on('SIGINT', () => {});
   const r = spawnSync(bin, ['update'], { stdio: 'inherit' });
   if (r.status !== 0) {
     process.stderr.write('Update did not complete; continuing with the installed version.\n');

--- a/npm/bin/loadout.js
+++ b/npm/bin/loadout.js
@@ -123,10 +123,23 @@ function fail(msg) {
 function confirm(question) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   return new Promise((resolve) => {
+    let answered = false;
     rl.question(question, (answer) => {
+      answered = true;
       rl.close();
       const a = answer.trim().toLowerCase();
       resolve(a === '' || a === 'y' || a === 'yes');
+    });
+    // Ctrl-C or Ctrl-D at a consent prompt is a cancellation, never consent.
+    // Without these, readline swallows SIGINT, the promise never resolves,
+    // and the wrapper exits 0 having silently done nothing. Abort the whole
+    // run instead, 130 like a shell would.
+    rl.on('SIGINT', () => rl.close());
+    rl.on('close', () => {
+      if (!answered) {
+        process.stdout.write('\n');
+        process.exit(130);
+      }
     });
   });
 }

--- a/npm/bin/loadout.js
+++ b/npm/bin/loadout.js
@@ -48,18 +48,19 @@ const UPDATE_CHECK_TIMEOUT_MS = 2500;
 // Resolved from the release page's redirect (…/releases/latest → …/tag/vX.Y.Z)
 // rather than the GitHub API, which is rate-limited per IP.
 async function latestVersion() {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), UPDATE_CHECK_TIMEOUT_MS);
   try {
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), UPDATE_CHECK_TIMEOUT_MS);
     const res = await fetch('https://github.com/elleryfamilia/loadout/releases/latest', {
       redirect: 'manual',
       signal: ctrl.signal,
     });
-    clearTimeout(timer);
     const m = (res.headers.get('location') || '').match(/\/tag\/v?(\d+\.\d+\.\d+)/);
     return m ? m[1] : null;
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/npm/bin/loadout.js
+++ b/npm/bin/loadout.js
@@ -39,6 +39,69 @@ function findLoad() {
   return null;
 }
 
+// "npx gets me the latest" is a basic expectation, so before delegating to an
+// existing install, check the newest release tag and offer (never force) the
+// update. The check must never block the run: short timeout, and any failure —
+// offline, rate-limited, unparseable — means "skip it".
+const UPDATE_CHECK_TIMEOUT_MS = 2500;
+
+// Resolved from the release page's redirect (…/releases/latest → …/tag/vX.Y.Z)
+// rather than the GitHub API, which is rate-limited per IP.
+async function latestVersion() {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), UPDATE_CHECK_TIMEOUT_MS);
+    const res = await fetch('https://github.com/elleryfamilia/loadout/releases/latest', {
+      redirect: 'manual',
+      signal: ctrl.signal,
+    });
+    clearTimeout(timer);
+    const m = (res.headers.get('location') || '').match(/\/tag\/v?(\d+\.\d+\.\d+)/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+function installedVersion(bin) {
+  const r = spawnSync(bin, ['--version'], { encoding: 'utf8' });
+  const m = r.status === 0 ? (r.stdout || '').match(/(\d+\.\d+\.\d+)/) : null;
+  return m ? m[1] : null;
+}
+
+function isNewer(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i += 1) {
+    if (pa[i] !== pb[i]) return pa[i] > pb[i];
+  }
+  return false;
+}
+
+// The update itself is `load update` — the CLI's own receipt-based updater —
+// so this stays a launcher and never reimplements install logic. Declining,
+// failing, or a non-interactive terminal all fall through to delegation.
+async function maybeOfferUpdate(bin, args) {
+  if (args[0] === 'update') return; // already updating explicitly
+  const current = installedVersion(bin);
+  if (!current) return;
+  const latest = await latestVersion();
+  if (!latest || !isNewer(latest, current)) return;
+
+  const msg = `loadout ${latest} is available (installed: ${current}).`;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    process.stderr.write(`${msg} Run \`load update\` to update.\n`);
+    return;
+  }
+  const ok = await confirm(`${msg} Update now? [Y/n] `);
+  if (!ok) return;
+  const r = spawnSync(bin, ['update'], { stdio: 'inherit' });
+  if (r.status !== 0) {
+    process.stderr.write('Update did not complete; continuing with the installed version.\n');
+  }
+  process.stdout.write('\n');
+}
+
 // Hand off to the real binary. SIGINT must reach only the child (e.g. Ctrl-C
 // stopping `load studio` prints its exit message); a no-op listener keeps this
 // wrapper alive until the child exits, then the child's status is mirrored.
@@ -73,7 +136,10 @@ async function main() {
   }
 
   const existing = findLoad();
-  if (existing) delegate(existing, args);
+  if (existing) {
+    await maybeOfferUpdate(existing, args);
+    delegate(existing, args);
+  }
 
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     fail(

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ellery/loadout",
-  "version": "0.1.0",
-  "description": "Installer and launcher for loadout — the adaptive context layer for AI coding agents (Claude Code, Cursor, Codex, Gemini, opencode). Asks before installing the `load` binary, then delegates to it.",
+  "version": "0.2.0",
+  "description": "Installer and launcher for loadout — the adaptive context layer for AI coding agents (Claude Code, Cursor, Codex, Gemini, opencode). Asks before installing (or updating) the `load` binary, then delegates to it.",
   "bin": {
     "loadout": "bin/loadout.js"
   },


### PR DESCRIPTION
## What

Running `npx @ellery/loadout …` with `load` already installed now checks the latest release and, when the install is older, **asks** before running `load update` — then delegates as before. npx's basic contract ("this gets me the latest") now holds, without ever updating unasked.

- Latest version resolved from the `releases/latest` redirect (no rate-limited GitHub API), 2.5s timeout, any failure → skip the check and run normally. The check can never block or break a run.
- Interactive: consent prompt (`Update now? [Y/n]`); decline → delegate on the installed version. The update itself is `load update`, the CLI's own receipt-based updater — the wrapper stays a launcher.
- Non-interactive: one-line stderr hint, no prompt, no update.
- `npx @ellery/loadout update` skips the check (already updating explicitly).
- Checking GitHub directly (not the npm package version) keeps the guarantee correct even when npx serves a stale cached wrapper.

npm-package-only change (0.1.0 → 0.2.0); the Rust CLI is untouched. Merging publishes 0.2.0 via the existing npm-publish workflow.

## Validation

All four paths tested against the real registry state (latest = 0.17.0):
- up-to-date install → no prompt, silent delegation
- stale install, non-TTY → stderr hint + delegation, exit 0
- stale install, TTY, decline → delegation without update
- stale install, TTY, accept → `load update` runs, then delegation
(stale paths driven with a fake `load` script in a real PTY; offline resilience is by construction — every fetch failure path returns null and skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016amFfPpPPpSGTpSRpYTE3p