### PR TITLE
Animate phases open and shut in the plan viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ version and date (see [RELEASING.md](RELEASING.md)).
 - `Phase.icon` and `PlanTask.icon` are **still accepted and still validated**
   against the same 16-name vocabulary, so existing `plan.json` files keep
   working — the redesigned page just doesn't draw them.
+- **Phases now open and shut with a short animation** instead of appearing
+  and disappearing between one frame and the next. Expanding a phase used to
+  shove the rest of the page down in a single jump; it now grows into place
+  over about a quarter of a second, and its chevron turns with the click.
+  Clicking again part-way through reverses from wherever it had got to.
+  Expand all and collapse all move the same way. If your system asks for
+  reduced motion, the change stays instant.
 
 ### Fixed
 
@@ -44,6 +51,9 @@ version and date (see [RELEASING.md](RELEASING.md)).
 - The summary's phase ledger dropped its `Est · risk` column when no task in
   the plan carries an estimate or a risk rating, instead of showing that
   header over a column of empty cells.
+- Adding a comment to a phase collapsed that phase, hiding the editor the
+  click had just opened. The Comment button sits on the phase's header row,
+  which is the element a browser toggles the phase with.
 
 ## 0.18.0 — 2026-07-16
 

--- a/src/plan/assets/plan.css
+++ b/src/plan/assets/plan.css
@@ -1144,7 +1144,11 @@ details.phase > summary:hover { background: var(--accent-wash); }
    rules are not, since the body is what's animating. */
 details.phase[open]:not(.is-closing) > summary {
   align-items: start;
-  padding-bottom: 1.5rem;
+  /* Tighter than the shut row's, and deliberately: the summary's padding is
+     what the hover and :target bands are drawn to, so it should wrap the
+     summary's own content rather than stand in for the gap under it. The
+     body below owns that gap -- see its padding-top. */
+  padding-bottom: 0.75rem;
 }
 
 .phase-numeral {
@@ -1222,6 +1226,15 @@ details.phase > summary:hover .phase-marker { color: var(--accent); }
    rings and anything else that legitimately paints past the edge. */
 details.phase > .phase-body {
   margin-left: calc(var(--numeral-col) + var(--numeral-gap));
+  /* The body opens with a section rule (Dependencies, or the first task's
+     heading), and every other rule on the page carries more space above its
+     label than below it -- that ratio is what makes a label read as heading
+     the thing under it rather than trailing the thing over it. Without this
+     the phase body started flush against the summary, so its first label was
+     the one exception: equidistant from the phase description above and the
+     graph below. A phase is one level down from a top-level section, so the
+     gap is a block's worth rather than a section's. */
+  padding-top: var(--gap-block);
   padding-bottom: 2.25rem;
 }
 

--- a/src/plan/assets/plan.css
+++ b/src/plan/assets/plan.css
@@ -201,15 +201,17 @@
   --t-fast: 110ms;
   --t-mid: 200ms;
   --t-slow: 380ms;
+  /* How long a phase takes to open or shut. A <details> element has no
+     motion of its own, so this one is driven from plan.js -- which reads
+     the value (and --ease) back off :root rather than carrying a number of
+     its own, so the page's motion budget stays declared here with the rest
+     of it. Short on purpose: long enough to show the page growing, short
+     enough that nobody waits for it. */
+  --t-disclose: 240ms;
 }
 
 @keyframes pv-rise {
   from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: none; }
-}
-
-@keyframes pv-reveal {
-  from { opacity: 0; transform: translateY(-4px); }
   to { opacity: 1; transform: none; }
 }
 
@@ -1130,8 +1132,17 @@ details.phase > summary {
 details.phase > summary:hover { background: var(--accent-wash); }
 
 /* Open phases give the numeral more room and top-align it with the title,
-   because the content below it is now several blocks tall. */
-details.phase[open] > summary {
+   because the content below it is now several blocks tall.
+
+   `.is-closing` is plan.js telling this stylesheet "the reader has clicked
+   this shut; it is only still `open` because its body is mid-animation".
+   The DOM has to keep the attribute for a few hundred milliseconds longer
+   (there would be nothing left on screen to shrink otherwise), but the row
+   itself must look shut from the click onwards, or the chevron and the
+   numeral would snap back after the movement instead of leading it. Every
+   [open] rule on the summary is excused for that window; the body's own
+   rules are not, since the body is what's animating. */
+details.phase[open]:not(.is-closing) > summary {
   align-items: start;
   padding-bottom: 1.5rem;
 }
@@ -1146,7 +1157,7 @@ details.phase[open] > summary {
   transition: font-size var(--t-mid) var(--ease), color var(--t-fast) var(--ease);
 }
 
-details.phase[open] > summary .phase-numeral { font-size: 3.5rem; }
+details.phase[open]:not(.is-closing) > summary .phase-numeral { font-size: 3.5rem; }
 details.phase > summary:hover .phase-numeral { color: var(--accent); }
 
 .phase-head {
@@ -1191,21 +1202,32 @@ details.phase > summary:hover .phase-numeral { color: var(--accent); }
   transition: transform var(--t-mid) var(--ease), color var(--t-fast) var(--ease);
 }
 
-details.phase[open] > summary .phase-marker { transform: rotate(90deg); }
+details.phase[open]:not(.is-closing) > summary .phase-marker { transform: rotate(90deg); }
 details.phase > summary:hover .phase-marker { color: var(--accent); }
 
-/* The expanded body, indented to sit under the phase's content column. Every
-   direct child rises in on open -- one short movement that shows where the new
-   content came from. */
+/* The expanded body, indented to sit under the phase's content column.
+
+   Its opening and closing movement is driven from plan.js, not from here --
+   a CSS animation cannot do the job. A shut <details> hides its body with
+   `content-visibility: hidden`, which skips the subtree's RENDERING but
+   leaves its animations on their original timeline, so a keyframe animation
+   declared here fires once when the page loads and never again when a phase
+   is actually opened. (This rule used to carry a `pv-reveal` fade for
+   exactly that reason and had quietly stopped running.) plan.js animates the
+   height, the bottom padding and the opacity together over --t-disclose.
+
+   It also sets `overflow: hidden` inline for the length of that animation
+   and clears it afterwards: the body is only ever a clipping box while it is
+   shorter than its own contents. Left on permanently it would crop focus
+   rings and anything else that legitimately paints past the edge. */
 details.phase > .phase-body {
   margin-left: calc(var(--numeral-col) + var(--numeral-gap));
   padding-bottom: 2.25rem;
-  animation: pv-reveal var(--t-slow) var(--ease) both;
 }
 
 @media (max-width: 46rem) {
   details.phase > summary { grid-template-columns: 3rem minmax(0, 1fr) auto; gap: 1rem; }
-  details.phase[open] > summary .phase-numeral { font-size: 2.25rem; }
+  details.phase[open]:not(.is-closing) > summary .phase-numeral { font-size: 2.25rem; }
   details.phase > .phase-body { margin-left: 0; }
 }
 

--- a/src/plan/assets/plan.css
+++ b/src/plan/assets/plan.css
@@ -1105,7 +1105,14 @@ details.phase > summary {
   gap: var(--numeral-gap);
   align-items: center;
   padding: var(--gap-row) 0;
-  transition: background var(--t-fast) var(--ease);
+  /* The bottom padding differs between the shut and open rows (see the
+     [open] rule below), so it has to travel over the same window the body
+     does. Left untransitioned it changed on the frame of the click, which
+     shunted everything below the phase 14px in the OPPOSITE direction to
+     the one the body was about to move it -- a jump introduced by the
+     animation, in the middle of the animation. */
+  transition: background var(--t-fast) var(--ease),
+              padding-bottom var(--t-disclose) var(--ease);
 }
 
 /* Wherever a task row HAS a rail (the same breakpoint, from the other side),

--- a/src/plan/assets/plan.js
+++ b/src/plan/assets/plan.js
@@ -265,6 +265,51 @@
       if (phase.classList.contains("is-closing")) throw new Error("the instant path left is-closing set");
       if (body.style.overflow) throw new Error("the instant path left the body clipped");
     });
+    check("a link in a phase row still navigates", function () {
+      const phase = document.querySelector("details.phase");
+      const teaser = phase && phase.querySelector(".phase-teaser");
+      if (!teaser) throw new Error("no phase description to put a link in");
+      /* The phase description sits INSIDE the <summary>, and the renderer
+         keeps safe markdown links in it. Taking over the summary's click
+         cancelled those links: one cancelled flag covers every activation
+         behaviour on the event's path. Injected here rather than baked into
+         the fixture because what is under test is this file's click
+         handling, not the renderer. */
+      const link = document.createElement("a");
+      link.href = "#selftest-link-probe";
+      link.textContent = "link";
+      teaser.appendChild(link);
+      const wasOpen = phase.open;
+      /* Read the cancelled flag from the far end of the bubble path -- past
+         the summary's handler -- then cancel for real, so the probe does not
+         actually navigate the page it is testing. */
+      let cancelled = null;
+      function spy(e) { cancelled = e.defaultPrevented; e.preventDefault(); }
+      document.addEventListener("click", spy);
+      link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      document.removeEventListener("click", spy);
+      link.remove();
+      if (cancelled === null) throw new Error("the probe click never reached the document");
+      if (cancelled) throw new Error("clicking a link in a phase row cancelled its navigation");
+      if (phase.open !== wasOpen) throw new Error("clicking a link in a phase row toggled the phase");
+    });
+    check("commenting on a shut phase reveals the editor", function () {
+      const phase = document.querySelector("details.phase");
+      const btn = phase && phase.querySelector("summary .comment-btn");
+      const box = phase && phase.querySelector(".phase-body > .comment-box");
+      if (!btn || !box) throw new Error("phase has no comment editor mounted");
+      /* Collapsing a phase leaves an open editor with `hidden === false`
+         while the <details> keeps it off screen, so the two disagree. A
+         plain toggle from that state hides something already invisible and
+         the click does nothing a reader can see. */
+      setPhaseOpen(phase, false, false);
+      box.hidden = false;
+      btn.click();
+      if (phaseIsShut(phase)) throw new Error("commenting on a shut phase left it shut");
+      if (box.hidden) throw new Error("commenting on a shut phase hid the editor");
+      setPhaseOpen(phase, false, false);
+      box.hidden = true;
+    });
     if (location.protocol !== "file:" || window.parent !== window) {
       /* Non-plain-file contexts only — a real http(s) serving, or the CI
          harness that frames this page in a sandboxed iframe to give it the
@@ -1003,18 +1048,23 @@
            its toggle. Commenting on an open phase used to shut it, hiding
            the very box the click had just opened. */
         e.stopPropagation();
-        box.hidden = !box.hidden;
-        if (box.hidden) return;
         if (el.tagName === "DETAILS" && phaseIsShut(el)) {
           /* The button is in the summary but the box is in the body, which
-             only exists while the phase is open -- so open it. Focus without
-             scrolling: the body is mid-animation and clipped, and scrolling
-             into it now would leave the clip box scrolled once it settles. */
+             is off screen while the phase is shut -- whatever `hidden` says.
+             It can be left un-hidden, too: collapsing a phase that had an
+             editor open does not touch the box. Toggling from there would
+             hide something the reader cannot see and the click would have no
+             visible effect at all, so a shut phase always REVEALS rather
+             than toggles. Focus without scrolling: the body is mid-animation
+             and clipped, and scrolling into it now would leave the clip box
+             scrolled once it settles. */
+          box.hidden = false;
           setPhaseOpen(el, true, true);
           textarea.focus({ preventScroll: true });
           return;
         }
-        textarea.focus();
+        box.hidden = !box.hidden;
+        if (!box.hidden) textarea.focus();
       });
 
       cancelBtn.addEventListener("click", function () {
@@ -1061,6 +1111,19 @@
         if (!summary) return;
         summary.addEventListener("click", function (e) {
           if (e.defaultPrevented) return;
+          /* A link or a control inside the row owns its own click, and the
+             browser already does the right thing with one: the innermost
+             element with an activation behaviour wins, so a click on an <a>
+             in the phase description follows the link and does NOT toggle
+             the phase. Stay out of the way entirely. Cancelling here would
+             take the navigation with it -- a click event carries a single
+             cancelled flag for every activation behaviour on its path, so
+             there is no way to suppress the toggle and keep the link.
+             (`phase_summary_parts` keeps safe links in the teaser, and the
+             teaser is inside the <summary>.) */
+          if (e.target.closest && e.target.closest("a[href], button, input, select, textarea, label")) {
+            return;
+          }
           e.preventDefault();
           setPhaseOpen(d, phaseIsShut(d), true);
         });

--- a/src/plan/assets/plan.js
+++ b/src/plan/assets/plan.js
@@ -196,9 +196,12 @@
       /* It must start from collapsed, or the box would appear at full size
          and merely fade -- which is the jump, with a fade over it. */
       const first = opening[0].effect.getKeyframes()[0];
-      if (parseFloat(first.height) !== 0 || parseFloat(first.paddingBottom) !== 0) {
+      if (parseFloat(first.height) !== 0
+        || parseFloat(first.paddingTop) !== 0
+        || parseFloat(first.paddingBottom) !== 0) {
         throw new Error("opening starts at height=" + first.height
-          + " paddingBottom=" + first.paddingBottom + ", not from nothing");
+          + " paddingTop=" + first.paddingTop + " paddingBottom=" + first.paddingBottom
+          + ", not from nothing");
       }
       opening.forEach(function (a) { a.finish(); });
 
@@ -213,9 +216,12 @@
       const closing = heightAnimations(body);
       if (!closing.length) throw new Error("closing was not animated");
       const last = closing[0].effect.getKeyframes().slice(-1)[0];
-      if (parseFloat(last.height) !== 0 || parseFloat(last.paddingBottom) !== 0) {
+      if (parseFloat(last.height) !== 0
+        || parseFloat(last.paddingTop) !== 0
+        || parseFloat(last.paddingBottom) !== 0) {
         throw new Error("closing ends at height=" + last.height
-          + " paddingBottom=" + last.paddingBottom + ", not at nothing");
+          + " paddingTop=" + last.paddingTop + " paddingBottom=" + last.paddingBottom
+          + ", not at nothing");
       }
 
       /* And the instant path settles everything the animated one leaves in
@@ -522,9 +528,16 @@
     return !details.open || details.classList.contains("is-closing");
   }
 
-  function bottomPadding(el) {
-    return window.getComputedStyle(el).paddingBottom || "0px";
+  /* The body's vertical padding, which has to travel with its height: with
+     `box-sizing: border-box` a height of 0 still leaves the padding on
+     screen, so a phase would collapse to a bar of blank space and then drop
+     it -- precisely the jump this is all here to remove. */
+  function verticalPadding(el) {
+    const cs = window.getComputedStyle(el);
+    return { top: cs.paddingTop || "0px", bottom: cs.paddingBottom || "0px" };
   }
+
+  const NO_PADDING = { top: "0px", bottom: "0px" };
 
   /* The disclosure animations on an element, and only those. `getAnimations`
      also returns anything CSS has left lying around with a fill, so a bare
@@ -574,8 +587,8 @@
        the measurement: a shut <details> keeps reporting the size its body
        had when it was last open. */
     const from = details.open
-      ? { h: body.getBoundingClientRect().height, pad: bottomPadding(body) }
-      : { h: 0, pad: "0px" };
+      ? { h: body.getBoundingClientRect().height, pad: verticalPadding(body) }
+      : { h: 0, pad: NO_PADDING };
     if (running) { disclosing.delete(details); running.cancel(); }
 
     if (want) {
@@ -587,20 +600,27 @@
     /* And where it is going. Measured after the cancel above, so these are
        the element's own resting values, not another animation's. */
     const to = want
-      ? { h: body.getBoundingClientRect().height, pad: bottomPadding(body) }
-      : { h: 0, pad: "0px" };
+      ? { h: body.getBoundingClientRect().height, pad: verticalPadding(body) }
+      : { h: 0, pad: NO_PADDING };
 
     const timing = discloseTiming();
     const anim = body.animate(
-      /* Padding travels with the height. The body carries 2.25rem of bottom
-         padding and `box-sizing: border-box`, so a height of 0 alone still
-         leaves a 36px stub on screen -- the last thing a close did was drop
-         it, which is precisely the jump this is here to remove. Opacity
-         travels with them so the content fades rather than being sliced off
-         by the clip edge. */
+      /* Both paddings travel with the height (see verticalPadding), and
+         opacity travels with them so the content fades rather than being
+         sliced off by the clip edge. */
       [
-        { height: from.h + "px", paddingBottom: from.pad, opacity: want ? 0 : 1 },
-        { height: to.h + "px", paddingBottom: to.pad, opacity: want ? 1 : 0 },
+        {
+          height: from.h + "px",
+          paddingTop: from.pad.top,
+          paddingBottom: from.pad.bottom,
+          opacity: want ? 0 : 1,
+        },
+        {
+          height: to.h + "px",
+          paddingTop: to.pad.top,
+          paddingBottom: to.pad.bottom,
+          opacity: want ? 1 : 0,
+        },
       ],
       {
         duration: timing.duration,

--- a/src/plan/assets/plan.js
+++ b/src/plan/assets/plan.js
@@ -176,6 +176,56 @@
         throw new Error("system not marked pressed");
       }
     });
+    check("phases open and shut with motion", function () {
+      const phase = document.querySelector("details.phase");
+      if (!phase) throw new Error("no phases on the page");
+      const body = phase.querySelector(".phase-body");
+      if (!body) throw new Error("phase has no body to animate");
+      /* No Web Animations API, or a reader who asked for reduced motion:
+         instant IS the correct behaviour, and there would be nothing for
+         `heightAnimations` to report. Nothing to assert. */
+      if (!canDisclose() || !body.getAnimations) return;
+
+      setPhaseOpen(phase, false, false);
+
+      setPhaseOpen(phase, true, true);
+      if (!phase.open) throw new Error("opening did not open the phase");
+      if (phase.classList.contains("is-closing")) throw new Error("opening left is-closing set");
+      const opening = heightAnimations(body);
+      if (!opening.length) throw new Error("opening was not animated");
+      /* It must start from collapsed, or the box would appear at full size
+         and merely fade -- which is the jump, with a fade over it. */
+      const first = opening[0].effect.getKeyframes()[0];
+      if (parseFloat(first.height) !== 0 || parseFloat(first.paddingBottom) !== 0) {
+        throw new Error("opening starts at height=" + first.height
+          + " paddingBottom=" + first.paddingBottom + ", not from nothing");
+      }
+      opening.forEach(function (a) { a.finish(); });
+
+      /* The three things that make a close look right, and each of which
+         has to be got wrong deliberately to break: the body is still on the
+         page so there is something to shrink, the open styling is ALREADY
+         off so the chevron turns with the click rather than after it, and
+         the height really is being animated. */
+      setPhaseOpen(phase, false, true);
+      if (!phase.open) throw new Error("closing dropped the body before it could shrink");
+      if (!phase.classList.contains("is-closing")) throw new Error("closing left the open styling on");
+      const closing = heightAnimations(body);
+      if (!closing.length) throw new Error("closing was not animated");
+      const last = closing[0].effect.getKeyframes().slice(-1)[0];
+      if (parseFloat(last.height) !== 0 || parseFloat(last.paddingBottom) !== 0) {
+        throw new Error("closing ends at height=" + last.height
+          + " paddingBottom=" + last.paddingBottom + ", not at nothing");
+      }
+
+      /* And the instant path settles everything the animated one leaves in
+         flight -- otherwise a print or a second click could strand a phase
+         half-open, or leave its body permanently clipped. */
+      setPhaseOpen(phase, false, false);
+      if (phase.open) throw new Error("the instant path left the phase open");
+      if (phase.classList.contains("is-closing")) throw new Error("the instant path left is-closing set");
+      if (body.style.overflow) throw new Error("the instant path left the body clipped");
+    });
     if (location.protocol !== "file:" || window.parent !== window) {
       /* Non-plain-file contexts only — a real http(s) serving, or the CI
          harness that frames this page in a sandboxed iframe to give it the
@@ -418,6 +468,163 @@
       { rootMargin: "-10% 0px -70% 0px" }
     );
     phases.forEach(function (p) { spy.observe(p); });
+  }
+
+  /* ---- disclosure ----------------------------------------------------
+
+     A <details> element has no motion of its own: its body appears and
+     disappears between one frame and the next, so opening a phase shoves
+     everything below it down the page in a single jump, and shutting one
+     yanks it back. `setPhaseOpen` gives that change a duration by animating
+     the body's height, and every path a READER can trigger goes through it
+     -- the summary itself, the expand-all and collapse-all buttons, and a
+     comment button that has to open the phase it lives on.
+
+     Programmatic paths deliberately do not. Printing and the self-test pass
+     `false` for `animate` and stay instant: they want the end state, not a
+     transition to it.
+
+     Nothing here is load-bearing. A browser with no Web Animations API, or
+     a reader who has asked their system for reduced motion, falls straight
+     through to setting `.open` -- which is exactly the behaviour this page
+     had before. */
+
+  /* The animation currently running on a phase, if any, so a second click
+     part-way through can take the phase over rather than fight it. */
+  const disclosing = new WeakMap();
+
+  /* Duration and easing for a disclosure, read out of plan.css. A value that
+     is missing (no stylesheet) or unparseable falls back to a sane pair
+     rather than to a zero-length -- and therefore invisible -- animation. */
+  function discloseTiming() {
+    const root = window.getComputedStyle(document.documentElement);
+    const raw = root.getPropertyValue("--t-disclose").trim();
+    const ms = raw.slice(-2) === "ms" ? parseFloat(raw) : parseFloat(raw) * 1000;
+    return {
+      duration: ms > 0 ? ms : 240,
+      easing: root.getPropertyValue("--ease").trim() || "ease",
+    };
+  }
+
+  /* Whether to animate at all. plan.css's prefers-reduced-motion block can
+     only reach CSS animations and transitions, so motion driven from here
+     has to consult the same query itself or it would ignore the one setting
+     the whole budget is meant to answer to. */
+  function canDisclose() {
+    if (!window.Element || typeof Element.prototype.animate !== "function") return false;
+    if (!window.matchMedia) return true;
+    return !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+
+  /* Whether a phase reads as SHUT to the person looking at it: either really
+     closed, or open-but-mid-close. A click during a close has to re-open. */
+  function phaseIsShut(details) {
+    return !details.open || details.classList.contains("is-closing");
+  }
+
+  function bottomPadding(el) {
+    return window.getComputedStyle(el).paddingBottom || "0px";
+  }
+
+  /* The disclosure animations on an element, and only those. `getAnimations`
+     also returns anything CSS has left lying around with a fill, so a bare
+     length check would pass whether or not this file animated anything --
+     the keyframes are what identify ours. */
+  function heightAnimations(el) {
+    if (!el.getAnimations) return [];
+    return el.getAnimations().filter(function (a) {
+      const frames = a.effect && a.effect.getKeyframes ? a.effect.getKeyframes() : [];
+      return frames.some(function (f) { return f.height !== undefined; });
+    });
+  }
+
+  /* Open or shut one phase.
+
+     Opening is the straightforward direction: set `open` (so the chevron,
+     the numeral and every other [open] rule in plan.css start their own
+     transitions on the same frame), then grow the body from nothing into
+     its natural height.
+
+     Closing cannot do that in reverse, because clearing `open` removes the
+     body from the page immediately and leaves nothing to shrink. So `open`
+     stays set until the animation finishes, and the `is-closing` class tells
+     plan.css to treat the phase as visually shut in the meantime -- see the
+     `:not(.is-closing)` rules on the summary. */
+  function setPhaseOpen(details, want, animate) {
+    const body = details.querySelector(".phase-body");
+    const running = disclosing.get(details);
+
+    if (!body || animate === false || !canDisclose()) {
+      if (running) { disclosing.delete(details); running.cancel(); }
+      if (body) body.style.overflow = "";
+      details.classList.remove("is-closing");
+      details.open = want;
+      return;
+    }
+
+    /* Clip first, measure second. `overflow: hidden` makes the body a block
+       formatting context, so its children's margins stop collapsing through
+       it -- measuring before setting it would return a height the box never
+       actually has while animating, and the phase would jump at the end by
+       the difference. */
+    body.style.overflow = "hidden";
+    /* Where the box is NOW. Mid-animation these read the animated values, so
+       a click part-way through a close carries on from where it got to
+       instead of restarting. Note the state is taken from `open`, never from
+       the measurement: a shut <details> keeps reporting the size its body
+       had when it was last open. */
+    const from = details.open
+      ? { h: body.getBoundingClientRect().height, pad: bottomPadding(body) }
+      : { h: 0, pad: "0px" };
+    if (running) { disclosing.delete(details); running.cancel(); }
+
+    if (want) {
+      details.classList.remove("is-closing");
+      details.open = true;
+    } else {
+      details.classList.add("is-closing");
+    }
+    /* And where it is going. Measured after the cancel above, so these are
+       the element's own resting values, not another animation's. */
+    const to = want
+      ? { h: body.getBoundingClientRect().height, pad: bottomPadding(body) }
+      : { h: 0, pad: "0px" };
+
+    const timing = discloseTiming();
+    const anim = body.animate(
+      /* Padding travels with the height. The body carries 2.25rem of bottom
+         padding and `box-sizing: border-box`, so a height of 0 alone still
+         leaves a 36px stub on screen -- the last thing a close did was drop
+         it, which is precisely the jump this is here to remove. Opacity
+         travels with them so the content fades rather than being sliced off
+         by the clip edge. */
+      [
+        { height: from.h + "px", paddingBottom: from.pad, opacity: want ? 0 : 1 },
+        { height: to.h + "px", paddingBottom: to.pad, opacity: want ? 1 : 0 },
+      ],
+      {
+        duration: timing.duration,
+        easing: timing.easing,
+        /* A close holds its last frame. Without the fill the body would
+           spring back to full height for the one frame between the
+           animation ending and `open` being cleared below. */
+        fill: want ? "none" : "forwards",
+      }
+    );
+    disclosing.set(details, anim);
+    anim.onfinish = function () {
+      /* A later call already took this phase over; the cleanup is its job
+         now. (Cancelling does not fire this handler, so reaching here with
+         a stale animation means the phase was re-clicked mid-flight.) */
+      if (disclosing.get(details) !== anim) return;
+      disclosing.delete(details);
+      if (!want) {
+        details.open = false;
+        details.classList.remove("is-closing");
+      }
+      body.style.overflow = "";
+      anim.cancel();
+    };
   }
 
   /* Where a commentable block wants its comment button and its draft box.
@@ -727,9 +934,25 @@
       box.appendChild(blockingRow);
       box.appendChild(actions);
 
-      btn.addEventListener("click", function () {
+      btn.addEventListener("click", function (e) {
+        /* The same guard the reviewed toggle carries below, for the same
+           reason: on a PHASE this button is placed inside the <summary>
+           (see commentSlots), and a click that reaches the summary triggers
+           its toggle. Commenting on an open phase used to shut it, hiding
+           the very box the click had just opened. */
+        e.stopPropagation();
         box.hidden = !box.hidden;
-        if (!box.hidden) textarea.focus();
+        if (box.hidden) return;
+        if (el.tagName === "DETAILS" && phaseIsShut(el)) {
+          /* The button is in the summary but the box is in the body, which
+             only exists while the phase is open -- so open it. Focus without
+             scrolling: the body is mid-animation and clipped, and scrolling
+             into it now would leave the clip box scrolled once it settles. */
+          setPhaseOpen(el, true, true);
+          textarea.focus({ preventScroll: true });
+          return;
+        }
+        textarea.focus();
       });
 
       cancelBtn.addEventListener("click", function () {
@@ -767,6 +990,20 @@
         return document.querySelectorAll("details.phase");
       }
 
+      /* A <summary>'s built-in default action is "toggle, instantly". Take
+         it over so a click gets the animation instead. Keyboard activation
+         (Enter or Space on the focused summary) dispatches a click of its
+         own, so it comes through the same handler and behaves the same. */
+      collapsibles().forEach(function (d) {
+        const summary = d.querySelector("summary");
+        if (!summary) return;
+        summary.addEventListener("click", function (e) {
+          if (e.defaultPrevented) return;
+          e.preventDefault();
+          setPhaseOpen(d, phaseIsShut(d), true);
+        });
+      });
+
       /* The markup ships an empty actions slot on the Phases section rule
          (render.rs's `section_rule`), so these land on the divider rather
          than floating above the list as a stray toolbar. */
@@ -777,7 +1014,7 @@
       expandBtn.className = "pv-textbtn";
       expandBtn.textContent = "expand all";
       expandBtn.addEventListener("click", function () {
-        collapsibles().forEach(function (d) { d.open = true; });
+        collapsibles().forEach(function (d) { setPhaseOpen(d, true, true); });
       });
 
       const collapseBtn = document.createElement("button");
@@ -785,7 +1022,7 @@
       collapseBtn.className = "pv-textbtn";
       collapseBtn.textContent = "collapse all";
       collapseBtn.addEventListener("click", function () {
-        collapsibles().forEach(function (d) { d.open = false; });
+        collapsibles().forEach(function (d) { setPhaseOpen(d, false, true); });
       });
 
       ctl.appendChild(expandBtn);
@@ -797,12 +1034,15 @@
          before print, then restore whatever state the user had before. */
       let preprintState = null;
       window.addEventListener("beforeprint", function () {
-        preprintState = Array.from(collapsibles()).map(function (d) { return d.open; });
-        collapsibles().forEach(function (d) { d.open = true; });
+        /* `phaseIsShut`, not `.open`: a phase caught mid-close is still
+           technically open, and restoring it as open afterwards would leave
+           the reader with a phase they had just clicked shut. */
+        preprintState = Array.from(collapsibles()).map(function (d) { return !phaseIsShut(d); });
+        collapsibles().forEach(function (d) { setPhaseOpen(d, true, false); });
       });
       window.addEventListener("afterprint", function () {
         if (!preprintState) return;
-        collapsibles().forEach(function (d, i) { d.open = preprintState[i]; });
+        collapsibles().forEach(function (d, i) { setPhaseOpen(d, preprintState[i], false); });
         preprintState = null;
       });
     }

--- a/src/plan/assets/plan.js
+++ b/src/plan/assets/plan.js
@@ -188,7 +188,23 @@
 
       setPhaseOpen(phase, false, false);
 
+      /* Nothing below the phase may move on the FRAME of the click: the whole
+         change has to be inside the animation. The summary's bottom padding
+         differs between the shut and open rows and was not transitioned, so
+         it shunted the rest of the page 14px the instant a phase was clicked
+         -- in the opposite direction to the one the body was about to move
+         it. A delta, never a position, so the frame's size cannot matter. */
+      const below = phase.nextElementSibling;
+      const beforeTop = below ? below.getBoundingClientRect().top : 0;
+
       setPhaseOpen(phase, true, true);
+      if (below) {
+        const shift = Math.abs(below.getBoundingClientRect().top - beforeTop);
+        if (shift > 1) {
+          throw new Error("clicking a phase shifted the page " + Math.round(shift)
+            + "px before anything had animated");
+        }
+      }
       if (!phase.open) throw new Error("opening did not open the phase");
       if (phase.classList.contains("is-closing")) throw new Error("opening left is-closing set");
       const opening = heightAnimations(body);
@@ -222,6 +238,23 @@
         throw new Error("closing ends at height=" + last.height
           + " paddingTop=" + last.paddingTop + " paddingBottom=" + last.paddingBottom
           + ", not at nothing");
+      }
+
+      /* Reversing that close has to resume from the frame ON SCREEN, opacity
+         included. The body is fully visible at this point, so an open that
+         assumed a start of 0 would blink it out and fade it back in. */
+      setPhaseOpen(phase, true, true);
+      const resumed = heightAnimations(body)[0].effect.getKeyframes()[0];
+      if (parseFloat(resumed.opacity) < 0.5) {
+        throw new Error("reversing a close restarts the fade at opacity " + resumed.opacity);
+      }
+      heightAnimations(body).forEach(function (a) { a.finish(); });
+
+      /* And a phase already sitting where it is asked to go is left alone --
+         "expand all" reaches every phase, including ones already open. */
+      setPhaseOpen(phase, true, true);
+      if (heightAnimations(body).length) {
+        throw new Error("re-opening an already-open phase animated it again");
       }
 
       /* And the instant path settles everything the animated one leaves in
@@ -528,16 +561,32 @@
     return !details.open || details.classList.contains("is-closing");
   }
 
-  /* The body's vertical padding, which has to travel with its height: with
+  /* Everything the disclosure animates, as it is RIGHT NOW -- read together
+     so a reversal mid-flight resumes from one consistent frame rather than
+     from three properties sampled at different times.
+
+     The padding is in here because it has to travel with the height: with
      `box-sizing: border-box` a height of 0 still leaves the padding on
      screen, so a phase would collapse to a bar of blank space and then drop
-     it -- precisely the jump this is all here to remove. */
-  function verticalPadding(el) {
-    const cs = window.getComputedStyle(el);
-    return { top: cs.paddingTop || "0px", bottom: cs.paddingBottom || "0px" };
+     it -- precisely the jump this is all here to remove.
+
+     The opacity is in here because it must NOT be assumed. Hard-coding a
+     start of 0 for every open blinked out any body that was already
+     visible: "expand all" over a phase a reader had opened by hand faded it
+     from nothing, and reversing a close snapped the content dimmer before
+     bringing it back. */
+  function bodyState(body) {
+    const cs = window.getComputedStyle(body);
+    return {
+      height: body.getBoundingClientRect().height + "px",
+      paddingTop: cs.paddingTop || "0px",
+      paddingBottom: cs.paddingBottom || "0px",
+      opacity: cs.opacity || "1",
+    };
   }
 
-  const NO_PADDING = { top: "0px", bottom: "0px" };
+  /* What a shut phase's body looks like: nothing at all, on every axis. */
+  const COLLAPSED = { height: "0px", paddingTop: "0px", paddingBottom: "0px", opacity: "0" };
 
   /* The disclosure animations on an element, and only those. `getAnimations`
      also returns anything CSS has left lying around with a fill, so a bare
@@ -575,20 +624,31 @@
       return;
     }
 
+    /* Already where it is being asked to go, and nothing in flight: leave it
+       alone. "Expand all" reaches every phase including the ones a reader
+       opened by hand, and animating one of those from its own current state
+       to its own current state is a no-op for the height but a full pass for
+       everything else.
+
+       An animation that has FINISHED but whose `onfinish` has not run yet
+       (that fires on a later task) is not in flight -- it still holds this
+       phase's slot in `disclosing`, and its own cleanup is still correct
+       when it arrives. */
+    const inFlight = !!running && running.playState !== "finished";
+    if (!inFlight && details.open === want && !details.classList.contains("is-closing")) return;
+
     /* Clip first, measure second. `overflow: hidden` makes the body a block
        formatting context, so its children's margins stop collapsing through
        it -- measuring before setting it would return a height the box never
        actually has while animating, and the phase would jump at the end by
        the difference. */
     body.style.overflow = "hidden";
-    /* Where the box is NOW. Mid-animation these read the animated values, so
-       a click part-way through a close carries on from where it got to
+    /* Where the box is NOW. Mid-animation this reads the animated values, so
+       a click part-way through a close carries on from the frame on screen
        instead of restarting. Note the state is taken from `open`, never from
        the measurement: a shut <details> keeps reporting the size its body
        had when it was last open. */
-    const from = details.open
-      ? { h: body.getBoundingClientRect().height, pad: verticalPadding(body) }
-      : { h: 0, pad: NO_PADDING };
+    const from = details.open ? bodyState(body) : COLLAPSED;
     if (running) { disclosing.delete(details); running.cancel(); }
 
     if (want) {
@@ -597,31 +657,13 @@
     } else {
       details.classList.add("is-closing");
     }
-    /* And where it is going. Measured after the cancel above, so these are
-       the element's own resting values, not another animation's. */
-    const to = want
-      ? { h: body.getBoundingClientRect().height, pad: verticalPadding(body) }
-      : { h: 0, pad: NO_PADDING };
+    /* And where it is going. Read after the cancel above, so these are the
+       element's own resting values, not another animation's. */
+    const to = want ? bodyState(body) : COLLAPSED;
 
     const timing = discloseTiming();
     const anim = body.animate(
-      /* Both paddings travel with the height (see verticalPadding), and
-         opacity travels with them so the content fades rather than being
-         sliced off by the clip edge. */
-      [
-        {
-          height: from.h + "px",
-          paddingTop: from.pad.top,
-          paddingBottom: from.pad.bottom,
-          opacity: want ? 0 : 1,
-        },
-        {
-          height: to.h + "px",
-          paddingTop: to.pad.top,
-          paddingBottom: to.pad.bottom,
-          opacity: want ? 1 : 0,
-        },
-      ],
+      [from, to],
       {
         duration: timing.duration,
         easing: timing.easing,

--- a/tests/fixtures/plan/kitchen-sink.html
+++ b/tests/fixtures/plan/kitchen-sink.html
@@ -1145,7 +1145,11 @@ details.phase > summary:hover { background: var(--accent-wash); }
    rules are not, since the body is what's animating. */
 details.phase[open]:not(.is-closing) > summary {
   align-items: start;
-  padding-bottom: 1.5rem;
+  /* Tighter than the shut row's, and deliberately: the summary's padding is
+     what the hover and :target bands are drawn to, so it should wrap the
+     summary's own content rather than stand in for the gap under it. The
+     body below owns that gap -- see its padding-top. */
+  padding-bottom: 0.75rem;
 }
 
 .phase-numeral {
@@ -1223,6 +1227,15 @@ details.phase > summary:hover .phase-marker { color: var(--accent); }
    rings and anything else that legitimately paints past the edge. */
 details.phase > .phase-body {
   margin-left: calc(var(--numeral-col) + var(--numeral-gap));
+  /* The body opens with a section rule (Dependencies, or the first task's
+     heading), and every other rule on the page carries more space above its
+     label than below it -- that ratio is what makes a label read as heading
+     the thing under it rather than trailing the thing over it. Without this
+     the phase body started flush against the summary, so its first label was
+     the one exception: equidistant from the phase description above and the
+     graph below. A phase is one level down from a top-level section, so the
+     gap is a block's worth rather than a section's. */
+  padding-top: var(--gap-block);
   padding-bottom: 2.25rem;
 }
 
@@ -2081,9 +2094,12 @@ pre code { font-size: 1em; }
       /* It must start from collapsed, or the box would appear at full size
          and merely fade -- which is the jump, with a fade over it. */
       const first = opening[0].effect.getKeyframes()[0];
-      if (parseFloat(first.height) !== 0 || parseFloat(first.paddingBottom) !== 0) {
+      if (parseFloat(first.height) !== 0
+        || parseFloat(first.paddingTop) !== 0
+        || parseFloat(first.paddingBottom) !== 0) {
         throw new Error("opening starts at height=" + first.height
-          + " paddingBottom=" + first.paddingBottom + ", not from nothing");
+          + " paddingTop=" + first.paddingTop + " paddingBottom=" + first.paddingBottom
+          + ", not from nothing");
       }
       opening.forEach(function (a) { a.finish(); });
 
@@ -2098,9 +2114,12 @@ pre code { font-size: 1em; }
       const closing = heightAnimations(body);
       if (!closing.length) throw new Error("closing was not animated");
       const last = closing[0].effect.getKeyframes().slice(-1)[0];
-      if (parseFloat(last.height) !== 0 || parseFloat(last.paddingBottom) !== 0) {
+      if (parseFloat(last.height) !== 0
+        || parseFloat(last.paddingTop) !== 0
+        || parseFloat(last.paddingBottom) !== 0) {
         throw new Error("closing ends at height=" + last.height
-          + " paddingBottom=" + last.paddingBottom + ", not at nothing");
+          + " paddingTop=" + last.paddingTop + " paddingBottom=" + last.paddingBottom
+          + ", not at nothing");
       }
 
       /* And the instant path settles everything the animated one leaves in
@@ -2407,9 +2426,16 @@ pre code { font-size: 1em; }
     return !details.open || details.classList.contains("is-closing");
   }
 
-  function bottomPadding(el) {
-    return window.getComputedStyle(el).paddingBottom || "0px";
+  /* The body's vertical padding, which has to travel with its height: with
+     `box-sizing: border-box` a height of 0 still leaves the padding on
+     screen, so a phase would collapse to a bar of blank space and then drop
+     it -- precisely the jump this is all here to remove. */
+  function verticalPadding(el) {
+    const cs = window.getComputedStyle(el);
+    return { top: cs.paddingTop || "0px", bottom: cs.paddingBottom || "0px" };
   }
+
+  const NO_PADDING = { top: "0px", bottom: "0px" };
 
   /* The disclosure animations on an element, and only those. `getAnimations`
      also returns anything CSS has left lying around with a fill, so a bare
@@ -2459,8 +2485,8 @@ pre code { font-size: 1em; }
        the measurement: a shut <details> keeps reporting the size its body
        had when it was last open. */
     const from = details.open
-      ? { h: body.getBoundingClientRect().height, pad: bottomPadding(body) }
-      : { h: 0, pad: "0px" };
+      ? { h: body.getBoundingClientRect().height, pad: verticalPadding(body) }
+      : { h: 0, pad: NO_PADDING };
     if (running) { disclosing.delete(details); running.cancel(); }
 
     if (want) {
@@ -2472,20 +2498,27 @@ pre code { font-size: 1em; }
     /* And where it is going. Measured after the cancel above, so these are
        the element's own resting values, not another animation's. */
     const to = want
-      ? { h: body.getBoundingClientRect().height, pad: bottomPadding(body) }
-      : { h: 0, pad: "0px" };
+      ? { h: body.getBoundingClientRect().height, pad: verticalPadding(body) }
+      : { h: 0, pad: NO_PADDING };
 
     const timing = discloseTiming();
     const anim = body.animate(
-      /* Padding travels with the height. The body carries 2.25rem of bottom
-         padding and `box-sizing: border-box`, so a height of 0 alone still
-         leaves a 36px stub on screen -- the last thing a close did was drop
-         it, which is precisely the jump this is here to remove. Opacity
-         travels with them so the content fades rather than being sliced off
-         by the clip edge. */
+      /* Both paddings travel with the height (see verticalPadding), and
+         opacity travels with them so the content fades rather than being
+         sliced off by the clip edge. */
       [
-        { height: from.h + "px", paddingBottom: from.pad, opacity: want ? 0 : 1 },
-        { height: to.h + "px", paddingBottom: to.pad, opacity: want ? 1 : 0 },
+        {
+          height: from.h + "px",
+          paddingTop: from.pad.top,
+          paddingBottom: from.pad.bottom,
+          opacity: want ? 0 : 1,
+        },
+        {
+          height: to.h + "px",
+          paddingTop: to.pad.top,
+          paddingBottom: to.pad.bottom,
+          opacity: want ? 1 : 0,
+        },
       ],
       {
         duration: timing.duration,

--- a/tests/fixtures/plan/kitchen-sink.html
+++ b/tests/fixtures/plan/kitchen-sink.html
@@ -1106,7 +1106,14 @@ details.phase > summary {
   gap: var(--numeral-gap);
   align-items: center;
   padding: var(--gap-row) 0;
-  transition: background var(--t-fast) var(--ease);
+  /* The bottom padding differs between the shut and open rows (see the
+     [open] rule below), so it has to travel over the same window the body
+     does. Left untransitioned it changed on the frame of the click, which
+     shunted everything below the phase 14px in the OPPOSITE direction to
+     the one the body was about to move it -- a jump introduced by the
+     animation, in the middle of the animation. */
+  transition: background var(--t-fast) var(--ease),
+              padding-bottom var(--t-disclose) var(--ease);
 }
 
 /* Wherever a task row HAS a rail (the same breakpoint, from the other side),
@@ -2086,7 +2093,23 @@ pre code { font-size: 1em; }
 
       setPhaseOpen(phase, false, false);
 
+      /* Nothing below the phase may move on the FRAME of the click: the whole
+         change has to be inside the animation. The summary's bottom padding
+         differs between the shut and open rows and was not transitioned, so
+         it shunted the rest of the page 14px the instant a phase was clicked
+         -- in the opposite direction to the one the body was about to move
+         it. A delta, never a position, so the frame's size cannot matter. */
+      const below = phase.nextElementSibling;
+      const beforeTop = below ? below.getBoundingClientRect().top : 0;
+
       setPhaseOpen(phase, true, true);
+      if (below) {
+        const shift = Math.abs(below.getBoundingClientRect().top - beforeTop);
+        if (shift > 1) {
+          throw new Error("clicking a phase shifted the page " + Math.round(shift)
+            + "px before anything had animated");
+        }
+      }
       if (!phase.open) throw new Error("opening did not open the phase");
       if (phase.classList.contains("is-closing")) throw new Error("opening left is-closing set");
       const opening = heightAnimations(body);
@@ -2120,6 +2143,23 @@ pre code { font-size: 1em; }
         throw new Error("closing ends at height=" + last.height
           + " paddingTop=" + last.paddingTop + " paddingBottom=" + last.paddingBottom
           + ", not at nothing");
+      }
+
+      /* Reversing that close has to resume from the frame ON SCREEN, opacity
+         included. The body is fully visible at this point, so an open that
+         assumed a start of 0 would blink it out and fade it back in. */
+      setPhaseOpen(phase, true, true);
+      const resumed = heightAnimations(body)[0].effect.getKeyframes()[0];
+      if (parseFloat(resumed.opacity) < 0.5) {
+        throw new Error("reversing a close restarts the fade at opacity " + resumed.opacity);
+      }
+      heightAnimations(body).forEach(function (a) { a.finish(); });
+
+      /* And a phase already sitting where it is asked to go is left alone --
+         "expand all" reaches every phase, including ones already open. */
+      setPhaseOpen(phase, true, true);
+      if (heightAnimations(body).length) {
+        throw new Error("re-opening an already-open phase animated it again");
       }
 
       /* And the instant path settles everything the animated one leaves in
@@ -2426,16 +2466,32 @@ pre code { font-size: 1em; }
     return !details.open || details.classList.contains("is-closing");
   }
 
-  /* The body's vertical padding, which has to travel with its height: with
+  /* Everything the disclosure animates, as it is RIGHT NOW -- read together
+     so a reversal mid-flight resumes from one consistent frame rather than
+     from three properties sampled at different times.
+
+     The padding is in here because it has to travel with the height: with
      `box-sizing: border-box` a height of 0 still leaves the padding on
      screen, so a phase would collapse to a bar of blank space and then drop
-     it -- precisely the jump this is all here to remove. */
-  function verticalPadding(el) {
-    const cs = window.getComputedStyle(el);
-    return { top: cs.paddingTop || "0px", bottom: cs.paddingBottom || "0px" };
+     it -- precisely the jump this is all here to remove.
+
+     The opacity is in here because it must NOT be assumed. Hard-coding a
+     start of 0 for every open blinked out any body that was already
+     visible: "expand all" over a phase a reader had opened by hand faded it
+     from nothing, and reversing a close snapped the content dimmer before
+     bringing it back. */
+  function bodyState(body) {
+    const cs = window.getComputedStyle(body);
+    return {
+      height: body.getBoundingClientRect().height + "px",
+      paddingTop: cs.paddingTop || "0px",
+      paddingBottom: cs.paddingBottom || "0px",
+      opacity: cs.opacity || "1",
+    };
   }
 
-  const NO_PADDING = { top: "0px", bottom: "0px" };
+  /* What a shut phase's body looks like: nothing at all, on every axis. */
+  const COLLAPSED = { height: "0px", paddingTop: "0px", paddingBottom: "0px", opacity: "0" };
 
   /* The disclosure animations on an element, and only those. `getAnimations`
      also returns anything CSS has left lying around with a fill, so a bare
@@ -2473,20 +2529,31 @@ pre code { font-size: 1em; }
       return;
     }
 
+    /* Already where it is being asked to go, and nothing in flight: leave it
+       alone. "Expand all" reaches every phase including the ones a reader
+       opened by hand, and animating one of those from its own current state
+       to its own current state is a no-op for the height but a full pass for
+       everything else.
+
+       An animation that has FINISHED but whose `onfinish` has not run yet
+       (that fires on a later task) is not in flight -- it still holds this
+       phase's slot in `disclosing`, and its own cleanup is still correct
+       when it arrives. */
+    const inFlight = !!running && running.playState !== "finished";
+    if (!inFlight && details.open === want && !details.classList.contains("is-closing")) return;
+
     /* Clip first, measure second. `overflow: hidden` makes the body a block
        formatting context, so its children's margins stop collapsing through
        it -- measuring before setting it would return a height the box never
        actually has while animating, and the phase would jump at the end by
        the difference. */
     body.style.overflow = "hidden";
-    /* Where the box is NOW. Mid-animation these read the animated values, so
-       a click part-way through a close carries on from where it got to
+    /* Where the box is NOW. Mid-animation this reads the animated values, so
+       a click part-way through a close carries on from the frame on screen
        instead of restarting. Note the state is taken from `open`, never from
        the measurement: a shut <details> keeps reporting the size its body
        had when it was last open. */
-    const from = details.open
-      ? { h: body.getBoundingClientRect().height, pad: verticalPadding(body) }
-      : { h: 0, pad: NO_PADDING };
+    const from = details.open ? bodyState(body) : COLLAPSED;
     if (running) { disclosing.delete(details); running.cancel(); }
 
     if (want) {
@@ -2495,31 +2562,13 @@ pre code { font-size: 1em; }
     } else {
       details.classList.add("is-closing");
     }
-    /* And where it is going. Measured after the cancel above, so these are
-       the element's own resting values, not another animation's. */
-    const to = want
-      ? { h: body.getBoundingClientRect().height, pad: verticalPadding(body) }
-      : { h: 0, pad: NO_PADDING };
+    /* And where it is going. Read after the cancel above, so these are the
+       element's own resting values, not another animation's. */
+    const to = want ? bodyState(body) : COLLAPSED;
 
     const timing = discloseTiming();
     const anim = body.animate(
-      /* Both paddings travel with the height (see verticalPadding), and
-         opacity travels with them so the content fades rather than being
-         sliced off by the clip edge. */
-      [
-        {
-          height: from.h + "px",
-          paddingTop: from.pad.top,
-          paddingBottom: from.pad.bottom,
-          opacity: want ? 0 : 1,
-        },
-        {
-          height: to.h + "px",
-          paddingTop: to.pad.top,
-          paddingBottom: to.pad.bottom,
-          opacity: want ? 1 : 0,
-        },
-      ],
+      [from, to],
       {
         duration: timing.duration,
         easing: timing.easing,

--- a/tests/fixtures/plan/kitchen-sink.html
+++ b/tests/fixtures/plan/kitchen-sink.html
@@ -2170,6 +2170,51 @@ pre code { font-size: 1em; }
       if (phase.classList.contains("is-closing")) throw new Error("the instant path left is-closing set");
       if (body.style.overflow) throw new Error("the instant path left the body clipped");
     });
+    check("a link in a phase row still navigates", function () {
+      const phase = document.querySelector("details.phase");
+      const teaser = phase && phase.querySelector(".phase-teaser");
+      if (!teaser) throw new Error("no phase description to put a link in");
+      /* The phase description sits INSIDE the <summary>, and the renderer
+         keeps safe markdown links in it. Taking over the summary's click
+         cancelled those links: one cancelled flag covers every activation
+         behaviour on the event's path. Injected here rather than baked into
+         the fixture because what is under test is this file's click
+         handling, not the renderer. */
+      const link = document.createElement("a");
+      link.href = "#selftest-link-probe";
+      link.textContent = "link";
+      teaser.appendChild(link);
+      const wasOpen = phase.open;
+      /* Read the cancelled flag from the far end of the bubble path -- past
+         the summary's handler -- then cancel for real, so the probe does not
+         actually navigate the page it is testing. */
+      let cancelled = null;
+      function spy(e) { cancelled = e.defaultPrevented; e.preventDefault(); }
+      document.addEventListener("click", spy);
+      link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      document.removeEventListener("click", spy);
+      link.remove();
+      if (cancelled === null) throw new Error("the probe click never reached the document");
+      if (cancelled) throw new Error("clicking a link in a phase row cancelled its navigation");
+      if (phase.open !== wasOpen) throw new Error("clicking a link in a phase row toggled the phase");
+    });
+    check("commenting on a shut phase reveals the editor", function () {
+      const phase = document.querySelector("details.phase");
+      const btn = phase && phase.querySelector("summary .comment-btn");
+      const box = phase && phase.querySelector(".phase-body > .comment-box");
+      if (!btn || !box) throw new Error("phase has no comment editor mounted");
+      /* Collapsing a phase leaves an open editor with `hidden === false`
+         while the <details> keeps it off screen, so the two disagree. A
+         plain toggle from that state hides something already invisible and
+         the click does nothing a reader can see. */
+      setPhaseOpen(phase, false, false);
+      box.hidden = false;
+      btn.click();
+      if (phaseIsShut(phase)) throw new Error("commenting on a shut phase left it shut");
+      if (box.hidden) throw new Error("commenting on a shut phase hid the editor");
+      setPhaseOpen(phase, false, false);
+      box.hidden = true;
+    });
     if (location.protocol !== "file:" || window.parent !== window) {
       /* Non-plain-file contexts only — a real http(s) serving, or the CI
          harness that frames this page in a sandboxed iframe to give it the
@@ -2908,18 +2953,23 @@ pre code { font-size: 1em; }
            its toggle. Commenting on an open phase used to shut it, hiding
            the very box the click had just opened. */
         e.stopPropagation();
-        box.hidden = !box.hidden;
-        if (box.hidden) return;
         if (el.tagName === "DETAILS" && phaseIsShut(el)) {
           /* The button is in the summary but the box is in the body, which
-             only exists while the phase is open -- so open it. Focus without
-             scrolling: the body is mid-animation and clipped, and scrolling
-             into it now would leave the clip box scrolled once it settles. */
+             is off screen while the phase is shut -- whatever `hidden` says.
+             It can be left un-hidden, too: collapsing a phase that had an
+             editor open does not touch the box. Toggling from there would
+             hide something the reader cannot see and the click would have no
+             visible effect at all, so a shut phase always REVEALS rather
+             than toggles. Focus without scrolling: the body is mid-animation
+             and clipped, and scrolling into it now would leave the clip box
+             scrolled once it settles. */
+          box.hidden = false;
           setPhaseOpen(el, true, true);
           textarea.focus({ preventScroll: true });
           return;
         }
-        textarea.focus();
+        box.hidden = !box.hidden;
+        if (!box.hidden) textarea.focus();
       });
 
       cancelBtn.addEventListener("click", function () {
@@ -2966,6 +3016,19 @@ pre code { font-size: 1em; }
         if (!summary) return;
         summary.addEventListener("click", function (e) {
           if (e.defaultPrevented) return;
+          /* A link or a control inside the row owns its own click, and the
+             browser already does the right thing with one: the innermost
+             element with an activation behaviour wins, so a click on an <a>
+             in the phase description follows the link and does NOT toggle
+             the phase. Stay out of the way entirely. Cancelling here would
+             take the navigation with it -- a click event carries a single
+             cancelled flag for every activation behaviour on its path, so
+             there is no way to suppress the toggle and keep the link.
+             (`phase_summary_parts` keeps safe links in the teaser, and the
+             teaser is inside the <summary>.) */
+          if (e.target.closest && e.target.closest("a[href], button, input, select, textarea, label")) {
+            return;
+          }
           e.preventDefault();
           setPhaseOpen(d, phaseIsShut(d), true);
         });

--- a/tests/fixtures/plan/kitchen-sink.html
+++ b/tests/fixtures/plan/kitchen-sink.html
@@ -202,15 +202,17 @@
   --t-fast: 110ms;
   --t-mid: 200ms;
   --t-slow: 380ms;
+  /* How long a phase takes to open or shut. A <details> element has no
+     motion of its own, so this one is driven from plan.js -- which reads
+     the value (and --ease) back off :root rather than carrying a number of
+     its own, so the page's motion budget stays declared here with the rest
+     of it. Short on purpose: long enough to show the page growing, short
+     enough that nobody waits for it. */
+  --t-disclose: 240ms;
 }
 
 @keyframes pv-rise {
   from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: none; }
-}
-
-@keyframes pv-reveal {
-  from { opacity: 0; transform: translateY(-4px); }
   to { opacity: 1; transform: none; }
 }
 
@@ -1131,8 +1133,17 @@ details.phase > summary {
 details.phase > summary:hover { background: var(--accent-wash); }
 
 /* Open phases give the numeral more room and top-align it with the title,
-   because the content below it is now several blocks tall. */
-details.phase[open] > summary {
+   because the content below it is now several blocks tall.
+
+   `.is-closing` is plan.js telling this stylesheet "the reader has clicked
+   this shut; it is only still `open` because its body is mid-animation".
+   The DOM has to keep the attribute for a few hundred milliseconds longer
+   (there would be nothing left on screen to shrink otherwise), but the row
+   itself must look shut from the click onwards, or the chevron and the
+   numeral would snap back after the movement instead of leading it. Every
+   [open] rule on the summary is excused for that window; the body's own
+   rules are not, since the body is what's animating. */
+details.phase[open]:not(.is-closing) > summary {
   align-items: start;
   padding-bottom: 1.5rem;
 }
@@ -1147,7 +1158,7 @@ details.phase[open] > summary {
   transition: font-size var(--t-mid) var(--ease), color var(--t-fast) var(--ease);
 }
 
-details.phase[open] > summary .phase-numeral { font-size: 3.5rem; }
+details.phase[open]:not(.is-closing) > summary .phase-numeral { font-size: 3.5rem; }
 details.phase > summary:hover .phase-numeral { color: var(--accent); }
 
 .phase-head {
@@ -1192,21 +1203,32 @@ details.phase > summary:hover .phase-numeral { color: var(--accent); }
   transition: transform var(--t-mid) var(--ease), color var(--t-fast) var(--ease);
 }
 
-details.phase[open] > summary .phase-marker { transform: rotate(90deg); }
+details.phase[open]:not(.is-closing) > summary .phase-marker { transform: rotate(90deg); }
 details.phase > summary:hover .phase-marker { color: var(--accent); }
 
-/* The expanded body, indented to sit under the phase's content column. Every
-   direct child rises in on open -- one short movement that shows where the new
-   content came from. */
+/* The expanded body, indented to sit under the phase's content column.
+
+   Its opening and closing movement is driven from plan.js, not from here --
+   a CSS animation cannot do the job. A shut <details> hides its body with
+   `content-visibility: hidden`, which skips the subtree's RENDERING but
+   leaves its animations on their original timeline, so a keyframe animation
+   declared here fires once when the page loads and never again when a phase
+   is actually opened. (This rule used to carry a `pv-reveal` fade for
+   exactly that reason and had quietly stopped running.) plan.js animates the
+   height, the bottom padding and the opacity together over --t-disclose.
+
+   It also sets `overflow: hidden` inline for the length of that animation
+   and clears it afterwards: the body is only ever a clipping box while it is
+   shorter than its own contents. Left on permanently it would crop focus
+   rings and anything else that legitimately paints past the edge. */
 details.phase > .phase-body {
   margin-left: calc(var(--numeral-col) + var(--numeral-gap));
   padding-bottom: 2.25rem;
-  animation: pv-reveal var(--t-slow) var(--ease) both;
 }
 
 @media (max-width: 46rem) {
   details.phase > summary { grid-template-columns: 3rem minmax(0, 1fr) auto; gap: 1rem; }
-  details.phase[open] > summary .phase-numeral { font-size: 2.25rem; }
+  details.phase[open]:not(.is-closing) > summary .phase-numeral { font-size: 2.25rem; }
   details.phase > .phase-body { margin-left: 0; }
 }
 
@@ -2039,6 +2061,56 @@ pre code { font-size: 1em; }
         throw new Error("system not marked pressed");
       }
     });
+    check("phases open and shut with motion", function () {
+      const phase = document.querySelector("details.phase");
+      if (!phase) throw new Error("no phases on the page");
+      const body = phase.querySelector(".phase-body");
+      if (!body) throw new Error("phase has no body to animate");
+      /* No Web Animations API, or a reader who asked for reduced motion:
+         instant IS the correct behaviour, and there would be nothing for
+         `heightAnimations` to report. Nothing to assert. */
+      if (!canDisclose() || !body.getAnimations) return;
+
+      setPhaseOpen(phase, false, false);
+
+      setPhaseOpen(phase, true, true);
+      if (!phase.open) throw new Error("opening did not open the phase");
+      if (phase.classList.contains("is-closing")) throw new Error("opening left is-closing set");
+      const opening = heightAnimations(body);
+      if (!opening.length) throw new Error("opening was not animated");
+      /* It must start from collapsed, or the box would appear at full size
+         and merely fade -- which is the jump, with a fade over it. */
+      const first = opening[0].effect.getKeyframes()[0];
+      if (parseFloat(first.height) !== 0 || parseFloat(first.paddingBottom) !== 0) {
+        throw new Error("opening starts at height=" + first.height
+          + " paddingBottom=" + first.paddingBottom + ", not from nothing");
+      }
+      opening.forEach(function (a) { a.finish(); });
+
+      /* The three things that make a close look right, and each of which
+         has to be got wrong deliberately to break: the body is still on the
+         page so there is something to shrink, the open styling is ALREADY
+         off so the chevron turns with the click rather than after it, and
+         the height really is being animated. */
+      setPhaseOpen(phase, false, true);
+      if (!phase.open) throw new Error("closing dropped the body before it could shrink");
+      if (!phase.classList.contains("is-closing")) throw new Error("closing left the open styling on");
+      const closing = heightAnimations(body);
+      if (!closing.length) throw new Error("closing was not animated");
+      const last = closing[0].effect.getKeyframes().slice(-1)[0];
+      if (parseFloat(last.height) !== 0 || parseFloat(last.paddingBottom) !== 0) {
+        throw new Error("closing ends at height=" + last.height
+          + " paddingBottom=" + last.paddingBottom + ", not at nothing");
+      }
+
+      /* And the instant path settles everything the animated one leaves in
+         flight -- otherwise a print or a second click could strand a phase
+         half-open, or leave its body permanently clipped. */
+      setPhaseOpen(phase, false, false);
+      if (phase.open) throw new Error("the instant path left the phase open");
+      if (phase.classList.contains("is-closing")) throw new Error("the instant path left is-closing set");
+      if (body.style.overflow) throw new Error("the instant path left the body clipped");
+    });
     if (location.protocol !== "file:" || window.parent !== window) {
       /* Non-plain-file contexts only — a real http(s) serving, or the CI
          harness that frames this page in a sandboxed iframe to give it the
@@ -2281,6 +2353,163 @@ pre code { font-size: 1em; }
       { rootMargin: "-10% 0px -70% 0px" }
     );
     phases.forEach(function (p) { spy.observe(p); });
+  }
+
+  /* ---- disclosure ----------------------------------------------------
+
+     A <details> element has no motion of its own: its body appears and
+     disappears between one frame and the next, so opening a phase shoves
+     everything below it down the page in a single jump, and shutting one
+     yanks it back. `setPhaseOpen` gives that change a duration by animating
+     the body's height, and every path a READER can trigger goes through it
+     -- the summary itself, the expand-all and collapse-all buttons, and a
+     comment button that has to open the phase it lives on.
+
+     Programmatic paths deliberately do not. Printing and the self-test pass
+     `false` for `animate` and stay instant: they want the end state, not a
+     transition to it.
+
+     Nothing here is load-bearing. A browser with no Web Animations API, or
+     a reader who has asked their system for reduced motion, falls straight
+     through to setting `.open` -- which is exactly the behaviour this page
+     had before. */
+
+  /* The animation currently running on a phase, if any, so a second click
+     part-way through can take the phase over rather than fight it. */
+  const disclosing = new WeakMap();
+
+  /* Duration and easing for a disclosure, read out of plan.css. A value that
+     is missing (no stylesheet) or unparseable falls back to a sane pair
+     rather than to a zero-length -- and therefore invisible -- animation. */
+  function discloseTiming() {
+    const root = window.getComputedStyle(document.documentElement);
+    const raw = root.getPropertyValue("--t-disclose").trim();
+    const ms = raw.slice(-2) === "ms" ? parseFloat(raw) : parseFloat(raw) * 1000;
+    return {
+      duration: ms > 0 ? ms : 240,
+      easing: root.getPropertyValue("--ease").trim() || "ease",
+    };
+  }
+
+  /* Whether to animate at all. plan.css's prefers-reduced-motion block can
+     only reach CSS animations and transitions, so motion driven from here
+     has to consult the same query itself or it would ignore the one setting
+     the whole budget is meant to answer to. */
+  function canDisclose() {
+    if (!window.Element || typeof Element.prototype.animate !== "function") return false;
+    if (!window.matchMedia) return true;
+    return !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+
+  /* Whether a phase reads as SHUT to the person looking at it: either really
+     closed, or open-but-mid-close. A click during a close has to re-open. */
+  function phaseIsShut(details) {
+    return !details.open || details.classList.contains("is-closing");
+  }
+
+  function bottomPadding(el) {
+    return window.getComputedStyle(el).paddingBottom || "0px";
+  }
+
+  /* The disclosure animations on an element, and only those. `getAnimations`
+     also returns anything CSS has left lying around with a fill, so a bare
+     length check would pass whether or not this file animated anything --
+     the keyframes are what identify ours. */
+  function heightAnimations(el) {
+    if (!el.getAnimations) return [];
+    return el.getAnimations().filter(function (a) {
+      const frames = a.effect && a.effect.getKeyframes ? a.effect.getKeyframes() : [];
+      return frames.some(function (f) { return f.height !== undefined; });
+    });
+  }
+
+  /* Open or shut one phase.
+
+     Opening is the straightforward direction: set `open` (so the chevron,
+     the numeral and every other [open] rule in plan.css start their own
+     transitions on the same frame), then grow the body from nothing into
+     its natural height.
+
+     Closing cannot do that in reverse, because clearing `open` removes the
+     body from the page immediately and leaves nothing to shrink. So `open`
+     stays set until the animation finishes, and the `is-closing` class tells
+     plan.css to treat the phase as visually shut in the meantime -- see the
+     `:not(.is-closing)` rules on the summary. */
+  function setPhaseOpen(details, want, animate) {
+    const body = details.querySelector(".phase-body");
+    const running = disclosing.get(details);
+
+    if (!body || animate === false || !canDisclose()) {
+      if (running) { disclosing.delete(details); running.cancel(); }
+      if (body) body.style.overflow = "";
+      details.classList.remove("is-closing");
+      details.open = want;
+      return;
+    }
+
+    /* Clip first, measure second. `overflow: hidden` makes the body a block
+       formatting context, so its children's margins stop collapsing through
+       it -- measuring before setting it would return a height the box never
+       actually has while animating, and the phase would jump at the end by
+       the difference. */
+    body.style.overflow = "hidden";
+    /* Where the box is NOW. Mid-animation these read the animated values, so
+       a click part-way through a close carries on from where it got to
+       instead of restarting. Note the state is taken from `open`, never from
+       the measurement: a shut <details> keeps reporting the size its body
+       had when it was last open. */
+    const from = details.open
+      ? { h: body.getBoundingClientRect().height, pad: bottomPadding(body) }
+      : { h: 0, pad: "0px" };
+    if (running) { disclosing.delete(details); running.cancel(); }
+
+    if (want) {
+      details.classList.remove("is-closing");
+      details.open = true;
+    } else {
+      details.classList.add("is-closing");
+    }
+    /* And where it is going. Measured after the cancel above, so these are
+       the element's own resting values, not another animation's. */
+    const to = want
+      ? { h: body.getBoundingClientRect().height, pad: bottomPadding(body) }
+      : { h: 0, pad: "0px" };
+
+    const timing = discloseTiming();
+    const anim = body.animate(
+      /* Padding travels with the height. The body carries 2.25rem of bottom
+         padding and `box-sizing: border-box`, so a height of 0 alone still
+         leaves a 36px stub on screen -- the last thing a close did was drop
+         it, which is precisely the jump this is here to remove. Opacity
+         travels with them so the content fades rather than being sliced off
+         by the clip edge. */
+      [
+        { height: from.h + "px", paddingBottom: from.pad, opacity: want ? 0 : 1 },
+        { height: to.h + "px", paddingBottom: to.pad, opacity: want ? 1 : 0 },
+      ],
+      {
+        duration: timing.duration,
+        easing: timing.easing,
+        /* A close holds its last frame. Without the fill the body would
+           spring back to full height for the one frame between the
+           animation ending and `open` being cleared below. */
+        fill: want ? "none" : "forwards",
+      }
+    );
+    disclosing.set(details, anim);
+    anim.onfinish = function () {
+      /* A later call already took this phase over; the cleanup is its job
+         now. (Cancelling does not fire this handler, so reaching here with
+         a stale animation means the phase was re-clicked mid-flight.) */
+      if (disclosing.get(details) !== anim) return;
+      disclosing.delete(details);
+      if (!want) {
+        details.open = false;
+        details.classList.remove("is-closing");
+      }
+      body.style.overflow = "";
+      anim.cancel();
+    };
   }
 
   /* Where a commentable block wants its comment button and its draft box.
@@ -2590,9 +2819,25 @@ pre code { font-size: 1em; }
       box.appendChild(blockingRow);
       box.appendChild(actions);
 
-      btn.addEventListener("click", function () {
+      btn.addEventListener("click", function (e) {
+        /* The same guard the reviewed toggle carries below, for the same
+           reason: on a PHASE this button is placed inside the <summary>
+           (see commentSlots), and a click that reaches the summary triggers
+           its toggle. Commenting on an open phase used to shut it, hiding
+           the very box the click had just opened. */
+        e.stopPropagation();
         box.hidden = !box.hidden;
-        if (!box.hidden) textarea.focus();
+        if (box.hidden) return;
+        if (el.tagName === "DETAILS" && phaseIsShut(el)) {
+          /* The button is in the summary but the box is in the body, which
+             only exists while the phase is open -- so open it. Focus without
+             scrolling: the body is mid-animation and clipped, and scrolling
+             into it now would leave the clip box scrolled once it settles. */
+          setPhaseOpen(el, true, true);
+          textarea.focus({ preventScroll: true });
+          return;
+        }
+        textarea.focus();
       });
 
       cancelBtn.addEventListener("click", function () {
@@ -2630,6 +2875,20 @@ pre code { font-size: 1em; }
         return document.querySelectorAll("details.phase");
       }
 
+      /* A <summary>'s built-in default action is "toggle, instantly". Take
+         it over so a click gets the animation instead. Keyboard activation
+         (Enter or Space on the focused summary) dispatches a click of its
+         own, so it comes through the same handler and behaves the same. */
+      collapsibles().forEach(function (d) {
+        const summary = d.querySelector("summary");
+        if (!summary) return;
+        summary.addEventListener("click", function (e) {
+          if (e.defaultPrevented) return;
+          e.preventDefault();
+          setPhaseOpen(d, phaseIsShut(d), true);
+        });
+      });
+
       /* The markup ships an empty actions slot on the Phases section rule
          (render.rs's `section_rule`), so these land on the divider rather
          than floating above the list as a stray toolbar. */
@@ -2640,7 +2899,7 @@ pre code { font-size: 1em; }
       expandBtn.className = "pv-textbtn";
       expandBtn.textContent = "expand all";
       expandBtn.addEventListener("click", function () {
-        collapsibles().forEach(function (d) { d.open = true; });
+        collapsibles().forEach(function (d) { setPhaseOpen(d, true, true); });
       });
 
       const collapseBtn = document.createElement("button");
@@ -2648,7 +2907,7 @@ pre code { font-size: 1em; }
       collapseBtn.className = "pv-textbtn";
       collapseBtn.textContent = "collapse all";
       collapseBtn.addEventListener("click", function () {
-        collapsibles().forEach(function (d) { d.open = false; });
+        collapsibles().forEach(function (d) { setPhaseOpen(d, false, true); });
       });
 
       ctl.appendChild(expandBtn);
@@ -2660,12 +2919,15 @@ pre code { font-size: 1em; }
          before print, then restore whatever state the user had before. */
       let preprintState = null;
       window.addEventListener("beforeprint", function () {
-        preprintState = Array.from(collapsibles()).map(function (d) { return d.open; });
-        collapsibles().forEach(function (d) { d.open = true; });
+        /* `phaseIsShut`, not `.open`: a phase caught mid-close is still
+           technically open, and restoring it as open afterwards would leave
+           the reader with a phase they had just clicked shut. */
+        preprintState = Array.from(collapsibles()).map(function (d) { return !phaseIsShut(d); });
+        collapsibles().forEach(function (d) { setPhaseOpen(d, true, false); });
       });
       window.addEventListener("afterprint", function () {
         if (!preprintState) return;
-        collapsibles().forEach(function (d, i) { d.open = preprintState[i]; });
+        collapsibles().forEach(function (d, i) { setPhaseOpen(d, preprintState[i], false); });
         preprintState = null;
       });
     }


### PR DESCRIPTION
Two commits, both on the plan viewer's phase disclosure.

## 1. Phases open and shut with motion (`437bba3`)

A `<details>` element has no motion of its own: its body appears and disappears between one frame and the next, so opening a phase shoved everything below it down the page in a single jump.

`plan.js` now animates the body's height, vertical padding and opacity over a new `--t-disclose` token (240ms). Every reader-facing path goes through one function — the summary itself, expand all, collapse all, and a comment button that has to open the phase it sits on. Printing and the self-test pass `animate: false` and stay instant: they want the end state, not a transition to it.

**Why JavaScript and not CSS.** The CSS that would do this (`::details-content` plus `interpolate-size: allow-keywords`) is not portable enough to rely on — a browser without it would get no change at all. The duration and easing still live in `plan.css` as `--t-disclose` and `--ease`, which the JS reads off `:root`, so the stylesheet's claim that the page's whole motion budget is declared in one place stays true.

**Closing can't just run the open backwards.** Clearing `open` removes the body from the page immediately, leaving nothing to shrink. So `open` stays set for the length of the animation and an `is-closing` class tells `plan.css` to treat the phase as visually shut meanwhile — that is what keeps the chevron turning with the click rather than a quarter-second after it. A click during a close reverses from wherever it had got to.

Two things fell out of writing it:

- **The `pv-reveal` fade on `.phase-body` had quietly stopped running.** A shut `<details>` hides its body with `content-visibility: hidden`, which skips the subtree's rendering but leaves its animations on their original timeline, so the keyframes fired once at page load and never again. The fade moves into the JS animation, which runs in both directions.
- **Commenting on a phase collapsed it**, hiding the editor the click had just opened: the Comment button is placed inside the `<summary>`, whose default action is to toggle. It now stops there, and opens a shut phase rather than toggling an open one.

Reduced motion is honoured explicitly — `plan.css`'s media query can only reach CSS animations, so JS-driven motion consults the same query itself and falls through to the plain instant toggle.

## 2. A phase body gets its own top space (`cc6c208`)

The Dependencies label sat 24px below the phase description and 26px above the graph — the only section label on the page with as much room under it as over it, so it read as floating between the two rather than heading the graph.

| label | above | below |
|---|---|---|
| Summary / Risks / Phases | 56 | 26 |
| Acceptance (in a task) | 22 | 14 |
| **Dependencies** (before) | **24** | **26** |
| **Dependencies** (after) | **40** | **26** |

The 24px was not the body's own spacing either: `.phase-body` had no top padding at all, so the whole gap came from the summary's `padding-bottom` — which is also what the hover and `:target` bands are drawn to, leaving the label pressed against the highlighted block's edge whenever a phase was pointed at. The summary's bottom padding drops to `0.75rem` so the band wraps its own content; the body takes `--gap-block` of top padding.

That new `padding-top` had to join the animation: with `box-sizing: border-box` a height of 0 still paints the padding, so an unanimated `padding-top` would have reappeared as a 28px stub at the top of every opening phase — the same defect already fixed at the bottom edge.

## Testing

740 lib + 194 integration tests, `clippy --all-targets` and `rustfmt` clean, both browser-smoke selftests green.

The page's own self-test gains a `phases open and shut with motion` check. Each assertion in it was verified against its own reintroduced defect rather than trusting a green run — that mattered here, because `.phase-body` always carries at least one animation, so a bare "is something animating?" test would have passed regardless. The check inspects keyframe shape instead. Seven defects were each confirmed to fail with a distinct message: close drops the body early, no `is-closing`, top padding stub, bottom padding stub, no animation at all, opens at full size, and closing stopping short of zero.

Behaviour verified in headless Chromium beyond the self-test: mid-flight interruption resumes from the current height rather than restarting; expand all and collapse all animate every phase; the reduced-motion path leaves no inline styles behind; the reviewed toggle and the comment button no longer toggle the phase; clicking the title or teaser still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9fLmTu8XQp1M4kCrZwK3A