### PR TITLE
fix(studio): say 'in use' on workflow cards instead of a bare checkmark

### DIFF
--- a/src/studio/assets/studio.css
+++ b/src/studio/assets/studio.css
@@ -523,8 +523,7 @@ body {
 .wf-card-glyph { display: inline-flex; color: var(--accent); flex: none; }
 .wf-card-glyph .icon { width: 17px; height: 17px; }
 .wf-card-name { font-weight: 600; font-size: 13.5px; flex: 1; min-width: 0; }
-.wf-card-dot { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; flex: none; border-radius: 50%; background: var(--ok); color: var(--bg); }
-.wf-card-dot .icon { width: 12px; height: 12px; }
+.wf-card-pill { flex: none; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; color: var(--ok); background: rgba(127, 214, 160, 0.14); border-radius: 999px; padding: 1px 7px; }
 .wf-card-tag { flex: none; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); background: var(--elevated); border-radius: var(--r-sm); padding: 1px 5px; }
 .wf-card-blurb { font-size: 11.5px; line-height: 1.4; color: var(--muted); }
 /* detail — the focused workflow filling the fixed spine */
@@ -536,7 +535,6 @@ body {
 .wf-source:hover { text-decoration: underline; }
 .wf-source .icon { width: 12px; height: 12px; }
 .wf-detail-actions { flex: none; }
-.wf-active-pill { font-size: 11px; padding: 4px 9px; color: var(--ok); background: rgba(127, 214, 160, 0.14); }
 
 /* slots — the fixed steps as an equal-height grid across the width, so the
    cells stay put and only their contents change when you switch workflows. The

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -3324,11 +3324,16 @@ mod tests {
             body.contains("Every's loop where each cycle makes the next one easier."),
             "card blurb shown"
         );
-        // The bound workflow shows an "equipped on a loadout" marker — there's no
-        // global "active workflow" concept anymore.
+        // The bound workflow shows an explicit "in use" pill (equipped on ≥1
+        // loadout) — there's no global "active workflow" concept anymore, and
+        // the marker must say so in text, not just an icon.
+        assert!(
+            body.contains(r#"class="wf-card-pill""#) && body.contains("in use"),
+            "visible in-use pill for spec-driven"
+        );
         assert!(
             body.contains("equipped on"),
-            "binding marker for spec-driven"
+            "tooltip carries the loadout count"
         );
         assert!(
             body.contains(r#"<span class="cmd-name">explore</span>"#),

--- a/src/studio/state.rs
+++ b/src/studio/state.rs
@@ -276,7 +276,8 @@ pub struct WorkflowView {
 }
 
 /// The Workflows tab snapshot: the curated catalog plus your own (the gallery),
-/// which one's slots are shown (`focused_id`), and which is the global active.
+/// and which one's slots are shown (`focused_id`). Per-card loadout bindings
+/// live on each [`WorkflowView::bound_by`]; there is no global active workflow.
 pub struct WorkflowsView {
     pub workflows: Vec<WorkflowView>,
     /// The workflow whose slots are shown below the gallery.
@@ -994,9 +995,9 @@ fn stage_content_differs(
 }
 
 /// Build the Workflows tab view: the curated catalog plus your own (the gallery
-/// cards), with the global active workflow flagged and one workflow `focus`ed
-/// (its slots shown below). `focus` is the card the user clicked; it falls back
-/// to the active workflow, then the first card.
+/// cards), each carrying the loadouts that bind it (`bound_by` — the "in use"
+/// marker), and one workflow `focus`ed (its slots shown below). `focus` is the
+/// card the user clicked; it falls back to the first card.
 pub fn workflows_view(snap: &Snapshot, focus: Option<&str>) -> WorkflowsView {
     let cfg = staged_config(snap).ok();
     let effective = cfg

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -1355,7 +1355,8 @@ pub fn targets_tab_fragment(view: &TargetsView) -> String {
 
 /// The Workflows tab: an always-visible gallery of curated + your own workflows
 /// (tiny named cards across the top), and below it the focused one shown as its
-/// ordered slots. Picking one makes it your single global active workflow.
+/// ordered slots. Browse/edit only — a workflow is used by equipping it in a
+/// loadout's Workflow slot, not activated globally.
 pub fn workflows_tab(view: &WorkflowsView, flash: Option<&str>) -> Markup {
     let focused = view
         .focused_id
@@ -1402,8 +1403,8 @@ pub fn workflows_tab_fragment(view: &WorkflowsView) -> String {
     workflows_tab(view, None).into_string()
 }
 
-/// Re-render the Workflows tab after selecting an active workflow: the tab (with
-/// a flash) plus a staged-changes indicator refresh.
+/// Re-render the Workflows tab after a gallery mutation (create/edit/delete):
+/// the tab (with a flash) plus a staged-changes indicator refresh.
 pub fn workflows_result(view: &WorkflowsView, flash: &str) -> String {
     html! {
         (workflows_tab(view, Some(flash)))
@@ -1507,7 +1508,7 @@ fn workflow_gallery_card(w: &WorkflowView, focused: bool) -> Markup {
             span class="wf-card-top" {
                 span class="wf-card-glyph" { (icon(glyph)) }
                 span class="wf-card-name" { (w.title) }
-                @if in_use { span class="wf-card-dot" title=(format!("equipped on {} loadout(s)", w.bound_by.len())) { (icon("check")) } }
+                @if in_use { span class="wf-card-pill" title=(format!("equipped on {} loadout(s)", w.bound_by.len())) { "in use" } }
                 @else if !w.builtin { span class="wf-card-tag" { "yours" } }
             }
             @if let Some(b) = &w.blurb { span class="wf-card-blurb" { (b) } }
@@ -1515,8 +1516,8 @@ fn workflow_gallery_card(w: &WorkflowView, focused: bool) -> Markup {
     }
 }
 
-/// The focused workflow in full: title + provenance + the slot spine + a "use
-/// this" action that sets it as the global active workflow.
+/// The focused workflow in full: title + provenance + the slot spine +
+/// browse/edit actions (Customize for built-ins; Edit/Delete for owned).
 fn workflow_detail(w: &WorkflowView) -> Markup {
     html! {
         div class="wf-detail" {


### PR DESCRIPTION
## Summary

Ellery's feedback on the Library → Workflows gallery: the green checkmark on a workflow card read as a global \"selected\" state — a model that no longer exists, since workflows are equipped per loadout, not activated system-wide.

- The marker is now an explicit **IN USE** pill (green, uppercase, rounded) instead of a bare check icon; the hover tooltip still carries the exact count (\"equipped on N loadout(s)\").
- Dropped the dead `.wf-active-pill` CSS rule (unreferenced leftover from the old global-active model) and rewrote the three doc comments that still described that model.
- Strengthened the gallery test to require the visible \"in use\" text and pill class, not just the tooltip.

Not touched here: `docs/screenshots/workflows.png` still shows the old checkmark — PR #38 also recaptures that file (without the inbox icon), so one recapture after both merge avoids a binary conflict.

## Validation

- `cargo test --lib studio`: 160 passed, 0 failed
- `cargo clippy --all-targets` / `cargo fmt --check`: clean
- Verified live: headless capture of the gallery shows the IN USE pill on the equipped card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc3AwWKfsMg487k4ki5ryJ