### PR TITLE
feat(update): check for a newer release on every command, configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to loadout are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
+## Unreleased
+
+### Changed
+
+- **The update nudge now runs on every `load` command, not once a day.**
+  Any interactive command — `refresh`, `studio` (after it stops), `doctor`,
+  `explain`, and the launch line before `load run` — prints
+  `↑ update  a newer loadout is available — run \`load update\`` when a newer
+  release exists. The network check itself is capped at once per 10 minutes
+  and its verdict is cached, so the reminder costs nothing in between and an
+  offline machine never waits on it. Configure with `[update]
+  check = "always" | "daily" | "off"` in the global config (`always` is the
+  default; `daily` is the old cadence; the `LOADOUT_NO_UPDATE_CHECK`
+  environment variable remains a hard off). The setting is global-only — a
+  repo layer can't silence or force the nudge.
+
 ## 0.19.0 — 2026-08-07
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,6 +203,28 @@ hostnames/secrets) is gitignored and never leaves the box. Put `[sync]` in
 `local.toml` to vary it per machine — e.g. a CI box that should pull but never
 push: `auto_push = false`.
 
+## `[update]` (implemented)
+
+When the ambient "a newer loadout is available — run `load update`" nudge
+checks and prints. The nudge appears after any interactive `load` command
+(and before an agent launch); it is TTY-only and never blocks — the network
+check is time-bounded and its verdict is cached, so a stale install is
+reminded on every command without a network call each time.
+
+```toml
+[update]
+check = "always"   # "always" (default) | "daily" | "off"
+```
+
+- `always` — evaluated on every command; the actual network check runs at most
+  once per 10 minutes (the cached verdict covers the window).
+- `daily` — at most one network check per day.
+- `off` — never check, never nudge. The `LOADOUT_NO_UPDATE_CHECK` environment
+  variable is a hard off regardless of this setting.
+
+Global-only: a repo layer that sets `[update]` is stripped (a cloned repo
+must not be able to silence — or force — the nudge).
+
 ## `[[agents]]` (implemented)
 
 Built-in agents are a base layer; override by `id` or add new ones — no code

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -303,10 +303,11 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
         std::fs::create_dir_all(crate::workflow::artifacts_dir(&prep.repo_base)).ok();
     }
 
-    // Best-effort, throttled (once/day), time-bounded "update available" hint —
-    // skipped on dry-run, non-TTY, and via `LOADOUT_NO_UPDATE_CHECK`. Printed
-    // before the launch line since the launch `exec`s away on Unix.
-    if let Some(detail) = crate::update::nudge_detail() {
+    // Best-effort, time-bounded "update available" hint, capped per the
+    // `[update] check` mode — skipped on dry-run, non-TTY, and via
+    // `LOADOUT_NO_UPDATE_CHECK`. Printed here rather than by main's ambient
+    // nudge because the launch `exec`s away on Unix — nothing after it runs.
+    if let Some(detail) = crate::update::nudge_detail(prep.config.update.check) {
         println!("{}", step(&p, p.cyan("↑"), "update", detail));
     }
     print_launch_step(&p, &program, &args.args);

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,8 @@ pub struct Config {
     pub env: EnvConfig,
     /// Codex-adapter knobs.
     pub codex: CodexConfig,
+    /// Ambient update-check behavior (`[update]`).
+    pub update: UpdateConfig,
     /// Your profiles (entirely user-authored; one is selected per context).
     pub profiles: Vec<LoadoutConfig>,
     /// Your fragment library (the `[[fragments]]` you authored, merged by
@@ -137,6 +139,15 @@ pub struct EnvConfig {
     pub allowlist: Vec<String>,
     /// Regexes over variable *names*; matches are always dropped.
     pub deny_name_patterns: Vec<String>,
+}
+
+/// Ambient update-check configuration (`[update]`).
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct UpdateConfig {
+    /// When the "newer release available" nudge checks and prints:
+    /// `always` (every command, network-capped — the default), `daily`, or
+    /// `off`. The `LOADOUT_NO_UPDATE_CHECK` env var is a hard off regardless.
+    pub check: crate::update::CheckMode,
 }
 
 /// Codex adapter configuration.
@@ -350,11 +361,14 @@ fn strip_global_only(layer: crate::fragment::Layer, parsed: &mut RawConfig) {
         //     otherwise add names (e.g. `DATABASE_URL`) to leak their values.
         //   - `[learn]` toggles ambient harvesting from your agent sessions;
         //     a cloned repo must never be able to flip it on.
+        //   - `[update]` governs the update-check nudge; a repo must not be
+        //     able to silence (or force) it.
         parsed.defaults = None;
         parsed.sync = None;
         parsed.codex = None;
         parsed.env = None;
         parsed.learn = None;
+        parsed.update = None;
     }
     if !layer.contributes_profiles() {
         parsed.profiles.clear();
@@ -384,6 +398,7 @@ struct RawConfig {
     codex: Option<RawCodex>,
     sync: Option<RawSync>,
     learn: Option<RawLearn>,
+    update: Option<RawUpdate>,
     // The user-authored loadouts. Canonical TOML key is `[[loadouts]]`; the old
     // `[[loadouts]]` key is still accepted (legacy alias) so existing configs
     // keep loading. The Rust field stays `profiles` — it's internal and renaming
@@ -452,6 +467,13 @@ struct RawLearn {
     model: Option<String>,
 }
 
+// Deliberately NOT `deny_unknown_fields`, same forward-compat stance as the
+// other operational tables.
+#[derive(Debug, Default, Deserialize)]
+struct RawUpdate {
+    check: Option<String>, // "always" (default) | "daily" | "off"
+}
+
 /// Every top-level key [`RawConfig`] models. A key outside this set is from a
 /// newer loadout (forward-compat) or a typo — tolerated, but warned about.
 const KNOWN_TOP_LEVEL: &[&str] = &[
@@ -460,6 +482,7 @@ const KNOWN_TOP_LEVEL: &[&str] = &[
     "codex",
     "sync",
     "learn",
+    "update",
     "loadouts",
     "profiles",
     "fragments",
@@ -500,6 +523,7 @@ fn warn_unknown_config_keys(text: &str, path: &Path) {
             "learn",
             &["enabled", "interval", "scope", "cli", "model"][..],
         ),
+        ("update", &["check"][..]),
     ] {
         if let Some(sub) = table.get(section).and_then(|v| v.as_table()) {
             for key in sub.keys() {
@@ -575,6 +599,12 @@ impl RawConfig {
             }
             if s.timeout.is_some() {
                 slot.timeout = s.timeout;
+            }
+        }
+        if let Some(u) = other.update {
+            let slot = self.update.get_or_insert_with(Default::default);
+            if u.check.is_some() {
+                slot.check = u.check;
             }
         }
         if let Some(l) = other.learn {
@@ -681,6 +711,11 @@ impl RawConfig {
             codex: CodexConfig {
                 write_override: codex.write_override.unwrap_or(true),
                 max_output_kib: codex.max_output_kib.unwrap_or(32),
+            },
+            update: UpdateConfig {
+                check: crate::update::CheckMode::parse(
+                    self.update.as_ref().and_then(|u| u.check.as_deref()),
+                ),
             },
             profiles,
             fragments,
@@ -958,6 +993,50 @@ mod tests {
         assert_eq!(c.learn.model.as_deref(), Some("sonnet"));
         // The earlier layer's `interval` survives — the overlay never set it.
         assert_eq!(c.learn.interval, std::time::Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn update_check_defaults_to_always_and_parses_each_mode() {
+        use crate::fragment::Layer;
+        use crate::update::CheckMode;
+        let c = Config::defaults();
+        assert_eq!(
+            c.update.check,
+            CheckMode::Always,
+            "[update] defaults to always"
+        );
+
+        for (value, expect) in [
+            ("always", CheckMode::Always),
+            ("daily", CheckMode::Daily),
+            ("off", CheckMode::Off),
+        ] {
+            let c = Config::from_layer_strs(vec![(
+                Layer::Global,
+                PathBuf::from("/g/config.toml"),
+                format!("[update]\ncheck = \"{value}\"\n"),
+            )])
+            .unwrap();
+            assert_eq!(c.update.check, expect, "check = \"{value}\"");
+        }
+
+        // A value written by a newer loadout degrades to daily, never bricks.
+        let c = Config::from_layer_strs(vec![(
+            Layer::Global,
+            PathBuf::from("/g/config.toml"),
+            "[update]\ncheck = \"hourly\"\n".to_string(),
+        )])
+        .unwrap();
+        assert_eq!(c.update.check, CheckMode::Daily);
+    }
+
+    #[test]
+    fn update_check_later_layer_wins_on_merge() {
+        let mut base: RawConfig = toml::from_str("[update]\ncheck = \"off\"\n").unwrap();
+        let overlay: RawConfig = toml::from_str("[update]\ncheck = \"daily\"\n").unwrap();
+        base.merge(overlay);
+        let c = base.finalize(vec![]);
+        assert_eq!(c.update.check, crate::update::CheckMode::Daily);
     }
 
     #[test]
@@ -1259,6 +1338,9 @@ mod tests {
 
         [learn]
         enabled = true
+
+        [update]
+        check = "off"
     "#;
 
     fn assert_operational_tables_stripped(c: &Config) {
@@ -1279,6 +1361,11 @@ mod tests {
         assert!(
             !c.learn.enabled,
             "repo must not enable [learn] — a cloned repo must never toggle learning"
+        );
+        assert_eq!(
+            c.update.check,
+            crate::update::CheckMode::Always,
+            "repo must not change [update].check — it can't silence (or force) the nudge"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,16 @@ fn main() -> ExitCode {
     };
     let rt = Runtime::new(cwd, cli.global.dry_run);
 
+    // The ambient update nudge runs after every interactive command, except:
+    // `run`/`launch` print their own before the launch `exec()`s away, `update`
+    // would be telling you what you just did, and `hook` is a machine caller
+    // whose stdout must stay clean. `nudge_detail`'s own gates (config mode,
+    // TTY, opt-out env, cap window) keep everything else quiet and cheap.
+    let ambient_nudge = !matches!(
+        &cli.command,
+        Command::Run(_) | Command::Launch(_) | Command::Update(_) | Command::Hook(_)
+    );
+
     let result = match &cli.command {
         Command::Detect(args) => commands::detect::run(&rt, args),
         Command::Run(args) => commands::run::run(&rt, args),
@@ -50,7 +60,12 @@ fn main() -> ExitCode {
     };
 
     match result {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(()) => {
+            if ambient_nudge {
+                loadout::update::ambient_nudge(&rt.cwd);
+            }
+            ExitCode::SUCCESS
+        }
         Err(e) => {
             eprintln!("error: {e:#}");
             ExitCode::FAILURE

--- a/src/update.rs
+++ b/src/update.rs
@@ -14,14 +14,59 @@ use std::time::{Duration, SystemTime};
 /// The app name axoupdater uses to locate the install receipt and releases.
 const APP: &str = "loadout";
 
-/// Opt out of the `load run` update nudge (any value disables it).
+/// Opt out of the update nudge entirely (any value disables it). The hard
+/// kill switch — it wins over any `[update] check` config.
 pub const NUDGE_OPT_OUT_ENV: &str = "LOADOUT_NO_UPDATE_CHECK";
 
-/// How often the `run` nudge re-checks for a newer release.
-const NUDGE_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+/// How often `check = "daily"` re-asks the release host.
+const DAILY_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// How often `check = "always"` re-asks the release host. "Always" means the
+/// nudge is *evaluated* on every command; the network call itself is capped at
+/// once per this window (GitHub's unauthenticated API allows 60 calls/hour per
+/// IP, shared with everything else on the machine) — within the window the
+/// cached verdict still nudges, so a stale install is reminded on every run.
+const ALWAYS_INTERVAL: Duration = Duration::from_secs(10 * 60);
 
 /// Bound the nudge's network check so a slow release host can't stall a launch.
 const NUDGE_TIMEOUT: Duration = Duration::from_millis(1500);
+
+/// When the ambient "newer release available" check runs. Configured via
+/// `[update] check = "always" | "daily" | "off"` in the global config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckMode {
+    /// Evaluate on every loadout command (network-capped; see [`ALWAYS_INTERVAL`]).
+    #[default]
+    Always,
+    /// At most one network check per day (the pre-0.20 behavior).
+    Daily,
+    /// Never check, never nudge.
+    Off,
+}
+
+impl CheckMode {
+    /// Parse the config string leniently. `None` (key absent) → the default;
+    /// an unrecognized value (likely written by a newer loadout) degrades to
+    /// `Daily` — still useful, minimal network — rather than erroring.
+    pub fn parse(value: Option<&str>) -> Self {
+        match value {
+            None => Self::default(),
+            Some(s) => match s.to_ascii_lowercase().as_str() {
+                "always" => Self::Always,
+                "daily" => Self::Daily,
+                "off" | "never" => Self::Off,
+                other => {
+                    crate::warn_user!(
+                        "unknown `[update] check` value '{other}' (expected always/daily/off); \
+                         using daily"
+                    );
+                    Self::Daily
+                }
+            },
+        }
+    }
+}
 
 /// What [`perform`] did, or why it couldn't.
 pub enum Outcome {
@@ -53,44 +98,189 @@ pub fn perform(check_only: bool) -> crate::Result<Outcome> {
         });
     }
     match updater.run_sync()? {
-        Some(result) => Ok(Outcome::Updated {
-            from: result.old_version.map(|v| v.to_string()),
-            to: result.new_version.to_string(),
-        }),
+        Some(result) => {
+            // A cached "available" verdict was computed against the binary we
+            // just replaced — drop it so the next command doesn't nudge about
+            // the update that already happened. (The version stamp in the
+            // cache guards this too; deleting is belt and braces.)
+            if let Some(cache) = cache_path() {
+                let _ = std::fs::remove_file(cache);
+            }
+            Ok(Outcome::Updated {
+                from: result.old_version.map(|v| v.to_string()),
+                to: result.new_version.to_string(),
+            })
+        }
         None => Ok(Outcome::AlreadyCurrent),
     }
 }
 
-/// Best-effort "update available" hint for `load run`. Returns the detail line
-/// to show (the caller renders it in its own step style), or `None` to stay
-/// quiet. It never errors and is cheap on the common path: gated on a TTY and the
-/// opt-out env, throttled to once per [`NUDGE_INTERVAL`] via an on-disk stamp, and
-/// the actual network check is time-bounded so it can't slow a launch.
-pub fn nudge_detail() -> Option<String> {
+/// Best-effort "update available" hint. Returns the detail line to show (the
+/// caller renders it in its own step style), or `None` to stay quiet. Never
+/// errors and is cheap on the common path: gated on a TTY and the opt-out env,
+/// the network call is capped per [`CheckMode`] via an on-disk verdict cache,
+/// and the check itself is time-bounded so it can't slow a launch. Within the
+/// cap window a cached "available" verdict still nudges — a stale install is
+/// reminded on every command, not just the one that happened to check.
+pub fn nudge_detail(mode: CheckMode) -> Option<String> {
+    if mode == CheckMode::Off {
+        return None;
+    }
     if std::env::var_os(NUDGE_OPT_OUT_ENV).is_some() {
         return None;
     }
     if !std::io::stdout().is_terminal() {
         return None;
     }
-    let stamp = stamp_path()?;
-    if !is_due(read_stamp(&stamp), SystemTime::now(), NUDGE_INTERVAL) {
-        return None;
+    let path = cache_path()?;
+    let (nudge, write) = decide(
+        mode,
+        read_cache(&path).as_ref(),
+        SystemTime::now(),
+        check_available_bounded,
+    );
+    if let Some(cache) = write {
+        let _ = write_cache(&path, &cache);
     }
-    // Stamp once per interval regardless of the outcome, so a flaky or offline
-    // check never nags and never repeatedly delays launches.
-    let available = check_available_bounded();
-    let _ = write_stamp(&stamp, SystemTime::now());
-    if available == Some(true) {
-        Some("a newer loadout is available — run `load update`".to_string())
-    } else {
-        None
+    nudge.then(|| "a newer loadout is available — run `load update`".to_string())
+}
+
+/// The ambient post-command nudge: [`nudge_detail`] with the mode read from
+/// the global config, printed in the standard step style. Called from `main`
+/// after interactive commands; `run` calls [`nudge_detail`] itself (it must
+/// print *before* the launch `exec()`s away). Infallible: an unreadable
+/// config falls back to the default mode.
+pub fn ambient_nudge(cwd: &Path) {
+    let repo_base = crate::context::repo_base_for(cwd);
+    let mode = crate::config::Config::load(&repo_base)
+        .map(|c| c.update.check)
+        .unwrap_or_default();
+    if let Some(detail) = nudge_detail(mode) {
+        let p = crate::style::Painter::auto();
+        println!(
+            "{}",
+            crate::commands::apply::step(&p, p.cyan("↑"), "update", detail)
+        );
     }
 }
 
-/// Where the once-a-day check timestamp lives (alongside the global config).
-fn stamp_path() -> Option<PathBuf> {
+/// What the last completed network check concluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Verdict {
+    /// A newer release exists.
+    Available,
+    /// This binary is the newest release.
+    Current,
+    /// The check could not complete (offline, timeout, no receipt).
+    Failed,
+}
+
+impl Verdict {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Available => "available",
+            Self::Current => "current",
+            Self::Failed => "failed",
+        }
+    }
+
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "available" => Some(Self::Available),
+            "current" => Some(Self::Current),
+            "failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+}
+
+/// The persisted result of the last check: when, by which binary version, and
+/// what it concluded. The version stamp invalidates the verdict across a
+/// binary swap (`load update`, reinstall) — an "available" computed by 0.19.0
+/// must not nudge the 0.20.0 that replaced it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CheckCache {
+    at: SystemTime,
+    version: String,
+    verdict: Verdict,
+}
+
+/// The one decision, pure over `(mode, cache, now)` with the network call
+/// injected — the whole matrix is unit-tested without touching the network.
+/// Returns `(nudge, cache-to-write)`.
+fn decide(
+    mode: CheckMode,
+    cache: Option<&CheckCache>,
+    now: SystemTime,
+    run_check: impl FnOnce() -> Option<bool>,
+) -> (bool, Option<CheckCache>) {
+    let interval = match mode {
+        CheckMode::Always => ALWAYS_INTERVAL,
+        CheckMode::Daily => DAILY_INTERVAL,
+        // Handled by the caller; treated as Daily defensively if it gets here.
+        CheckMode::Off => DAILY_INTERVAL,
+    };
+    // A cache from a different binary version is meaningless — ignore it (and
+    // check now). This also self-heals right after an update.
+    let valid = cache.filter(|c| c.version == env!("CARGO_PKG_VERSION"));
+    if valid.is_none_or(|c| is_due(Some(c.at), now, interval)) {
+        let verdict = match run_check() {
+            Some(true) => Verdict::Available,
+            Some(false) => Verdict::Current,
+            // Offline/timeout also stamps: the interval doubles as the retry
+            // backoff, so a dead network never pays the bound repeatedly.
+            None => Verdict::Failed,
+        };
+        let cache = CheckCache {
+            at: now,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            verdict,
+        };
+        return (verdict == Verdict::Available, Some(cache));
+    }
+    // Within the window: no network, but a known-available verdict still nudges.
+    (valid.is_some_and(|c| c.verdict == Verdict::Available), None)
+}
+
+/// Where the check cache lives (alongside the global config).
+fn cache_path() -> Option<PathBuf> {
     crate::config::global_config_dir().map(|d| d.join("update-check"))
+}
+
+/// Read the cache: one line, `<unix-secs> <version> <verdict>`. A legacy file
+/// holding only `<unix-secs>` (pre-0.20 stamp) reads as a `Failed` verdict at
+/// that time by this version — it throttles like before and never nudges from
+/// stale data.
+fn read_cache(path: &Path) -> Option<CheckCache> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let mut parts = text.split_whitespace();
+    let secs: u64 = parts.next()?.parse().ok()?;
+    let at = SystemTime::UNIX_EPOCH + Duration::from_secs(secs);
+    let (version, verdict) = match (parts.next(), parts.next().and_then(Verdict::parse)) {
+        (Some(v), Some(verdict)) => (v.to_string(), verdict),
+        _ => (env!("CARGO_PKG_VERSION").to_string(), Verdict::Failed),
+    };
+    Some(CheckCache {
+        at,
+        version,
+        verdict,
+    })
+}
+
+/// Persist the cache (see [`read_cache`] for the format).
+fn write_cache(path: &Path, cache: &CheckCache) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let secs = cache
+        .at
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    std::fs::write(
+        path,
+        format!("{secs} {} {}", cache.version, cache.verdict.as_str()),
+    )
 }
 
 /// Read the last-check time (unix seconds), or `None` if unset/unreadable.
@@ -101,18 +291,6 @@ fn stamp_path() -> Option<PathBuf> {
 pub(crate) fn read_stamp(path: &Path) -> Option<SystemTime> {
     let secs: u64 = std::fs::read_to_string(path).ok()?.trim().parse().ok()?;
     Some(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
-}
-
-/// Record the last-check time (unix seconds), creating the dir if needed.
-fn write_stamp(path: &Path, at: SystemTime) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let secs = at
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    std::fs::write(path, secs.to_string())
 }
 
 /// Whether a check is due: never checked, or `interval` has elapsed. A clock that
@@ -170,20 +348,135 @@ mod tests {
     }
 
     #[test]
-    fn stamp_round_trips_at_second_granularity() {
+    fn cache_round_trips_and_reads_the_legacy_stamp() {
         let dir = tempfile::tempdir().unwrap();
-        // Parent dir doesn't exist yet — write_stamp must create it.
+        // Parent dir doesn't exist yet — write_cache must create it.
         let path = dir.path().join("nested").join("update-check");
-        assert_eq!(read_stamp(&path), None, "missing stamp reads as None");
+        assert!(read_cache(&path).is_none(), "missing cache reads as None");
 
-        let at = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
-        write_stamp(&path, at).unwrap();
-        let back = read_stamp(&path).unwrap();
+        let cache = CheckCache {
+            at: SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+            version: "0.20.0".to_string(),
+            verdict: Verdict::Available,
+        };
+        write_cache(&path, &cache).unwrap();
+        assert_eq!(read_cache(&path).unwrap(), cache);
+
+        // A pre-0.20 stamp (bare unix seconds) reads as a Failed verdict at
+        // that time — it throttles, but can never nudge from stale data.
+        std::fs::write(&path, "1700000000").unwrap();
+        let legacy = read_cache(&path).unwrap();
+        assert_eq!(legacy.verdict, Verdict::Failed);
+        assert_eq!(legacy.at, cache.at);
+    }
+
+    /// A cache entry `age` seconds old, written by this binary version.
+    fn cache_aged(now: SystemTime, age: u64, verdict: Verdict) -> CheckCache {
+        CheckCache {
+            at: now - Duration::from_secs(age),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            verdict,
+        }
+    }
+
+    fn now() -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000_000)
+    }
+
+    #[test]
+    fn due_check_runs_and_persists_its_verdict() {
+        // No cache at all → the check runs; an available result nudges and is
+        // written back for the cap window.
+        let (nudge, write) = decide(CheckMode::Always, None, now(), || Some(true));
+        assert!(nudge);
+        assert_eq!(write.unwrap().verdict, Verdict::Available);
+
+        // Up to date → quiet, verdict still cached.
+        let (nudge, write) = decide(CheckMode::Always, None, now(), || Some(false));
+        assert!(!nudge);
+        assert_eq!(write.unwrap().verdict, Verdict::Current);
+    }
+
+    #[test]
+    fn within_the_window_a_cached_available_still_nudges_without_network() {
+        // 5 min old (inside the 10-min always-window): the injected check
+        // panicking proves no network call is made.
+        let cache = cache_aged(now(), 5 * 60, Verdict::Available);
+        let (nudge, write) = decide(CheckMode::Always, Some(&cache), now(), || {
+            panic!("must not hit the network inside the cap window")
+        });
+        assert!(nudge, "a known-stale install is reminded on every command");
+        assert!(write.is_none(), "nothing to re-write inside the window");
+
+        // Same window, current verdict → quiet.
+        let cache = cache_aged(now(), 5 * 60, Verdict::Current);
+        let (nudge, _) = decide(CheckMode::Always, Some(&cache), now(), || {
+            panic!("must not hit the network inside the cap window")
+        });
+        assert!(!nudge);
+    }
+
+    #[test]
+    fn always_rechecks_after_its_window_daily_after_a_day() {
+        // 11 min old: due under Always, not under Daily.
+        let cache = cache_aged(now(), 11 * 60, Verdict::Current);
+        let (nudge, write) = decide(CheckMode::Always, Some(&cache), now(), || Some(true));
+        assert!(nudge, "always re-checks after 10 minutes");
+        assert!(write.is_some());
+
+        let (nudge, write) = decide(CheckMode::Daily, Some(&cache), now(), || {
+            panic!("daily must not re-check an 11-minute-old verdict")
+        });
+        assert!(!nudge);
+        assert!(write.is_none());
+
+        // 25h old: due under Daily too.
+        let cache = cache_aged(now(), 25 * 60 * 60, Verdict::Current);
+        let (nudge, _) = decide(CheckMode::Daily, Some(&cache), now(), || Some(true));
+        assert!(nudge);
+    }
+
+    #[test]
+    fn failed_check_stamps_so_offline_never_pays_the_bound_repeatedly() {
+        let (nudge, write) = decide(CheckMode::Always, None, now(), || None);
+        assert!(!nudge);
         assert_eq!(
-            back.duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-            1_700_000_000
+            write.unwrap().verdict,
+            Verdict::Failed,
+            "a failed check is cached — the interval doubles as retry backoff"
         );
+
+        // Within the window the failure is honored: no retry, no nudge.
+        let cache = cache_aged(now(), 60, Verdict::Failed);
+        let (nudge, write) = decide(CheckMode::Always, Some(&cache), now(), || {
+            panic!("must not retry inside the backoff window")
+        });
+        assert!(!nudge);
+        assert!(write.is_none());
+    }
+
+    #[test]
+    fn cache_from_another_binary_version_is_ignored() {
+        // An "available" verdict computed by the binary this one replaced must
+        // not nudge — the check re-runs instead, whatever its age.
+        let cache = CheckCache {
+            at: now() - Duration::from_secs(60),
+            version: "0.0.1-not-this-binary".to_string(),
+            verdict: Verdict::Available,
+        };
+        let (nudge, write) = decide(CheckMode::Always, Some(&cache), now(), || Some(false));
+        assert!(!nudge, "stale-version verdict discarded; fresh check wins");
+        assert_eq!(write.unwrap().verdict, Verdict::Current);
+    }
+
+    #[test]
+    fn check_mode_parses_leniently() {
+        assert_eq!(CheckMode::parse(None), CheckMode::Always, "default");
+        assert_eq!(CheckMode::parse(Some("always")), CheckMode::Always);
+        assert_eq!(CheckMode::parse(Some("Daily")), CheckMode::Daily);
+        assert_eq!(CheckMode::parse(Some("off")), CheckMode::Off);
+        assert_eq!(CheckMode::parse(Some("never")), CheckMode::Off);
+        // Unknown (a newer loadout's value) degrades to Daily, never errors.
+        assert_eq!(CheckMode::parse(Some("hourly")), CheckMode::Daily);
     }
 }


### PR DESCRIPTION
## Summary

Ellery's ask: check for a newer release every time `load` runs (the check is fast), with a user setting to keep it on every run or turn it off.

- **Every interactive command now evaluates the update nudge** — a central post-command hook in `main` covers `refresh`, `studio` (prints after it stops), `doctor`, `explain`, etc.; `run`/bare-launch keep their own call since they must print before the launch `exec()`s away. `update` (redundant) and `hook` (machine caller, stdout must stay clean) are excluded.
- **New `[update] check = "always" | "daily" | "off"`** in the global config; `always` is the default, `daily` is the old cadence, and `LOADOUT_NO_UPDATE_CHECK` remains a hard off. Global-only: a repo layer setting `[update]` is stripped, same as `[learn]`/`[env]` — a cloned repo can't silence or force the nudge. Unknown values (from a newer loadout) degrade to `daily`, never brick.
- **Rate-limit-safe "always"**: GitHub's unauthenticated API allows 60 calls/hour/IP, so the network call is capped at once per 10 minutes. The verdict persists in the `update-check` file (now `<unix> <version> <verdict>`; the legacy bare-seconds stamp reads compatibly), so within the window a known-stale install still nudges with **zero** network. A failed check stamps too — the window doubles as offline backoff, and the 1.5s bound is the worst case, not the norm.
- **No stale nudges across updates**: the verdict is stamped with the binary version that computed it and the cache is deleted on a successful `load update`, so a freshly-updated binary never nudges about the update that already happened.

## Validation

- 748 lib tests (6 new: full `decide()` matrix — cap window, cached-available persistence, offline backoff, version invalidation, lenient mode parse, cache round-trip incl. legacy format) + config-layer tests (per-mode parse, merge precedence, repo-layer strip)
- `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check`: clean
- Live PTY smoke test: first command writes the verdict cache, second command inside the window skips the network (timestamp unchanged), non-TTY output stays clean

Note: touches `src/config.rs`/`src/commands/run.rs` near regions PR #38 (remove-learning) also edits — whichever lands second has a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc3AwWKfsMg487k4ki5ryJ