### PR TITLE
feat(run): amber equipping bar above the startup steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ version and date (see [RELEASING.md](RELEASING.md)).
 
 ## Unreleased
 
+### Added
+
+- **An equipping bar above the `load run` startup steps.** Launching an agent
+  now draws an amber progress bar — dungeon-crawl style, `▓▒░` shading — that
+  fills as each startup phase completes (sync, loadout selection, gear checks,
+  render, workflow, learn, update) and flashes **EQUIPPED** just before the
+  agent takes over the terminal. It's pure presentation: nothing is slowed
+  down, and it freezes out of the way if loadout needs to ask you something
+  mid-launch. Truecolor where the terminal supports it, 256-color otherwise;
+  disabled automatically for pipes, `NO_COLOR`, `TERM=dumb`, and dry runs, so
+  scripted output is unchanged.
+
 ### Changed
 
 - **The update nudge now runs on every `load` command, not once a day.**

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -136,8 +136,17 @@ pub(crate) fn step(p: &Painter, glyph: String, label: &str, detail: String) -> S
 }
 
 pub(crate) fn print_sync_step(p: &Painter, s: &SyncStatus) {
+    if let Some(line) = sync_step_line(p, s) {
+        println!("{line}");
+    }
+}
+
+/// The sync step line, or `None` when sync is disabled (nothing to show).
+/// Split from [`print_sync_step`] so `run` can route it through its progress
+/// bar while `refresh` keeps printing directly.
+pub(crate) fn sync_step_line(p: &Painter, s: &SyncStatus) -> Option<String> {
     let line = match s {
-        SyncStatus::Disabled => return,
+        SyncStatus::Disabled => return None,
         SyncStatus::Skipped { age } => step(
             p,
             p.green("✓"),
@@ -184,7 +193,7 @@ pub(crate) fn print_sync_step(p: &Painter, s: &SyncStatus) {
             "diverged — run `load sync` to reconcile".to_string(),
         ),
     };
-    println!("{line}");
+    Some(line)
 }
 
 /// "1 change" / "N changes".

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -16,13 +16,14 @@
 //! var to the directory holding the generated overlay, so the agent discovers it
 //! at launch without any committed file being touched.
 
+use std::cell::RefCell;
 use std::io::{IsTerminal, Write as _};
 use std::process::Command;
 
 use anyhow::anyhow;
 
 use super::apply::{
-    apply_for_agents, learn_pending_count, print_sync_step, step, sync_before_render,
+    apply_for_agents, learn_pending_count, step, sync_before_render, sync_step_line,
 };
 use super::{
     now_rfc3339, prepare_with_live, Aborted, Choice, MissingPolicy, ProfileChooser, Runtime,
@@ -34,9 +35,21 @@ use crate::context::Context;
 use crate::hash;
 use crate::learn::trigger::{maybe_spawn, Trigger};
 use crate::profile::LoadoutConfig;
+use crate::progress::EquipBar;
 use crate::skills::{self, LinkState, SkillState};
 use crate::style::Painter;
 use crate::vlog;
+
+/// [`StdinChooser`] behind the progress bar: freezes the bar before the
+/// interactive prompt so a redraw can never garble it, then delegates.
+struct BarChooser<'a>(&'a RefCell<EquipBar>);
+
+impl ProfileChooser for BarChooser<'_> {
+    fn choose(&self, ctx: &Context, candidates: &[LoadoutConfig]) -> crate::Result<Choice> {
+        self.0.borrow_mut().abandon();
+        StdinChooser.choose(ctx, candidates)
+    }
+}
 
 /// Interactive "which profile?" prompt for `load run` when 2+ profiles match
 /// and no choice is remembered yet. Falls back to no-profile (no prompt) when
@@ -158,13 +171,23 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
     let agent = args.agent.as_str();
     let p = Painter::auto();
 
+    // The equipping bar: drawn first, above the step lines, advanced once per
+    // startup phase (7 ticks), finished right before the launch. Every step
+    // line below it must go through `bar.println` (it counts lines for the
+    // in-place redraw), and every path that prompts must `abandon` it first.
+    // Disabled (plain prints, no escapes) on non-TTY / NO_COLOR / dry runs.
+    let bar = RefCell::new(EquipBar::start(7, rt.dry_run));
+
     // Pull the latest config first — best-effort, throttled, timeout-bounded;
     // it never blocks the launch. Done before `prepare_with` so the render below
     // composes freshly-pulled fragments/profiles. Print the line right away.
     let sync_status = sync_before_render(rt);
-    print_sync_step(&p, &sync_status);
+    if let Some(line) = sync_step_line(&p, &sync_status) {
+        bar.borrow_mut().println(&line);
+    }
+    bar.borrow_mut().tick(); // 1/7 sync
 
-    let prep = match prepare_with_live(rt, &StdinChooser, MissingPolicy::Defer, true) {
+    let prep = match prepare_with_live(rt, &BarChooser(&bar), MissingPolicy::Defer, true) {
         Ok(prep) => prep,
         // The user cancelled the profile chooser — exit cleanly, launch nothing.
         Err(e) if e.downcast_ref::<Aborted>().is_some() => {
@@ -177,6 +200,7 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
         }
         Err(e) => return Err(e),
     };
+    bar.borrow_mut().tick(); // 2/7 loadout selected
 
     // Passive hook bootstrap (see `bootstrap_hook_registrations`): launching
     // any agent also wires the IDE freshness hooks of installed ones. Learn
@@ -185,13 +209,15 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
     for note in
         crate::adapters::bootstrap_hook_registrations(&prep.config, learn_active, rt.dry_run)
     {
-        println!("  {} {}", p.green("✓"), p.dim(&note));
+        let line = format!("  {} {}", p.green("✓"), p.dim(&note));
+        bar.borrow_mut().println(&line);
     }
 
     // A profile that references a fragment id not in the library would silently
     // drop it from the overlay. Interrupt here — before any render/launch work —
     // and let the user decide: ignore once, open studio to fix it, or quit.
     if !prep.composition.missing.is_empty() {
+        bar.borrow_mut().abandon(); // resolve_missing prompts
         match resolve_missing(&prep, &p)? {
             MissingChoice::Continue => {}
             MissingChoice::OpenStudio => return open_studio_handoff(rt, agent),
@@ -212,8 +238,9 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
     // TTY-gated, only while the user looks pre-migration — offer the migrate
     // skill. Best-effort: a skill hiccup must never block the launch.
     if !rt.dry_run {
-        skill_preflight(&prep, &p);
+        skill_preflight(&prep, &p, &bar);
     }
+    bar.borrow_mut().tick(); // 3/7 gear checked (hooks, fragments, skills)
 
     // Accept the agent's launch program as an alias for its id — people type
     // the binary they know (`load cursor-agent`) for the `cursor` agent.
@@ -263,15 +290,23 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
         vlog!("skipping pre-launch render (--skip-render)");
         None
     };
-    print_render_step(&p, &prep, agent, result.as_ref());
+    bar.borrow_mut()
+        .println(&render_step_line(&p, &prep, agent, result.as_ref()));
+    bar.borrow_mut().tick(); // 4/7 render
 
     // The workflow active for this run (override wins, else the profile binding),
     // resolved the same way the render did. Drives the launch-env wiring + notice.
     let workflow = prep
         .config
         .resolve_active_workflow(args.workflow.as_deref(), prep.composition.primary_profile());
-    print_workflow_step(&p, workflow.as_ref());
-    print_learn_step(&p, learn_pending);
+    if let Some(line) = workflow_step_line(&p, workflow.as_ref()) {
+        bar.borrow_mut().println(&line);
+    }
+    bar.borrow_mut().tick(); // 5/7 flow
+    if let Some(line) = learn_step_line(&p, learn_pending) {
+        bar.borrow_mut().println(&line);
+    }
+    bar.borrow_mut().tick(); // 6/7 learn
 
     let rendered_at = now_rfc3339();
     let launch_args = build_launch_args(
@@ -308,9 +343,13 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
     // `LOADOUT_NO_UPDATE_CHECK`. Printed here rather than by main's ambient
     // nudge because the launch `exec`s away on Unix — nothing after it runs.
     if let Some(detail) = crate::update::nudge_detail(prep.config.update.check) {
-        println!("{}", step(&p, p.cyan("↑"), "update", detail));
+        let line = step(&p, p.cyan("↑"), "update", detail);
+        bar.borrow_mut().println(&line);
     }
-    print_launch_step(&p, &program, &args.args);
+    bar.borrow_mut().tick(); // 7/7 update
+    bar.borrow_mut().finish(); // ▓▓▓ EQUIPPED
+    let launch_line = launch_step_line(&p, &program, &args.args);
+    bar.borrow_mut().println(&launch_line);
 
     // Fire the trigger fast path right before the launch `exec()`s away
     // (unix) and replaces this process: `maybe_spawn` only ever waits on a
@@ -329,7 +368,7 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
 /// best-effort: errors are logged verbosely and never abort the run. Undecided,
 /// not-yet-installed skills are collected into ONE bundled offer — a fresh user
 /// gets a single question no matter how many skills loadout ships.
-fn skill_preflight(prep: &super::Prepared, p: &Painter) {
+fn skill_preflight(prep: &super::Prepared, p: &Painter, bar: &RefCell<EquipBar>) {
     let Some(home) = crate::config::home_dir() else {
         return;
     };
@@ -337,7 +376,7 @@ fn skill_preflight(prep: &super::Prepared, p: &Painter) {
     for skill in skills::all() {
         let outcome = match crate::binding::read_skill_decision(skill.id) {
             Some(SkillDecision::Declined) => Ok(()),
-            Some(SkillDecision::Accepted) => maintain_skill(&home, skill, p),
+            Some(SkillDecision::Accepted) => maintain_skill(&home, skill, p, bar),
             None => match skills::status(&home, skill).state {
                 // Already present with our marker (installed elsewhere or on
                 // another loadout version): adopt silently instead of asking.
@@ -356,7 +395,7 @@ fn skill_preflight(prep: &super::Prepared, p: &Painter) {
         }
     }
     if !offerable.is_empty() {
-        if let Err(e) = offer_skills(&home, &offerable, prep, p) {
+        if let Err(e) = offer_skills(&home, &offerable, prep, p, bar) {
             vlog!("skill offer failed: {e:#}");
         }
     }
@@ -366,24 +405,27 @@ fn skill_preflight(prep: &super::Prepared, p: &Painter) {
 /// links, refresh a pristine install when this binary ships a newer version.
 /// A user-deleted canonical dir is respected (recorded as declined, one notice);
 /// user-edited files are never touched (`doctor` reports them).
-fn maintain_skill(home: &std::path::Path, skill: &skills::Skill, p: &Painter) -> crate::Result<()> {
+fn maintain_skill(
+    home: &std::path::Path,
+    skill: &skills::Skill,
+    p: &Painter,
+    bar: &RefCell<EquipBar>,
+) -> crate::Result<()> {
     let st = skills::status(home, skill);
     match st.state {
         SkillState::NotInstalled => {
             // The user deleted it; don't resurrect. Remember the opt-out.
             crate::binding::write_skill_decision(skill.id, SkillDecision::Declined)?;
-            println!(
-                "{}",
-                step(
-                    p,
-                    p.dim("·"),
-                    "skill",
-                    p.dim(&format!(
-                        "'{}' was removed — leaving it; `load skill install` restores it",
-                        skill.id
-                    )),
-                )
+            let line = step(
+                p,
+                p.dim("·"),
+                "skill",
+                p.dim(&format!(
+                    "'{}' was removed — leaving it; `load skill install` restores it",
+                    skill.id
+                )),
             );
+            bar.borrow_mut().println(&line);
         }
         SkillState::Unmanaged
         | SkillState::Managed {
@@ -404,10 +446,8 @@ fn maintain_skill(home: &std::path::Path, skill: &skills::Skill, p: &Painter) ->
                 } else {
                     "repaired agent links"
                 };
-                println!(
-                    "{}",
-                    step(p, p.green("✓"), "skill", format!("'{}' {what}", skill.id))
-                );
+                let line = step(p, p.green("✓"), "skill", format!("'{}' {what}", skill.id));
+                bar.borrow_mut().println(&line);
             }
         }
     }
@@ -424,6 +464,7 @@ fn offer_skills(
     offerable: &[&skills::Skill],
     prep: &super::Prepared,
     p: &Painter,
+    bar: &RefCell<EquipBar>,
 ) -> crate::Result<()> {
     if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
         return Ok(());
@@ -431,6 +472,8 @@ fn offer_skills(
     if !prep.config.profiles.is_empty() {
         return Ok(());
     }
+    // Interactive from here on — freeze the bar before the prompt.
+    bar.borrow_mut().abandon();
 
     let ids = offerable
         .iter()
@@ -509,12 +552,12 @@ fn skill_blurb(id: &str) -> &'static str {
 
 // --- the stepped run summary --------------------------------------------------
 
-fn print_render_step(
+fn render_step_line(
     p: &Painter,
     prep: &super::Prepared,
     agent: &str,
     result: Option<&ApplyResult>,
-) {
+) -> String {
     let label = prep.profile_label();
     let profile = if label.is_empty() {
         "no loadout"
@@ -528,53 +571,47 @@ fn print_render_step(
         ),
         None => format!("{profile} → {agent} {}", p.dim("· render skipped")),
     };
-    println!("{}", step(p, p.green("✓"), "render", detail));
+    step(p, p.green("✓"), "render", detail)
 }
 
-fn print_launch_step(p: &Painter, program: &str, args: &[String]) {
+fn launch_step_line(p: &Painter, program: &str, args: &[String]) -> String {
     let cmd = if args.is_empty() {
         program.to_string()
     } else {
         format!("{program} {}", args.join(" "))
     };
-    println!("{}", step(p, p.cyan("▸"), "launch", cmd));
+    step(p, p.cyan("▸"), "launch", cmd)
 }
 
-/// One concise run-summary line naming the active workflow (or nothing when
+/// One concise run-summary line naming the active workflow (or `None` when
 /// none is bound). Tells the user the spine is live and how to invoke a stage.
-fn print_workflow_step(p: &Painter, workflow: Option<&crate::workflow::Workflow>) {
-    let Some(wf) = workflow else { return };
-    println!(
-        "{}",
-        step(
-            p,
-            p.cyan("◆"),
-            "flow",
-            format!(
-                "{} {}",
-                wf.title(),
-                p.dim(&format!("· {} stages · /loadout:<stage>", wf.stages.len()))
-            ),
-        )
-    );
+fn workflow_step_line(p: &Painter, workflow: Option<&crate::workflow::Workflow>) -> Option<String> {
+    let wf = workflow?;
+    Some(step(
+        p,
+        p.cyan("◆"),
+        "flow",
+        format!(
+            "{} {}",
+            wf.title(),
+            p.dim(&format!("· {} stages · /loadout:<stage>", wf.stages.len()))
+        ),
+    ))
 }
 
 /// The learn discovery step line: at most one, present only when candidates
 /// are actually staged. `pending` is folded once (see `learn_pending_count`)
 /// and passed in — this function is display-only, no I/O of its own.
-fn print_learn_step(p: &Painter, pending: usize) {
+fn learn_step_line(p: &Painter, pending: usize) -> Option<String> {
     if pending == 0 {
-        return;
+        return None;
     }
-    println!(
-        "{}",
-        step(
-            p,
-            p.cyan("✦"),
-            "learn",
-            format!("{pending} staged suggestions await review — load studio"),
-        )
-    );
+    Some(step(
+        p,
+        p.cyan("✦"),
+        "learn",
+        format!("{pending} staged suggestions await review — load studio"),
+    ))
 }
 
 /// The `LOADOUT_<NAME>_PATH` env vars for a bound workflow's handoff artifacts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod markdown;
 pub mod pack;
 pub mod plan;
 pub mod profile;
+pub mod progress;
 pub mod providers;
 pub mod recents;
 pub mod redact;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,253 @@
+//! The `load run` startup progress bar — the "equipping" sweep drawn above the
+//! step lines. Dungeon-crawl themed: amber ▓ fill with a dim ▒ leading edge on
+//! a dark ░ track, `EQUIPPED` when full.
+//!
+//! ## How it stays above the steps
+//!
+//! The bar prints first, then every step line is printed *through*
+//! [`EquipBar::println`], which keeps a count of lines below the bar. A
+//! [`EquipBar::tick`] redraws in place by moving the cursor up that many
+//! lines and back (`CSI F` / `CSI E`) — no full-screen control, no flicker.
+//! The count is only correct while all output flows through the bar, so:
+//!
+//! - Any path about to prompt the user (profile chooser, missing-fragment
+//!   dialog, skill offer) calls [`EquipBar::abandon`] first: the bar freezes
+//!   at its last state and every later call degrades to a plain `println!`.
+//!   A frozen half-bar during a rare interactive run is fine; a redraw
+//!   overwriting a prompt is not.
+//! - A stray `warn_user!` to stderr is not counted and can misalign one
+//!   redraw by a line. Accepted: warnings mid-`run` are rare, the damage is
+//!   cosmetic, and the alternative (threading the bar into every warning
+//!   site) isn't worth it.
+//!
+//! Disabled entirely (all methods degrade to plain prints) when stdout is not
+//! a TTY, `NO_COLOR` is set, `TERM=dumb`, or the run is `--dry-run` — so
+//! piped/scripted/test output is byte-identical to before the bar existed.
+
+use std::io::Write;
+
+use crate::style::Painter;
+
+/// Bar width in cells (fits comfortably beside step lines at 80 cols).
+const WIDTH: usize = 34;
+
+/// Amber, the dungeon-crawl phosphor. Truecolor when the terminal declares it.
+const AMBER: (u8, u8, u8) = (255, 176, 0);
+/// The ▒ leading edge — darker amber.
+const EMBER: (u8, u8, u8) = (160, 110, 0);
+/// The unlit ░ track.
+const TRACK: (u8, u8, u8) = (60, 45, 10);
+
+/// The startup progress bar. Construct with [`EquipBar::start`]; drive with
+/// [`EquipBar::println`] / [`EquipBar::tick`]; end with [`EquipBar::finish`].
+pub struct EquipBar {
+    /// `None` → disabled: `println` passes through, everything else no-ops.
+    out: Option<Box<dyn Write>>,
+    p: Painter,
+    total: u8,
+    done: u8,
+    /// Step lines printed below the bar since it was drawn.
+    below: u16,
+}
+
+impl EquipBar {
+    /// Start the bar on stdout with `total` ticks, drawing it at zero. Enabled
+    /// only on an interactive terminal (TTY + no `NO_COLOR` + `TERM != dumb`)
+    /// and never on dry runs.
+    pub fn start(total: u8, dry_run: bool) -> Self {
+        let on = !dry_run
+            && crate::style::enabled()
+            && std::env::var_os("TERM").is_none_or(|t| t != "dumb");
+        let mut bar = Self::with_writer(
+            on.then(|| Box::new(std::io::stdout()) as Box<dyn Write>),
+            total,
+        );
+        bar.draw_initial();
+        bar
+    }
+
+    /// Injectable-writer constructor (tests drive a buffer instead of stdout).
+    fn with_writer(out: Option<Box<dyn Write>>, total: u8) -> Self {
+        EquipBar {
+            out,
+            p: Painter::auto(),
+            total: total.max(1),
+            done: 0,
+            below: 0,
+        }
+    }
+
+    fn draw_initial(&mut self) {
+        let line = self.render();
+        if let Some(out) = self.out.as_mut() {
+            let _ = writeln!(out, "{line}");
+            let _ = out.flush();
+        }
+    }
+
+    /// Print one step line below the bar (plain `println!` when disabled).
+    pub fn println(&mut self, line: &str) {
+        match self.out.as_mut() {
+            Some(out) => {
+                let _ = writeln!(out, "{line}");
+                let _ = out.flush();
+                self.below = self.below.saturating_add(1);
+            }
+            None => println!("{line}"),
+        }
+    }
+
+    /// Advance one tick and redraw the bar in place.
+    pub fn tick(&mut self) {
+        self.done = (self.done + 1).min(self.total);
+        self.redraw();
+    }
+
+    /// Fill to 100% (`EQUIPPED`) whatever the tick count — called right before
+    /// the launch line, so the flash is the last frame before the agent owns
+    /// the terminal.
+    pub fn finish(&mut self) {
+        self.done = self.total;
+        self.redraw();
+    }
+
+    /// Freeze the bar before interactive input: no more redraws, and later
+    /// `println`s stop counting (they pass straight through). Idempotent.
+    pub fn abandon(&mut self) {
+        if let Some(mut out) = self.out.take() {
+            let _ = out.flush();
+        }
+    }
+
+    /// Move up to the bar line, repaint it, move back. `CSI {n}F` = cursor to
+    /// the start of the line n above; `CSI {n}E` = to the start of the line n
+    /// below — so column state never leaks.
+    fn redraw(&mut self) {
+        let line = self.render();
+        let up = u32::from(self.below) + 1;
+        if let Some(out) = self.out.as_mut() {
+            let _ = write!(out, "\x1b[{up}F{line}\x1b[K\x1b[{up}E");
+            let _ = out.flush();
+        }
+    }
+
+    /// One bar frame: `  ▓▓▓▓▒▒░░░░  62%` (or `EQUIPPED` when full).
+    fn render(&self) -> String {
+        let frac = f64::from(self.done) / f64::from(self.total);
+        let filled = ((WIDTH as f64) * frac).round() as usize;
+        let lead = if filled == 0 || filled == WIDTH {
+            0
+        } else {
+            (WIDTH - filled).min(2)
+        };
+        let track = WIDTH - filled - lead;
+        let bar = format!(
+            "{}{}{}",
+            self.p.rgb(&"▓".repeat(filled), AMBER),
+            self.p.rgb(&"▒".repeat(lead), EMBER),
+            self.p.rgb(&"░".repeat(track), TRACK),
+        );
+        let label = if self.done == self.total {
+            self.p.bold(&self.p.rgb("EQUIPPED", AMBER))
+        } else {
+            self.p
+                .rgb(&format!("{:>3}%", (frac * 100.0).round() as u32), AMBER)
+        };
+        format!("  {bar} {label}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// A writer the test can read back after the bar is done with it.
+    #[derive(Clone, Default)]
+    struct Sink(Arc<Mutex<Vec<u8>>>);
+    impl Write for Sink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn bar_with_sink(total: u8) -> (EquipBar, Sink) {
+        let sink = Sink::default();
+        let mut bar = EquipBar::with_writer(Some(Box::new(sink.clone())), total);
+        bar.draw_initial();
+        (bar, sink)
+    }
+
+    fn output(sink: &Sink) -> String {
+        String::from_utf8(sink.0.lock().unwrap().clone()).unwrap()
+    }
+
+    #[test]
+    fn renders_fill_lead_and_track_summing_to_width() {
+        let mut bar = EquipBar::with_writer(None, 7);
+        bar.done = 4;
+        let frame = bar.render();
+        let cells = frame.chars().filter(|c| "▓▒░".contains(*c)).count();
+        assert_eq!(cells, WIDTH, "fill + lead + track always spans the bar");
+        assert!(frame.contains('▓') && frame.contains('▒') && frame.contains('░'));
+        assert!(frame.contains("57%"), "4/7 → 57%: {frame}");
+    }
+
+    #[test]
+    fn full_bar_says_equipped_with_no_lead_or_track() {
+        let mut bar = EquipBar::with_writer(None, 7);
+        bar.done = 7;
+        let frame = bar.render();
+        assert!(frame.contains("EQUIPPED"), "{frame}");
+        assert_eq!(frame.chars().filter(|c| *c == '▓').count(), WIDTH);
+        assert!(!frame.contains('▒') && !frame.contains('░'));
+    }
+
+    #[test]
+    fn redraw_reaches_up_past_exactly_the_printed_lines() {
+        let (mut bar, sink) = bar_with_sink(7);
+        bar.println("  ✓ sync   up to date");
+        bar.println("  ✓ render  rust → claude");
+        bar.tick();
+        let out = output(&sink);
+        // 2 lines below the bar → the redraw must move up 3 and back down 3.
+        assert!(
+            out.contains("\x1b[3F"),
+            "cursor up to the bar line: {out:?}"
+        );
+        assert!(out.contains("\x1b[3E"), "cursor restored below: {out:?}");
+    }
+
+    #[test]
+    fn abandon_freezes_redraws_but_keeps_printing() {
+        let (mut bar, sink) = bar_with_sink(7);
+        bar.println("  ✓ sync");
+        bar.abandon();
+        let frozen = output(&sink).len();
+        bar.tick();
+        bar.finish();
+        assert_eq!(
+            output(&sink).len(),
+            frozen,
+            "no bytes may reach the terminal after abandon"
+        );
+        // println after abandon degrades to plain stdout (not the sink) — the
+        // observable contract is simply: the sink sees nothing more.
+        bar.println("  ✓ render");
+        assert_eq!(output(&sink).len(), frozen);
+    }
+
+    #[test]
+    fn disabled_bar_never_emits_escapes() {
+        let mut bar = EquipBar::with_writer(None, 7);
+        bar.tick();
+        bar.finish();
+        // Nothing to assert on a writer (there is none); the invariant is that
+        // these calls are no-ops and println falls through to plain stdout.
+        bar.abandon();
+    }
+}

--- a/src/style.rs
+++ b/src/style.rs
@@ -4,11 +4,30 @@
 
 use std::io::IsTerminal;
 
-use anstyle::{AnsiColor, Style};
+use anstyle::{Ansi256Color, AnsiColor, Color, RgbColor, Style};
 
 /// Whether ANSI color should be emitted (stdout is a TTY and `NO_COLOR` unset).
 pub fn enabled() -> bool {
     std::env::var_os("NO_COLOR").is_none() && std::io::stdout().is_terminal()
+}
+
+/// Whether the terminal declares 24-bit color (`COLORTERM=truecolor`/`24bit`).
+/// Anything else gets the 256-color cube approximation from [`Painter::rgb`].
+fn truecolor() -> bool {
+    std::env::var_os("COLORTERM").is_some_and(|v| v == "truecolor" || v == "24bit")
+}
+
+/// Nearest xterm-256 color-cube index for an RGB value (the standard
+/// 16 + 6×6×6 mapping; the levels are 0,95,135,175,215,255).
+fn cube_index(r: u8, g: u8, b: u8) -> u8 {
+    fn level(c: u8) -> u8 {
+        match c {
+            0..=47 => 0,
+            48..=114 => 1,
+            c => ((c as u16 - 35) / 40) as u8,
+        }
+    }
+    16 + 36 * level(r) + 6 * level(g) + level(b)
 }
 
 /// A painter capturing whether color is on, so call sites read cleanly.
@@ -54,6 +73,18 @@ impl Painter {
     }
     pub fn bold(&self, s: &str) -> String {
         self.paint(s, Style::new().bold())
+    }
+
+    /// An exact RGB foreground on truecolor terminals, degrading to the
+    /// nearest xterm-256 cube color elsewhere (256-color support is effectively
+    /// universal among TTYs that pass [`enabled`], macOS Terminal included).
+    pub fn rgb(&self, s: &str, (r, g, b): (u8, u8, u8)) -> String {
+        let color: Color = if truecolor() {
+            RgbColor(r, g, b).into()
+        } else {
+            Ansi256Color(cube_index(r, g, b)).into()
+        };
+        self.paint(s, Style::new().fg_color(Some(color)))
     }
 }
 


### PR DESCRIPTION
## Summary

Ellery picked the **Dungeon Crawl** style from the progress-bar concept demo: launching an agent now draws an amber `▓▒░` bar above the startup step lines, filling one tick per phase (sync → loadout → gear → render → flow → learn → update) and flashing **EQUIPPED** as the last frame before the launch `exec()`s away.

Mechanics:

- New `src/progress.rs` (`EquipBar`): the bar prints first; every step line goes through `bar.println` so it knows how many lines to reach up past for an in-place redraw (`CSI {n}F` … `CSI {n}E` — no full-screen control). `finish()` fills to 100% whatever the tick count.
- **Prompts can never be garbled**: the three interactive paths — profile chooser, missing-fragment dialog, and the bundled skill offer — call `abandon()` first, freezing the bar; later prints degrade to plain `println!`. Known cosmetic limit (documented in the module): a stray stderr warning isn't counted and can misalign one redraw by a line.
- `Painter::rgb()` added to `style.rs`: exact truecolor when `COLORTERM=truecolor/24bit`, nearest xterm-256 cube color otherwise (macOS Terminal included).
- Gated off (byte-identical output to before) for non-TTY, `NO_COLOR`, `TERM=dumb`, and `--dry-run`.
- Step printers refactored to `*_line` builders (`sync_step_line` shared with `refresh`, which keeps printing directly).

## Validation

- 753 lib tests (5 new: render geometry, EQUIPPED frame, redraw cursor math against an injected writer, abandon freeze, disabled no-op) — full suite + clippy `-D warnings` + fmt clean
- Existing CLI suites pass untouched — proof the non-TTY path is byte-identical
- Live PTY run (fake HOME + stub agent on PATH): bar renders above the steps, sweeps to EQUIPPED, agent execs with `LOADOUT_RUN=1`, no cursor artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc3AwWKfsMg487k4ki5ryJ