### PR TITLE
Drop the Gemini CLI agent (Google retired it 2026-06-18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to loadout are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
+## Unreleased
+
+### Removed
+
+- **Dropped the Gemini CLI agent.** Google retired the standalone `gemini`
+  binary on 2026-06-18 in favour of the Antigravity CLI (`agy`), so it's gone
+  as a loadout agent — `load gemini`, the `gemini` overlay, its
+  `GEMINI.local.md` / `~/.gemini/settings.json` wiring, and the docs/studio
+  references all go with it. Antigravity itself isn't a drop-in replacement:
+  `agy` reads a committed `AGENTS.md` and only falls back to
+  `AGENTS.override.md` when there's no `AGENTS.md`, which is the opposite of
+  Codex and doesn't fit loadout's gitignored-overlay model, so no `agy` agent
+  is added for now. (A stray `~/.gemini/` config dir on your machine is
+  Antigravity's, not the old Gemini CLI's.)
+
 ## 0.22.1 — 2026-08-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A *loadout* is the kit you equip before a job — your conventions, your tooling
 - Your project's `AGENTS.md` describes **the repo.**
 - Loadout carries **what you bring to it** — across every project, machine, and agent.
 
-Works with **Claude, Codex, Gemini, Cursor, opencode, and Copilot**. Your context arrives as a local, gitignored file each agent reads — committed project instruction files are never touched.
+Works with **Claude, Codex, Cursor, opencode, and Copilot**. Your context arrives as a local, gitignored file each agent reads — committed project instruction files are never touched.
 
 ---
 
@@ -169,13 +169,12 @@ Loadout produces one overlay and delivers it the way each agent expects.
 | ---------- | ------------------------------------------------------------------------ | -------------------------------------------------------------- |
 | `claude`   | `.loadout/generated/claude.md`                                            | Adds a managed import block to `CLAUDE.local.md`               |
 | `codex`    | `.loadout/generated/agents.md`                                            | Merges into gitignored `AGENTS.override.md`                    |
-| `gemini`   | `.loadout/generated/gemini.md`                                            | Wires through gitignored `GEMINI.local.md` and Gemini settings |
 | `opencode` | `.loadout/generated/opencode.md`                                          | Registers the overlay in global opencode instructions          |
 | `copilot`  | `.loadout/generated/copilot/.github/instructions/loadout.instructions.md` | Launches Copilot CLI with the custom instructions directory    |
 | `cursor`   | `.cursor/rules/loadout.mdc` (always-on rule)                              | Read by the Cursor IDE **and** `cursor-agent` CLI; a user-level `sessionStart` hook keeps it fresh — and wires a matching repo automatically the first time you open it |
 | `generic`  | `.loadout/generated/generic.md`                                           | Emit-only; you wire it yourself                                 |
 
-It never edits committed shared files like `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, or `.github/copilot-instructions.md` — only local, gitignored paths.
+It never edits committed shared files like `AGENTS.md`, `CLAUDE.md`, or `.github/copilot-instructions.md` — only local, gitignored paths.
 
 ---
 
@@ -224,7 +223,7 @@ load skill install
 
 Then, in an agent session, run `/loadout-migrate` or just ask *"Import my CLAUDE.md into Loadout."*
 
-Three more ship: [`loadout-remember`](skills/loadout-remember/SKILL.md) saves a durable cross-project preference as a fragment when you mention one mid-session (instead of leaving it stranded in one agent's memory), [`loadout-import-workflow`](skills/loadout-import-workflow/SKILL.md) turns another repo's command/skill suite into a loadout [workflow](#workflows), and [`loadout-plan-preview`](skills/loadout-plan-preview/SKILL.md) drives the [plan preview](#plan-previews) loop above. The skills follow the cross-agent `SKILL.md` format, so the same install works in Claude Code, Codex, Gemini, opencode, and Cursor.
+Three more ship: [`loadout-remember`](skills/loadout-remember/SKILL.md) saves a durable cross-project preference as a fragment when you mention one mid-session (instead of leaving it stranded in one agent's memory), [`loadout-import-workflow`](skills/loadout-import-workflow/SKILL.md) turns another repo's command/skill suite into a loadout [workflow](#workflows), and [`loadout-plan-preview`](skills/loadout-plan-preview/SKILL.md) drives the [plan preview](#plan-previews) loop above. The skills follow the cross-agent `SKILL.md` format, so the same install works in Claude Code, Codex, opencode, and Cursor.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,8 +76,7 @@ cwd → repo_base → Config::load → detect_context → select (one loadout by
   file, import vs embed, owned vs managed-block).
 - **Auto-wire only through local/gitignored paths.** Claude's `CLAUDE.local.md`
   (`@import`), Codex's `AGENTS.override.md` (read before the committed `AGENTS.md`),
-  Gemini's `GEMINI.local.md` (`@import`, registered once in
-  `~/.gemini/settings.json` `context.fileName`), Cursor's `.cursor/rules/loadout.mdc`
+  Cursor's `.cursor/rules/loadout.mdc`
   (a fully loadout-owned always-on rule, gitignored — Cursor doesn't filter rules
   by gitignore), and Copilot's gitignored overlay
   (pointed at via `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` by `load run`) are wired

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -239,17 +239,15 @@ described by an `AgentDescriptor` along four axes:
 
 The decisive rule: **auto-wire through local/gitignored paths only** — Claude →
 `CLAUDE.local.md` (`@import`), Codex → `AGENTS.override.md` (which Codex reads
-before the committed `AGENTS.md`), Gemini → a gitignored `GEMINI.local.md`
-(`@import`) registered once in `~/.gemini/settings.json` `context.fileName`,
+before the committed `AGENTS.md`),
 Copilot → the gitignored overlay via `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` set by
 `load run` (no persistent local hook exists). loadout **never edits a committed,
-shared instruction file** (`AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`);
+shared instruction file** (`AGENTS.md`, `.github/copilot-instructions.md`);
 agents with no wiring path are **emit-only** — a gitignored overlay plus a hint on
 how to wire it, not content in a shared file.
 
 Built-ins: `claude` (import), `codex` (auto `AGENTS.override.md` merge,
-`--no-override` to skip), `gemini` (auto `GEMINI.local.md` @import + registers it
-in `~/.gemini/settings.json`), `copilot` (`load run` sets
+`--no-override` to skip), `copilot` (`load run` sets
 `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` → the gitignored overlay), `cursor` (owned
 `.cursor/rules/loadout.mdc` rule — one file read by the IDE agent *and* the
 `cursor-agent` CLI — plus a user-level `sessionStart` hook in `~/.cursor/hooks.json`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,18 +238,18 @@ binary — update that machine's `load` first. Built-ins are unaffected.
 
 ```toml
 [[agents]]
-id = "gemini"
-generated_filename = "gemini.md"
-launch = "gemini"                  # program for `load run gemini` (omit → render-only)
+id = "opencode"
+generated_filename = "opencode.md"
+launch = "opencode"              # program for `load run opencode` (omit → render-only)
 # aliases = ["agent"]              # extra tokens that resolve to this agent (cursor: `agent`)
 template = "overlay"              # body template name (repo/global override → embedded)
-# importer = "GEMINI.local.md"             # auto-wire @import into a LOCAL file
+# importer = "CLAUDE.local.md"             # auto-wire @import into a LOCAL file
 # override_target = "AGENTS.override.md"   # auto-merge target, gitignored (default-on)
 # override_base   = "AGENTS.md"            # file whose content seeds the override
 # target_file = ".cursor/rules/loadout.mdc" # loadout-owned wired file, written raw (no marker block)
 # preamble = "---\nalwaysApply: true\n---\n" # raw first bytes of target_file (e.g. MDC frontmatter)
 # append_prompt_flag = "--append-system-prompt"   # run injects a freshness note via this flag
-wire_hint = "include .loadout/generated/gemini.md from your agent config"
+wire_hint = "include .loadout/generated/opencode.md from your agent config"
 ```
 
 Built-in defaults:
@@ -258,7 +258,6 @@ Built-in defaults:
 | --- | --- | --- | --- |
 | `claude` | `claude.md` | import → `CLAUDE.local.md` | `claude` |
 | `codex` | `agents.md` | auto → gitignored `AGENTS.override.md` (Codex prefers it); `--no-override` = emit-only | `codex` |
-| `gemini` | `gemini.md` | auto → gitignored `GEMINI.local.md` (`@import`) + registers it in `~/.gemini/settings.json` `context.fileName` | `gemini` |
 | `opencode` | `opencode.md` | registers overlay path in `~/.config/opencode/opencode.json` `instructions` | `opencode` |
 | `copilot` | `copilot/.github/instructions/loadout.instructions.md` | `load run` sets `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` → `.loadout/generated/copilot` | `copilot` |
 | `cursor` | `cursor.md` | owned file → gitignored `.cursor/rules/loadout.mdc` (`alwaysApply` rule, IDE + CLI) + `sessionStart` hook in `~/.cursor/hooks.json` for IDE freshness | `cursor-agent` |

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -12,8 +12,8 @@ for any descriptor. The wiring it picks:
 
 - `importer` set → managed `@import` block in that (local) file; gitignore it if
   loadout created it. Add `importer_registry` when the agent only loads that file
-  once its name is registered in the agent's own settings (e.g. Gemini's
-  `~/.gemini/settings.json` `context.fileName`).
+  once its name is registered in the agent's own settings (e.g. opencode's
+  `~/.config/opencode/opencode.json` `instructions`).
 - `override_target` set → auto-merge (default-on) into that gitignored file,
   re-seeded from `override_base` on each (re)write; opt out with `--no-override`
   / `[codex] write_override = false`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -43,7 +43,7 @@ literals ("looks private — move it to local.toml").
 Anything loadout generates is machine-specific and local: `.loadout/generated/`,
 `.loadout/logs/`, `AGENTS.override.md`, and `CLAUDE.local.md` (only when loadout
 created it — if you already track it, your gitignore is left alone). Hand-authored
-`AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md` are committed and
+`AGENTS.md` / `.github/copilot-instructions.md` are committed and
 never auto-edited. Committing a derived file would either churn, leak host-
 specific content, or (for `AGENTS.override.md`, which Codex *prefers* over
 `AGENTS.md`) force your machine's snapshot onto teammates.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -150,13 +150,13 @@ fragments = [
   "work-strict",
 ]
 
-# Agents are built in (claude, codex, gemini, opencode, copilot, generic).
+# Agents are built in (claude, codex, opencode, copilot, cursor, generic).
 # Override one by id, or add your own — no code change needed. Fields:
 #   id, generated_filename (required); display_name, template, launch,
 #   importer (auto-wire @import into a LOCAL file), override_target/override_base
 #   (opt-in merge), wire_hint, append_prompt_flag.
 # loadout auto-wires only agents with a LOCAL importer; everything else is
-# emit-only (a gitignored overlay + a hint), so committed AGENTS.md/GEMINI.md
+# emit-only (a gitignored overlay + a hint), so committed AGENTS.md
 # are never touched by default.
 #
 # [[agents]]

--- a/src/adapters/commands.rs
+++ b/src/adapters/commands.rs
@@ -51,8 +51,6 @@ The `loadout-plan-preview` skill carries the full authoring guidance when availa
 pub enum CommandFormat {
     /// Markdown with YAML frontmatter (Claude Code, opencode).
     Markdown,
-    /// TOML with `description` + `prompt` (Gemini CLI).
-    Toml,
     /// Cursor Skills: a folder per command holding a `SKILL.md` (the leaf
     /// folder names the skill, so commands land as
     /// `<commands_dir>/loadout/loadout-<stage>/SKILL.md` → `/loadout-<stage>`).
@@ -64,7 +62,6 @@ impl CommandFormat {
     pub fn ext(self) -> &'static str {
         match self {
             CommandFormat::Markdown | CommandFormat::Skill => "md",
-            CommandFormat::Toml => "toml",
         }
     }
 
@@ -74,7 +71,6 @@ impl CommandFormat {
     fn arg_placeholder(self) -> &'static str {
         match self {
             CommandFormat::Markdown => "$ARGUMENTS",
-            CommandFormat::Toml => "{{args}}",
             CommandFormat::Skill => "the request that accompanied this skill invocation",
         }
     }
@@ -151,21 +147,8 @@ fn render_stage_command(
                 yaml_dq(&description)
             )
         }
-        // Build via the toml crate so escaping is always correct.
-        CommandFormat::Toml => toml::to_string(&GeminiCommandFile {
-            description: &description,
-            prompt: &body,
-        })
-        .unwrap_or_default(),
     };
     StageCommand { filename, content }
-}
-
-/// Serializable shape of a Gemini CLI command file (`description` + `prompt`).
-#[derive(Serialize)]
-struct GeminiCommandFile<'a> {
-    description: &'a str,
-    prompt: &'a str,
 }
 
 /// The stage's prompt body — the contract the agent follows when the command
@@ -440,23 +423,6 @@ mod tests {
         let cmds = stage_commands(&wf, CommandFormat::Markdown, &[]);
         let plan = cmds.iter().find(|c| c.filename == "plan.md").unwrap();
         assert!(plan.content.contains(PLAN_PREVIEW_EPILOGUE));
-    }
-
-    #[test]
-    fn toml_command_is_valid_and_uses_gemini_args() {
-        let cmds = stage_commands(&builtin("spec-driven"), CommandFormat::Toml, &[]);
-        let plan = cmds.iter().find(|c| c.filename == "plan.toml").unwrap();
-        // Parses as TOML with description + prompt.
-        let v: toml::Value = toml::from_str(&plan.content).expect("valid TOML");
-        assert!(v.get("description").and_then(|d| d.as_str()).is_some());
-        let prompt = v.get("prompt").and_then(|p| p.as_str()).unwrap();
-        // loadout's own arg placeholder is Gemini's `{{args}}`, not `$ARGUMENTS`.
-        // (Vendored upstream content may itself contain `$ARGUMENTS` — that's the
-        // source's text, not loadout's placeholder, so we don't assert its absence.)
-        assert!(prompt.contains("{{args}}"), "gemini arg placeholder");
-        // spec's plan reads spec.md and writes plan.md.
-        assert!(prompt.contains("spec.md"));
-        assert!(prompt.contains("plan.md"));
     }
 
     #[test]

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -9,8 +9,8 @@
 //!   overlay into a *local* file (e.g. Claude's `CLAUDE.local.md`). Safe to
 //!   auto-wire because the importer is itself local/gitignored. With
 //!   **`importer_registry`** also set, the importer's name is registered in the
-//!   agent's own settings so it's actually loaded (e.g. Gemini's
-//!   `~/.gemini/settings.json` `context.fileName`).
+//!   agent's own settings so it's actually loaded (e.g. opencode's
+//!   `~/.config/opencode/opencode.json` `instructions`).
 //! - **`override_target`** set → auto-wire (default-on): merge the overlay
 //!   (inlined) into a gitignored override file the agent *prefers* over its
 //!   committed instruction file (e.g. Codex reads `AGENTS.override.md` before
@@ -44,7 +44,7 @@ pub(crate) mod hooks_claude;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AgentDescriptor {
-    /// Stable agent id (`claude`, `codex`, `gemini`, …).
+    /// Stable agent id (`claude`, `codex`, `opencode`, …).
     pub id: String,
     /// Human-friendly name (defaults to the id).
     #[serde(default)]
@@ -68,7 +68,7 @@ pub struct AgentDescriptor {
     pub importer: Option<String>,
     /// Some agents only load the `importer` file once its name is registered in
     /// an external settings file. This declares that registration so the import
-    /// is actually read (e.g. Gemini's `~/.gemini/settings.json` `context.fileName`).
+    /// is actually read (e.g. opencode's `~/.config/opencode/opencode.json`).
     #[serde(default)]
     pub importer_registry: Option<ImporterRegistry>,
     /// Opt-in override file to merge the overlay into (e.g. `AGENTS.override.md`).
@@ -119,7 +119,7 @@ pub struct AgentDescriptor {
     /// `None` → the agent gets the workflow context section only.
     #[serde(default)]
     pub commands_dir: Option<String>,
-    /// On-disk format for this agent's command files (markdown vs Gemini TOML).
+    /// On-disk format for this agent's command files (markdown vs Cursor skill).
     /// Ignored unless `commands_dir` is set; defaults to markdown.
     #[serde(default)]
     pub command_format: Option<commands::CommandFormat>,
@@ -144,19 +144,18 @@ fn default_template() -> String {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ImporterRegistry {
-    /// Settings file relative to `$HOME` (e.g. `.gemini/settings.json`).
+    /// Settings file relative to `$HOME` (e.g. `.config/opencode/opencode.json`).
     pub settings_file: String,
     /// JSON object-key path to the registered string array (e.g.
-    /// `["context", "fileName"]` for Gemini, `["instructions"]` for opencode).
+    /// `["instructions"]` for opencode).
     pub key_path: Vec<String>,
     /// The agent's built-in default, preserved when we first create the array
-    /// (e.g. `GEMINI.md`). `None` for keys with no implicit default (opencode's
-    /// `instructions`).
+    /// `None` for keys with no implicit default (opencode's `instructions`).
     #[serde(default)]
     pub default_name: Option<String>,
-    /// The literal value to register. When `None`, the [`AgentDescriptor::importer`]
-    /// basename is registered instead (Gemini registers `GEMINI.local.md`; opencode
-    /// has no importer and registers the overlay path `.loadout/generated/opencode.md`).
+    /// The literal value to register (e.g. opencode registers the overlay path
+    /// `.loadout/generated/opencode.md`). When `None`, the
+    /// [`AgentDescriptor::importer`] basename is registered instead.
     #[serde(default)]
     pub value: Option<String>,
 }
@@ -260,31 +259,10 @@ pub fn builtin_agents() -> Vec<AgentDescriptor> {
             ),
             ..d("codex", "agents.md")
         },
-        AgentDescriptor {
-            display_name: Some("Gemini CLI".into()),
-            launch: Some("gemini".into()),
-            // Gemini has no built-in local-context filename, so auto-wire a
-            // gitignored `GEMINI.local.md` (@import) and register that name in
-            // `~/.gemini/settings.json` `context.fileName` so Gemini loads it
-            // alongside the committed `GEMINI.md` (additive, never shadowing).
-            importer: Some("GEMINI.local.md".into()),
-            importer_registry: Some(ImporterRegistry {
-                settings_file: ".gemini/settings.json".into(),
-                key_path: vec!["context".into(), "fileName".into()],
-                default_name: Some("GEMINI.md".into()),
-                value: None, // registers the importer basename (GEMINI.local.md)
-            }),
-            wire_hint: Some(
-                "Gemini reads GEMINI.md (and resolves @imports). To wire this overlay \
-                 manually instead, add `@.loadout/generated/gemini.md` to a GEMINI.md."
-                    .into(),
-            ),
-            // Gemini reads project commands from `.gemini/commands/` as TOML; a
-            // `loadout/` subdir namespaces them as `/loadout:<stage>`.
-            commands_dir: Some(".gemini/commands".into()),
-            command_format: Some(commands::CommandFormat::Toml),
-            ..d("gemini", "gemini.md")
-        },
+        // Gemini CLI was removed: Google retired the standalone `gemini` binary
+        // on 2026-06-18 in favor of the Antigravity CLI (`agy`), which resolves
+        // context differently (prefers a committed AGENTS.md over any gitignored
+        // override), so loadout's overlay approach doesn't cleanly apply.
         AgentDescriptor {
             display_name: Some("opencode".into()),
             launch: Some("opencode".into()),
@@ -555,7 +533,7 @@ pub fn apply(
             gitignore_extra.push(importer.clone());
         }
         // Register the importer's name in the agent's own settings so it actually
-        // loads (e.g. Gemini's global `~/.gemini/settings.json` `context.fileName`).
+        // loads (e.g. opencode's global `~/.config/opencode/opencode.json`).
         if let Some(reg) = &d.importer_registry {
             apply_importer_registry(
                 app,
@@ -1032,8 +1010,8 @@ fn generated_path(app: &AppContext, filename: &str) -> PathBuf {
 /// Register a value in the agent's own settings file (resolved under `$HOME`) so
 /// the agent actually loads the overlay, and warn if a workspace settings file
 /// would mask that registration. The registered value is `reg.value` when set
-/// (e.g. opencode's overlay path), else the `importer` basename (e.g. Gemini's
-/// `GEMINI.local.md`). Appends to `files`/`notes`/`warnings`; degrades to a
+/// (e.g. opencode's overlay path), else the `importer` basename (a local
+/// `@`-import file). Appends to `files`/`notes`/`warnings`; degrades to a
 /// warning (never corrupts) on any read/parse failure.
 fn apply_importer_registry(
     app: &AppContext,

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -823,7 +823,7 @@ pub fn clean(d: &AgentDescriptor, app: &AppContext) -> crate::Result<CleanResult
         }
     }
 
-    notes.push("committed instruction files (AGENTS.md, GEMINI.md, …) were not touched".into());
+    notes.push("committed instruction files (AGENTS.md, …) were not touched".into());
     if app.in_repo() {
         notes.push("left .gitignore entries in place (remove them by hand if desired)".into());
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,7 +49,7 @@ pub struct GlobalArgs {
     pub dry_run: bool,
 }
 
-// Agents are selected by id string (claude/codex/gemini/opencode/copilot/generic,
+// Agents are selected by id string (claude/codex/opencode/copilot/cursor/generic,
 // or "all"), validated at runtime against the loaded config so new agents added
 // via `[[agents]]` work without code changes.
 

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -2,7 +2,7 @@
 //!
 //! Removes only what loadout created (gitignored overlays, override files, and
 //! our managed marker block in importer files). Hand-authored, committed
-//! instruction files (`AGENTS.md`, `GEMINI.md`, `copilot-instructions.md`) are
+//! instruction files (`AGENTS.md`, `copilot-instructions.md`) are
 //! never touched.
 
 use anyhow::anyhow;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -323,11 +323,12 @@ mod tests {
             resolve_agents(None, &cfg).unwrap(),
             vec!["claude".to_string()]
         );
-        // `all` expands to every built-in agent (now six).
+        // `all` expands to every built-in agent.
         let all = resolve_agents(Some("all"), &cfg).unwrap();
-        assert!(all.contains(&"gemini".to_string()));
+        assert!(all.contains(&"claude".to_string()));
         assert!(all.contains(&"copilot".to_string()));
         assert!(all.contains(&"opencode".to_string()));
+        assert!(!all.contains(&"gemini".to_string()), "gemini was removed");
         // A specific id resolves to itself; unknown ids error.
         assert_eq!(resolve_agents(Some("codex"), &cfg).unwrap(), vec!["codex"]);
         assert!(resolve_agents(Some("nope"), &cfg).is_err());

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -505,7 +505,7 @@ fn offer_skills(
     println!(
         "  {} loadout ships agent skills {}",
         p.cyan("✦"),
-        p.dim("(work in Claude Code, Codex, Gemini CLI, opencode)")
+        p.dim("(work in Claude Code, Codex, opencode, Cursor)")
     );
     for skill in offerable {
         println!("    {} — {}", p.bold(skill.id), skill_blurb(skill.id));

--- a/src/config.rs
+++ b/src/config.rs
@@ -790,7 +790,7 @@ pub fn state_dir() -> Option<PathBuf> {
 }
 
 /// The user's home directory (`$HOME`), if set. Used to resolve other tools'
-/// dotfiles (e.g. Gemini's `~/.gemini/settings.json`). Honors a `$HOME` override
+/// dotfiles (e.g. opencode's `~/.config/opencode/opencode.json`). Honors a `$HOME` override
 /// so tests stay isolated from the real home.
 pub fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")

--- a/src/render/header.rs
+++ b/src/render/header.rs
@@ -14,7 +14,7 @@ pub struct HeaderMeta<'a> {
     pub generated_at: &'a str,
     /// Host the snapshot was generated on.
     pub host: &'a str,
-    /// Agent id (`claude`/`codex`/`gemini`/…).
+    /// Agent id (`claude`/`codex`/`opencode`/…).
     pub agent: &'a str,
     /// Selected profile name.
     pub profile: &'a str,

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -3,7 +3,7 @@
 //! loadout ships agent skills (SKILL.md directories per the cross-agent Agent
 //! Skills format) embedded in the binary, so installer-based users get them
 //! without a repo checkout. The canonical install location is
-//! `~/.agents/skills/<id>/` — read natively by Gemini CLI, opencode, and
+//! `~/.agents/skills/<id>/` — read natively by opencode and
 //! Cursor (`~/.agents/skills/` is one of Cursor's documented user-level skill
 //! locations, alongside `~/.cursor/skills/`; see `LINKED_AGENT_DIRS`) — with
 //! symlinks from `~/.claude/skills/<id>` and `~/.codex/skills/<id>` for agents
@@ -198,7 +198,7 @@ fn on_disk_hash(dir: &Path, skill: &Skill) -> Option<String> {
 // --- layout -------------------------------------------------------------------
 
 /// Agent dotdirs that need their own `skills/` entry (symlinked to canonical).
-/// Gemini CLI and opencode read `~/.agents/skills/` natively and need nothing.
+/// opencode reads `~/.agents/skills/` natively and needs nothing.
 ///
 /// Cursor also needs nothing: `cursor-agent` (confirmed 2026.07.01-41b2de7,
 /// both by decompiling its bundled source and per cursor.com/docs/skills)

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -2153,7 +2153,7 @@ fn print_next_steps() {
     println!();
     println!("Your loadout is saved. Launch an agent with it from any project:");
     println!();
-    println!("  load claude    (also: load cursor, load codex, load gemini, load opencode)");
+    println!("  load claude    (also: load cursor, load codex, load opencode, load copilot)");
     println!();
     println!("Reopen the studio anytime: load studio");
 }

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -647,7 +647,7 @@ pub fn skill_card(ids: &[&str], rows: &[SkillRow], state: &SkillCardState) -> St
                     span class="muted small" {
                         "loadout ships agent skills (" strong { (id_list) } "): import an existing "
                         "CLAUDE.md/AGENTS.md, and save preferences you state mid-session as global guidance "
-                        "(work in Claude Code, Codex, Gemini CLI, opencode)."
+                        "(work in Claude Code, Codex, opencode, Cursor)."
                     }
                     button class="btn btn-ghost"
                         hx-post="/skills/install" hx-target="#skill-card"

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -74,7 +74,7 @@ mod tests {
         assert_eq!(t.source, "embedded");
         assert!(t.content.contains("agent context"));
         // Any agent id falls back to the same shared overlay.
-        let t2 = resolve(d.path(), "gemini").unwrap();
+        let t2 = resolve(d.path(), "opencode").unwrap();
         assert_eq!(t2.source, "embedded");
         assert_eq!(t.content, t2.content);
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -60,8 +60,8 @@ impl Fixture {
         let mut c = Command::cargo_bin("load").unwrap();
         // Point the global config dir at an empty location → no global layer.
         c.env("LOADOUT_CONFIG_DIR", self.global.path().join("empty"));
-        // Isolate $HOME so agent dotfile writes (e.g. Gemini's
-        // ~/.gemini/settings.json registration) never touch the real home.
+        // Isolate $HOME so agent dotfile writes (e.g. opencode's
+        // ~/.config/opencode/opencode.json registration) never touch the real home.
         c.env("HOME", self.global.path().join("home"));
         // Isolate the per-machine trust store (the HOME override already
         // covers the fallback path; the explicit var makes asserts addressable).
@@ -70,7 +70,7 @@ impl Fixture {
         c
     }
 
-    /// Read a file from the isolated `$HOME` (e.g. `.gemini/settings.json`).
+    /// Read a file from the isolated `$HOME` (e.g. `.config/opencode/opencode.json`).
     fn read_home(&self, rel: &str) -> String {
         fs::read_to_string(self.global.path().join("home").join(rel)).unwrap()
     }
@@ -1115,7 +1115,7 @@ fn doctor_does_not_flag_stderr_only_failures() {
 }
 
 #[test]
-fn refresh_all_six_agents_emit_gitignored_overlays() {
+fn refresh_all_agents_emit_gitignored_overlays() {
     let fx = Fixture::new();
     fx.rust_project();
 
@@ -1127,7 +1127,6 @@ fn refresh_all_six_agents_emit_gitignored_overlays() {
     for f in [
         "claude.md",
         "agents.md",
-        "gemini.md",
         "opencode.md",
         "copilot/.github/instructions/loadout.instructions.md",
         "generic.md",
@@ -1136,71 +1135,10 @@ fn refresh_all_six_agents_emit_gitignored_overlays() {
     }
     // Committed instruction files are never touched.
     assert!(!fx.exists("AGENTS.md"));
-    assert!(!fx.exists("GEMINI.md"));
     assert!(!fx.exists(".github/copilot-instructions.md"));
-    // Auto-wired agents: Claude (local @import), Codex (gitignored override), and
-    // Gemini (gitignored GEMINI.local.md @import + global settings registration).
+    // Auto-wired agents: Claude (local @import) and Codex (gitignored override).
     assert!(fx.exists("CLAUDE.local.md"));
     assert!(fx.exists("AGENTS.override.md"));
-    assert!(fx.exists("GEMINI.local.md"));
-    assert!(fx.home_exists(".gemini/settings.json"));
-}
-
-#[test]
-fn gemini_auto_wires_local_import_and_registers_settings() {
-    let fx = Fixture::new();
-    fx.rust_project();
-    fx.git_init();
-    // A committed GEMINI.md must be left untouched (wiring is additive).
-    fx.write("GEMINI.md", "# Team GEMINI\n\nKeep me.\n");
-
-    fx.cmd()
-        .args(["refresh", "--agent", "gemini"])
-        .assert()
-        .success();
-
-    // Local @import file created (gitignored), pointing at the overlay.
-    assert!(fx.exists("GEMINI.local.md"));
-    let local = fx.read("GEMINI.local.md");
-    assert!(local.contains("@.loadout/generated/gemini.md"));
-    assert!(local.contains("BEGIN loadout (managed)"));
-    assert!(fx.read(".gitignore").contains("GEMINI.local.md"));
-    // Committed GEMINI.md untouched.
-    assert_eq!(fx.read("GEMINI.md"), "# Team GEMINI\n\nKeep me.\n");
-
-    // Global ~/.gemini/settings.json registers GEMINI.local.md in context.fileName
-    // (alongside the default GEMINI.md) so Gemini actually loads it.
-    let settings: serde_json::Value =
-        serde_json::from_str(&fx.read_home(".gemini/settings.json")).unwrap();
-    let names = settings["context"]["fileName"].as_array().unwrap();
-    assert!(names.iter().any(|v| v == "GEMINI.local.md"));
-    assert!(names.iter().any(|v| v == "GEMINI.md"));
-
-    // Idempotent: a second render leaves settings byte-identical.
-    let before = fx.read_home(".gemini/settings.json");
-    fx.cmd()
-        .args(["refresh", "--agent", "gemini"])
-        .assert()
-        .success();
-    assert_eq!(fx.read_home(".gemini/settings.json"), before);
-}
-
-#[test]
-fn gemini_warns_when_workspace_settings_would_mask_registration() {
-    let fx = Fixture::new();
-    fx.rust_project();
-    // A project-level .gemini/settings.json that sets context.fileName *replaces*
-    // (doesn't merge with) the home one, so the home registration is masked.
-    fx.write(
-        ".gemini/settings.json",
-        "{\"context\":{\"fileName\":[\"GEMINI.md\"]}}",
-    );
-
-    fx.cmd()
-        .args(["refresh", "--agent", "gemini"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("overrides the home registration"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Google retired the standalone `gemini` CLI on **2026-06-18** in favour of the Antigravity CLI (`agy`) — for free/Pro/Ultra tiers, `gemini` now returns HTTP 410. So loadout's gemini adapter targets a dead binary for most users; this removes it.

## What's removed

- The `gemini` built-in `AgentDescriptor` (launch, `GEMINI.local.md` `@import` wiring, `~/.gemini/settings.json` registration, `.gemini/commands` TOML commands).
- The now-dead `CommandFormat::Toml` + `GeminiCommandFile` plumbing — gemini was its only user (verified no other agent uses `Toml`).
- The two gemini-specific CLI tests; the "all agents" test drops gemini; the agent-list assertion now asserts gemini is *absent*.
- User-facing agent enumerations (CLI help, studio help/skill-offer copy) and docs (README "works with" + agent table, configuration/concepts/architecture/extending/security).

## What stays

- **`ImporterRegistry`** — opencode still uses it; its doc comments repoint from Gemini to opencode.
- The **ai-tools environment probe** still lists `gemini` — it detects installed binaries on the machine (like aider/goose/etc.), not loadout's supported agents.

## Why no Antigravity (`agy`) replacement

I verified empirically (three `agy` runs): `agy` reads a committed **`AGENTS.md`** and only falls back to `AGENTS.override.md` when there's no `AGENTS.md` — the **opposite** of Codex, and it never merges the two. loadout writes a gitignored override and relies on the agent preferring it (works for Codex), so `agy` would silently ignore loadout's overlay in any repo that ships an `AGENTS.md`. The only clean path would be `agy`'s sessionStart hook *if* its output injects context — unverified — so no `agy` agent is added here.

## Validation

- `cargo test --all --locked`: 467 lib + 141 CLI + others, 0 failed
- `cargo clippy --all-targets -D warnings` / `cargo fmt --check`: clean
- Full-tree sweep confirms no residual gemini as a supported agent (only the removal tombstone, the env probe, and historical CHANGELOG entries remain)

Follow-up: the loadout.tools site still lists Gemini in "works with" — separate repo, I'll handle it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc3AwWKfsMg487k4ki5ryJ