### PR TITLE
fix(studio): stop apply failing on a global-config backup, and make the topbar responsive

### DIFF
--- a/src/studio/assets/studio.css
+++ b/src/studio/assets/studio.css
@@ -968,11 +968,26 @@ pre.error { color: var(--error-fg); padding: 16px; font-family: var(--mono); whi
   .brand-name { display: none; }
   .tabs { gap: 4px; }
   .tab { padding: 7px 10px; }
-  .tab-label { display: none; }
+  .topbar .tab-label { display: none; }
   .topbar-right { flex: 0 1 auto; gap: 6px; }
   .staged-wrap { min-width: 0; gap: 4px; }
-  .staged-label { display: none; }
-  .btn-label { display: none; }
+  /* Not `display: none` like the two labels above: those sit inside a
+     <button>, where a `title` is a proper accessible-name fallback once
+     content is excluded from the tree. This is a bare <span> with no
+     interactive role, so a title on it is exposed as a description at
+     best — a screen reader would be left with just "3". Clipping instead
+     of removing keeps "3 staged" in the accessibility tree at every
+     width, with zero visual footprint. */
+  .topbar .staged-label {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .topbar .btn-label { display: none; }
   #staged .btn.btn-sm { padding: 5px 7px; }
 }
 

--- a/src/studio/assets/studio.css
+++ b/src/studio/assets/studio.css
@@ -142,7 +142,7 @@ body {
   display: inline-flex; align-items: center; gap: 8px;
   font: 600 15px var(--sans); color: var(--muted);
   padding: 9px 20px; border: none; border-radius: var(--r);
-  background: transparent; cursor: pointer;
+  background: transparent; cursor: pointer; white-space: nowrap;
 }
 .tab .icon { width: 17px; height: 17px; }
 .tab:hover { background: var(--panel-2); color: var(--fg); }
@@ -169,7 +169,7 @@ body {
 :root[data-theme-pref="light"] .theme-toggle .ti-light,
 :root[data-theme-pref="dark"] .theme-toggle .ti-dark,
 :root:not([data-theme-pref]) .theme-toggle .ti-auto { display: inline-flex; }
-.staged-count { display: inline-flex; align-items: center; gap: 6px; font-weight: 600; }
+.staged-count { display: inline-flex; align-items: center; gap: 6px; font-weight: 600; white-space: nowrap; }
 .staged-count .icon { color: var(--accent); }
 
 /* --- main + buttons -------------------------------------------------------- */
@@ -941,6 +941,49 @@ pre.error { color: var(--error-fg); padding: 16px; font-family: var(--mono); whi
   .tab-profiles, .profile-editor { grid-template-columns: 1fr; }
   .profile-rail, .editor-preview-col { position: static; max-height: none; overflow: visible; }
   .pack-grid { grid-template-columns: 1fr; }
+}
+
+/* Responsive topbar. The bar is three flex groups (brand / tabs / controls);
+   full labels on all three stop fitting a bit above 1300px (measured: at
+   1200px they already overlap by ~49px), well before the 1024px breakpoint
+   above handles the rest of the page, so this gets its own threshold. Each
+   group sheds its *label* first and keeps every control: the wordmark drops
+   to just the mark, tab buttons and the staged/Review/Discard/Apply buttons
+   go icon-only (each keeps a `title` as its accessible name), and the
+   "N staged" text shrinks to just the count. Nothing is ever hidden — only
+   a label. Studio now commonly opens in an IDE's Simple Browser pane
+   (~1000px, often narrower next to a chat sidebar), so this isn't a rare
+   case. */
+@media (max-width: 1300px) {
+  .topbar {
+    /* Once labels are gone, brand and the controls no longer need matching
+       widths to keep the tabs *visually* centered (that math only held while
+       both sides had comparable content) — space-between plus each side
+       sizing to its own content places the tabs reasonably between two
+       unevenly-sized groups instead of leaving a lopsided gap on one side. */
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .brand { flex: 0 1 auto; }
+  .brand-name { display: none; }
+  .tabs { gap: 4px; }
+  .tab { padding: 7px 10px; }
+  .tab-label { display: none; }
+  .topbar-right { flex: 0 1 auto; gap: 6px; }
+  .staged-wrap { min-width: 0; gap: 4px; }
+  .staged-label { display: none; }
+  .btn-label { display: none; }
+  #staged .btn.btn-sm { padding: 5px 7px; }
+}
+
+/* Phone-width panes: squeeze further. Still no control is hidden. */
+@media (max-width: 480px) {
+  .topbar { padding: 0 8px; gap: 6px; }
+  .tabs { gap: 3px; }
+  .tab { padding: 6px 7px; }
+  .topbar-right { gap: 4px; }
+  .staged-wrap { gap: 3px; }
+  .icon-btn { width: 26px; height: 26px; }
 }
 
 /* --- Recents drawer ------------------------------------------------------ */

--- a/src/studio/assets/studio.css
+++ b/src/studio/assets/studio.css
@@ -944,17 +944,26 @@ pre.error { color: var(--error-fg); padding: 16px; font-family: var(--mono); whi
 }
 
 /* Responsive topbar. The bar is three flex groups (brand / tabs / controls);
-   full labels on all three stop fitting a bit above 1300px (measured: at
-   1200px they already overlap by ~49px), well before the 1024px breakpoint
-   above handles the rest of the page, so this gets its own threshold. Each
-   group sheds its *label* first and keeps every control: the wordmark drops
-   to just the mark, tab buttons and the staged/Review/Discard/Apply buttons
-   go icon-only (each keeps a `title` as its accessible name), and the
-   "N staged" text shrinks to just the count. Nothing is ever hidden — only
-   a label. Studio now commonly opens in an IDE's Simple Browser pane
+   full labels on all three stop fitting well before the 1024px breakpoint
+   above handles the rest of the page, so this gets its own threshold. The
+   number that has to fit isn't fixed, though: "N staged" grows a digit once
+   a session crosses into double digits, which a real editing session can
+   reach easily (`session.ops().len()` in edit.rs is uncapped and never
+   deduplicated -- applying one starter pack alone stages 14-15 ops).
+   Measured with the widest plausible count (99) and the real embedded
+   fonts: the gap between the tabs and the staged cluster is still negative
+   (overlapping) at 1305-1310px, crosses zero around 1315px, and only clears
+   a comfortable ~16px margin past 1350px -- 1300px, sized against a
+   single-digit count, was nowhere near enough. 1360px leaves ~23px of
+   margin at its nearest full-label neighbor (1361px), growing from there.
+   Each group sheds its *label* first and keeps every control: the wordmark
+   drops to just the mark, tab buttons and the staged/Review/Discard/Apply
+   buttons go icon-only (each keeps a `title` as its accessible name), and
+   the "N staged" text shrinks to just the count. Nothing is ever hidden —
+   only a label. Studio now commonly opens in an IDE's Simple Browser pane
    (~1000px, often narrower next to a chat sidebar), so this isn't a rare
    case. */
-@media (max-width: 1300px) {
+@media (max-width: 1360px) {
   .topbar {
     /* Once labels are gone, brand and the controls no longer need matching
        widths to keep the tabs *visually* centered (that math only held while

--- a/src/studio/edit.rs
+++ b/src/studio/edit.rs
@@ -1297,7 +1297,8 @@ mod tests {
 
     #[test]
     fn apply_backs_up_global_layer_under_state_dir_not_repo_cache() {
-        let (d, gdir) = repo_with_global("[[fragments]]\nid = \"a\"\nguidance = \"A\"\n");
+        let body = "[[fragments]]\nid = \"a\"\nguidance = \"A\"\n";
+        let (d, gdir) = repo_with_global(body);
         let state = tempfile::tempdir().unwrap();
         let mut s = session_with_state(d.path(), &gdir, state.path());
         s.stage(StagedOp::CreateFragment {
@@ -1308,14 +1309,22 @@ mod tests {
 
         s.apply().unwrap();
 
-        let bak_dir = state.path().join("studio-backups");
+        // Exact expected name (`apply`'s `"{name}.{layer:?}.bak"` scheme) and
+        // exact pre-apply contents — pins what the backup is *for*, not just
+        // that some file landed in the right directory.
+        let bak_path = state
+            .path()
+            .join("studio-backups")
+            .join("config.toml.Global.bak");
         assert!(
-            bak_dir.exists(),
-            "global layer's backup should land under the injected state dir"
+            bak_path.is_file(),
+            "expected {} to exist",
+            bak_path.display()
         );
-        assert!(
-            std::fs::read_dir(&bak_dir).unwrap().next().is_some(),
-            "state dir's studio-backups should contain the .bak file"
+        assert_eq!(
+            std::fs::read_to_string(&bak_path).unwrap(),
+            body,
+            "backup should hold the pre-apply bytes"
         );
         assert!(
             !config::cache_dir(d.path()).exists(),
@@ -1341,7 +1350,9 @@ mod tests {
 
         let (d, gdir) = repo_with_global("[[fragments]]\nid = \"a\"\nguidance = \"A\"\n");
         let state = tempfile::tempdir().unwrap();
-        let original_mode = std::fs::metadata(d.path()).unwrap().permissions().mode();
+        // Mask off the file-type bits (`mode()` returns e.g. `0o40755` for a
+        // directory) — `Permissions::from_mode` wants permission bits only.
+        let original_mode = std::fs::metadata(d.path()).unwrap().permissions().mode() & 0o777;
         std::fs::set_permissions(d.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
 
         let result = (|| -> Result<()> {

--- a/src/studio/edit.rs
+++ b/src/studio/edit.rs
@@ -164,6 +164,11 @@ pub struct Session {
     repo_base: PathBuf,
     layers: Vec<LayerFile>,
     ops: Vec<StagedOp>,
+    /// Per-machine state dir a global layer's `.bak` snapshot backs up under
+    /// (see [`backup_dir_for`]). Injected rather than read from
+    /// [`config::state_dir`] directly, so tests never touch the real
+    /// `~/.local/state`.
+    state_dir: Option<PathBuf>,
     /// Script hashes to record as trusted once `apply()` writes succeed — one
     /// entry per accepted script-bearing `EditFragment`/`EditTarget`. The
     /// explicit studio edit *is* the trust approval.
@@ -196,7 +201,21 @@ impl Session {
     /// Open a session over the repo's writable layers (`config.toml` +
     /// `local.toml`), plus the global layers when `global_dir` is given. Missing
     /// files are tracked as empty so they can be created by staged ops.
+    ///
+    /// Uses the real per-machine state dir ([`config::state_dir`]) for
+    /// global-layer backups; see [`Self::open_with`] to inject a different one.
     pub fn open(repo_base: &Path, global_dir: Option<&Path>) -> Result<Self> {
+        Self::open_with(repo_base, global_dir, config::state_dir())
+    }
+
+    /// Like [`Self::open`], but with the state dir injected instead of read
+    /// from the environment — lets callers (tests, mainly) keep backups out of
+    /// the real `~/.local/state`.
+    pub fn open_with(
+        repo_base: &Path,
+        global_dir: Option<&Path>,
+        state_dir: Option<PathBuf>,
+    ) -> Result<Self> {
         let mut candidates: Vec<(Layer, PathBuf, bool)> = Vec::new();
         if let Some(g) = global_dir {
             candidates.push((Layer::Global, g.join("config.toml"), true));
@@ -213,6 +232,7 @@ impl Session {
             repo_base: repo_base.to_path_buf(),
             layers,
             ops: Vec::new(),
+            state_dir,
             pending_trust: Vec::new(),
         })
     }
@@ -395,8 +415,9 @@ impl Session {
         self.validate().context("staged config is invalid")?;
         self.check_external_edits()?;
 
-        // Snapshot a one-shot .bak for each existing file that will change.
-        let backup_dir = config::cache_dir(&self.repo_base).join("studio-backups");
+        // Snapshot a one-shot .bak for each existing file that will change, in
+        // a directory that matches that layer's scope — a global layer must
+        // not back up into whatever repo happens to be studio's cwd.
         for lf in &self.layers {
             if lf.staged.to_string() != lf.original && !lf.original.is_empty() {
                 let name = lf
@@ -404,6 +425,8 @@ impl Session {
                     .file_name()
                     .map(|n| n.to_string_lossy().into_owned())
                     .unwrap_or_else(|| "layer".to_string());
+                let backup_dir =
+                    backup_dir_for(lf.layer, &self.repo_base, self.state_dir.as_deref());
                 let bak = backup_dir.join(format!("{}.{:?}.bak", name, lf.layer));
                 atomic_write(&bak, &lf.original)
                     .with_context(|| format!("backing up {}", lf.path.display()))?;
@@ -454,6 +477,30 @@ impl Session {
             );
         }
         Ok(())
+    }
+}
+
+/// Where a layer's pre-apply `.bak` snapshot belongs.
+///
+/// Global layers (`Layer::Global`, `Layer::GlobalLocal`) are per-machine
+/// state, not repo state — the studio process may have no meaningful
+/// `repo_base` at all (e.g. launched with no cwd), and `load sync` puts the
+/// global config dir itself under git, so a `.bak` dropped there would get
+/// committed and synced between machines. They back up under
+/// [`config::state_dir`] instead — the directory that already exists for
+/// exactly this "must never sync" reason (script trust hashes).
+///
+/// Repo layers (`Layer::Repo`, `Layer::RepoLocal`) keep the existing
+/// repo-scoped cache dir. A `None` state dir (no `$HOME` to resolve one)
+/// falls back to the repo path for every layer, preserving today's behavior
+/// rather than failing.
+fn backup_dir_for(layer: Layer, repo_base: &Path, state_dir: Option<&Path>) -> PathBuf {
+    let repo_backups = config::cache_dir(repo_base).join("studio-backups");
+    match layer {
+        Layer::Global | Layer::GlobalLocal => state_dir
+            .map(|dir| dir.join("studio-backups"))
+            .unwrap_or(repo_backups),
+        Layer::BuiltIn | Layer::Repo | Layer::RepoLocal => repo_backups,
     }
 }
 
@@ -1196,5 +1243,124 @@ mod tests {
         let cfg =
             crate::config::Config::load_from(Some(&gdir.join("config.toml")), d.path()).unwrap();
         assert_eq!(cfg.default_agent, "codex");
+    }
+
+    // --- backup routing: global layers back up to state_dir, not repo cache ---
+
+    fn session_with_state(repo: &Path, gdir: &Path, state_dir: &Path) -> Session {
+        Session::open_with(repo, Some(gdir), Some(state_dir.to_path_buf())).unwrap()
+    }
+
+    #[test]
+    fn backup_dir_for_global_layers_uses_injected_state_dir() {
+        let repo = Path::new("/repo");
+        let state = Path::new("/state");
+        for layer in [Layer::Global, Layer::GlobalLocal] {
+            assert_eq!(
+                backup_dir_for(layer, repo, Some(state)),
+                state.join("studio-backups"),
+                "{layer:?} should back up under the state dir"
+            );
+        }
+    }
+
+    #[test]
+    fn backup_dir_for_repo_layers_uses_repo_cache() {
+        let repo = Path::new("/repo");
+        let state = Path::new("/state");
+        for layer in [Layer::Repo, Layer::RepoLocal] {
+            assert_eq!(
+                backup_dir_for(layer, repo, Some(state)),
+                config::cache_dir(repo).join("studio-backups"),
+                "{layer:?} should stay repo-scoped even with a state dir available"
+            );
+        }
+    }
+
+    #[test]
+    fn backup_dir_for_falls_back_to_repo_cache_without_a_state_dir() {
+        let repo = Path::new("/repo");
+        for layer in [
+            Layer::BuiltIn,
+            Layer::Global,
+            Layer::GlobalLocal,
+            Layer::Repo,
+            Layer::RepoLocal,
+        ] {
+            assert_eq!(
+                backup_dir_for(layer, repo, None),
+                config::cache_dir(repo).join("studio-backups"),
+                "{layer:?} with no state dir (no $HOME) should preserve today's behavior"
+            );
+        }
+    }
+
+    #[test]
+    fn apply_backs_up_global_layer_under_state_dir_not_repo_cache() {
+        let (d, gdir) = repo_with_global("[[fragments]]\nid = \"a\"\nguidance = \"A\"\n");
+        let state = tempfile::tempdir().unwrap();
+        let mut s = session_with_state(d.path(), &gdir, state.path());
+        s.stage(StagedOp::CreateFragment {
+            layer: Layer::Global,
+            cap: Box::new(cap("b", "B")),
+        })
+        .unwrap();
+
+        s.apply().unwrap();
+
+        let bak_dir = state.path().join("studio-backups");
+        assert!(
+            bak_dir.exists(),
+            "global layer's backup should land under the injected state dir"
+        );
+        assert!(
+            std::fs::read_dir(&bak_dir).unwrap().next().is_some(),
+            "state dir's studio-backups should contain the .bak file"
+        );
+        assert!(
+            !config::cache_dir(d.path()).exists(),
+            "repo cache dir must never be created for a global-only apply"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn apply_succeeds_when_repo_base_is_unwritable() {
+        // Regression for the reported bug: studio launched with no cwd (VS
+        // Code extension) inherits `/` as repo_base. A global-layer backup
+        // must not depend on repo_base being writable at all.
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!(
+                "skipping apply_succeeds_when_repo_base_is_unwritable: running as root, \
+                 permission bits are not enforced"
+            );
+            return;
+        }
+
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let (d, gdir) = repo_with_global("[[fragments]]\nid = \"a\"\nguidance = \"A\"\n");
+        let state = tempfile::tempdir().unwrap();
+        let original_mode = std::fs::metadata(d.path()).unwrap().permissions().mode();
+        std::fs::set_permissions(d.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let result = (|| -> Result<()> {
+            let mut s = session_with_state(d.path(), &gdir, state.path());
+            s.stage(StagedOp::CreateFragment {
+                layer: Layer::Global,
+                cap: Box::new(cap("b", "B")),
+            })?;
+            s.apply()?;
+            Ok(())
+        })();
+
+        // Restore write permission unconditionally so `tempfile` can clean up
+        // the directory, regardless of whether apply succeeded.
+        std::fs::set_permissions(d.path(), std::fs::Permissions::from_mode(original_mode)).unwrap();
+
+        result.expect(
+            "apply must succeed with a read-only repo_base — the global layer's backup \
+             does not belong there",
+        );
     }
 }

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -1934,7 +1934,7 @@ fn handle_fragment_try(req: &Req) -> Resp {
 
 fn handle_discard(state: &Arc<Mutex<StudioState>>) -> Resp {
     if let Err(e) = state.lock().unwrap().session.discard() {
-        return Resp::html(views::error_fragment(&format!("discard failed: {e}")));
+        return Resp::html(views::error_fragment(&format!("discard failed: {e:#}")));
     }
     profiles_tab_resp(state, None, Some("discarded staged changes"), true)
 }
@@ -1986,7 +1986,7 @@ fn handle_apply(state: &Arc<Mutex<StudioState>>) -> Resp {
             }
             profiles_tab_resp(state, None, Some(&msg), true)
         }
-        Err(e) => Resp::html(views::error_fragment(&format!("apply failed: {e}"))),
+        Err(e) => Resp::html(views::error_fragment(&format!("apply failed: {e:#}"))),
     }
 }
 

--- a/src/studio/settings.rs
+++ b/src/studio/settings.rs
@@ -172,10 +172,26 @@ fn apply_or_stage(state: &Arc<Mutex<StudioState>>, op: StagedOp, applied_msg: &s
                 // The op stays staged — `apply()` only clears ops on success —
                 // so this is surfaced rather than discarded; the top-bar
                 // Apply can retry once the conflict is resolved.
-                Err(e) => (
-                    true,
-                    format!("config changed on disk — review and apply from the top bar: {e}"),
-                ),
+                //
+                // `apply()`'s external-edit gate runs before any write, so if
+                // that's why this failed, the on-disk bytes it compared
+                // against are still out of sync with what this session
+                // loaded — checking `external_edits()` here (same lock,
+                // right after the failure) tells us that structurally
+                // instead of guessing from the error text. Any other failure
+                // (e.g. a backup write that couldn't create its directory)
+                // leaves the loaded files untouched, so this reads empty and
+                // the message doesn't assert a cause it doesn't know.
+                Err(e) => {
+                    let is_external_edit =
+                        !state.lock().unwrap().session.external_edits().is_empty();
+                    let msg = if is_external_edit {
+                        format!("config changed on disk — review and apply from the top bar: {e:#}")
+                    } else {
+                        format!("apply failed: {e:#}")
+                    };
+                    (true, msg)
+                }
             }
         }
     };
@@ -184,4 +200,129 @@ fn apply_or_stage(state: &Arc<Mutex<StudioState>>, op: StagedOp, applied_msg: &s
     resp.body
         .extend_from_slice(views::staged_indicator_loader().as_bytes());
     resp
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+    use crate::fragment::Layer;
+
+    /// A repo tempdir plus a global config dir (a subdir of it) whose
+    /// `config.toml` starts with `body`. Mirrors the fixture in
+    /// `studio::edit::tests` / `studio::sync_card::tests`.
+    fn repo_with_global(body: &str) -> (tempfile::TempDir, PathBuf) {
+        let d = tempfile::tempdir().unwrap();
+        let gdir = d.path().join("global");
+        std::fs::create_dir_all(&gdir).unwrap();
+        std::fs::write(gdir.join("config.toml"), body).unwrap();
+        (d, gdir)
+    }
+
+    /// A studio state whose session is opened via `open_with`, so the state
+    /// dir is injected rather than resolved from the real `~/.local/state`
+    /// (see `studio::edit::Session::open_with`).
+    fn state_with_session(
+        repo: &Path,
+        gdir: &Path,
+        state_dir: Option<PathBuf>,
+    ) -> Arc<Mutex<StudioState>> {
+        let gcfg = gdir.join("config.toml");
+        let config = crate::config::Config::load_from(Some(&gcfg), repo).unwrap();
+        let base_context = crate::context::detect_context(repo, &config).unwrap();
+        let session = crate::studio::edit::Session::open_with(repo, Some(gdir), state_dir).unwrap();
+        Arc::new(Mutex::new(StudioState {
+            session,
+            base_context,
+            repo_base: repo.to_path_buf(),
+            token: "testtoken".into(),
+            port: 7777,
+            onboarding_active: false,
+            active_tab: "settings".into(),
+            recents_path: None,
+        }))
+    }
+
+    #[test]
+    fn apply_or_stage_names_the_external_edit_when_thats_the_cause() {
+        let (d, gdir) = repo_with_global("[defaults]\nagent = \"claude\"\n");
+        let state = state_with_session(d.path(), &gdir, Some(d.path().join("state")));
+
+        // Someone edits the global config out from under the open session.
+        std::fs::write(gdir.join("config.toml"), "[defaults]\nagent = \"codex\"\n").unwrap();
+
+        let resp = apply_or_stage(
+            &state,
+            StagedOp::SetDefaultAgent {
+                layer: Layer::Global,
+                agent: "opencode".into(),
+            },
+            "saved",
+        );
+        let body = String::from_utf8(resp.body).unwrap();
+        assert!(
+            body.contains("config changed on disk — review and apply from the top bar"),
+            "external-edit failure should keep its specific wording: {body}"
+        );
+        assert!(
+            body.contains("changed on disk"),
+            "should still surface the real error text: {body}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn apply_or_stage_does_not_blame_an_external_edit_for_an_unrelated_failure() {
+        // Regression for the settings-page half of the read-only-backup bug:
+        // a failure that has nothing to do with an external edit (here, the
+        // same unwritable-backup-dir failure `Session::apply` was just fixed
+        // for at the repo-scoped layer) must not be reported with the
+        // external-edit wording, and must show the real chain.
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!(
+                "skipping apply_or_stage_does_not_blame_an_external_edit_for_an_unrelated_failure: \
+                 running as root, permission bits are not enforced"
+            );
+            return;
+        }
+
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let (d, gdir) = repo_with_global("[defaults]\nagent = \"claude\"\n");
+        // No state dir injected: a Global-layer backup falls back to the
+        // repo-scoped cache dir (`Session::open` with no `$HOME` behaves the
+        // same way), which we then make unwritable.
+        let state = state_with_session(d.path(), &gdir, None);
+
+        let original_mode = std::fs::metadata(d.path()).unwrap().permissions().mode();
+        std::fs::set_permissions(d.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let resp = apply_or_stage(
+            &state,
+            StagedOp::SetDefaultAgent {
+                layer: Layer::Global,
+                agent: "codex".into(),
+            },
+            "saved",
+        );
+
+        // Restore unconditionally so `tempfile` can clean up.
+        std::fs::set_permissions(d.path(), std::fs::Permissions::from_mode(original_mode)).unwrap();
+
+        let body = String::from_utf8(resp.body).unwrap();
+        assert!(
+            !body.contains("changed on disk"),
+            "must not claim an external edit when the real cause was a write failure: {body}"
+        );
+        assert!(
+            body.contains("apply failed"),
+            "should surface a cause-neutral message: {body}"
+        );
+        assert!(
+            body.contains("Permission denied"),
+            "{{e:#}} should surface the full chain, not just the outermost \
+             'backing up ...' frame: {body}"
+        );
+    }
 }

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -428,16 +428,14 @@ fn library_nav(active: &str) -> Markup {
 }
 
 /// The staged-changes indicator (top-bar right). Re-pulled via `GET /staged`.
-/// Below 1300px `.staged-label`/`.btn-label` hide (see studio.css), leaving
-/// icon-only controls — each button keeps a `title` as its accessible name,
-/// and the count itself keeps a `title` spelling out the full phrase.
+/// At or below 1300px `.staged-label`/`.btn-label` hide (see studio.css),
+/// leaving icon-only controls — each button keeps a `title` as its
+/// accessible name, and the count itself keeps a `title` spelling out the
+/// full phrase.
 pub fn staged_indicator(staged: usize) -> Markup {
-    let phrase = format!(
-        "{staged} staged change{}",
-        if staged == 1 { "" } else { "s" }
-    );
     html! {
         @if staged > 0 {
+            @let phrase = format!("{staged} staged change{}", if staged == 1 { "" } else { "s" });
             span class="staged-count" title=(phrase) { (icon("layers")) (staged) span class="staged-label" { " staged" } }
             button class="btn btn-ghost btn-sm" title="Review" hx-get="/diff" hx-target="#main" { (icon("eye")) span class="btn-label" { "Review" } }
             button class="btn btn-ghost btn-sm" title="Discard" hx-post="/discard" hx-target="#main"

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -399,8 +399,8 @@ fn tab_bar(active: &str) -> Markup {
     let cls = |name: &str| if name == active { "tab active" } else { "tab" };
     html! {
         nav class="tabs" {
-            button class=(cls("profiles")) data-tab="profiles" hx-get="/tab/profiles" hx-target="#main" { (icon("layers")) "Loadouts" }
-            button class=(cls("library")) data-tab="library" hx-get="/tab/library" hx-target="#main" { (icon("book")) "Library" }
+            button class=(cls("profiles")) data-tab="profiles" title="Loadouts" hx-get="/tab/profiles" hx-target="#main" { (icon("layers")) span class="tab-label" { "Loadouts" } }
+            button class=(cls("library")) data-tab="library" title="Library" hx-get="/tab/library" hx-target="#main" { (icon("book")) span class="tab-label" { "Library" } }
         }
     }
 }
@@ -428,15 +428,22 @@ fn library_nav(active: &str) -> Markup {
 }
 
 /// The staged-changes indicator (top-bar right). Re-pulled via `GET /staged`.
+/// Below 1300px `.staged-label`/`.btn-label` hide (see studio.css), leaving
+/// icon-only controls — each button keeps a `title` as its accessible name,
+/// and the count itself keeps a `title` spelling out the full phrase.
 pub fn staged_indicator(staged: usize) -> Markup {
+    let phrase = format!(
+        "{staged} staged change{}",
+        if staged == 1 { "" } else { "s" }
+    );
     html! {
         @if staged > 0 {
-            span class="staged-count" { (icon("layers")) (staged) " staged" }
-            button class="btn btn-ghost btn-sm" hx-get="/diff" hx-target="#main" { "Review" }
-            button class="btn btn-ghost btn-sm" hx-post="/discard" hx-target="#main"
-                hx-confirm="Discard all staged changes? Your config files won't be modified." { (icon("x")) "Discard" }
-            button class="btn btn-primary btn-sm" hx-post="/apply" hx-target="#main"
-                hx-confirm="Apply staged changes to your config files?" { (icon("check")) "Apply" }
+            span class="staged-count" title=(phrase) { (icon("layers")) (staged) span class="staged-label" { " staged" } }
+            button class="btn btn-ghost btn-sm" title="Review" hx-get="/diff" hx-target="#main" { (icon("eye")) span class="btn-label" { "Review" } }
+            button class="btn btn-ghost btn-sm" title="Discard" hx-post="/discard" hx-target="#main"
+                hx-confirm="Discard all staged changes? Your config files won't be modified." { (icon("x")) span class="btn-label" { "Discard" } }
+            button class="btn btn-primary btn-sm" title="Apply" hx-post="/apply" hx-target="#main"
+                hx-confirm="Apply staged changes to your config files?" { (icon("check")) span class="btn-label" { "Apply" } }
         } @else {
             span class="muted small" { "No staged changes" }
         }

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -428,7 +428,7 @@ fn library_nav(active: &str) -> Markup {
 }
 
 /// The staged-changes indicator (top-bar right). Re-pulled via `GET /staged`.
-/// At or below 1300px `.staged-label`/`.btn-label` hide (see studio.css),
+/// At or below 1360px `.staged-label`/`.btn-label` hide (see studio.css),
 /// leaving icon-only controls — each button keeps a `title` as its
 /// accessible name, and the count itself keeps a `title` spelling out the
 /// full phrase.

--- a/tests/browser_smoke.rs
+++ b/tests/browser_smoke.rs
@@ -214,11 +214,16 @@ fn viewer_selftest_passes_under_opaque_origin_sandbox() {
 // --- studio topbar responsiveness -------------------------------------------
 
 /// The widths the topbar is required to handle without overlap or
-/// horizontal overflow (R2 brief): 1400px down to 380px. 1310 and 1301 are
-/// the tightest sampled points just above the 1300px compact-mode
-/// breakpoint (`studio.css`) -- everything else here is round; these two
-/// exist specifically to catch the breakpoint being set too low.
-const TOPBAR_TEST_WIDTHS: [u32; 10] = [1400, 1310, 1301, 1200, 1024, 900, 768, 600, 480, 380];
+/// horizontal overflow (R2 brief): 1400px down to 380px. 1360/1361 are the
+/// tightest sampled points straddling the compact-mode breakpoint
+/// (`studio.css`, currently 1360px) -- 1360 is the last compact width, 1361
+/// the first full-label one, so together they catch the breakpoint being
+/// set too low. 1301/1310 are kept from an earlier (lower) breakpoint value
+/// as a regression check that they stay comfortably inside compact mode.
+/// Everything else here is round.
+const TOPBAR_TEST_WIDTHS: [u32; 12] = [
+    1400, 1361, 1360, 1310, 1301, 1200, 1024, 900, 768, 600, 480, 380,
+];
 
 /// Expected count of measured pieces per group (brand: mark + wordmark;
 /// tabs: the two nav buttons; topbar-right: the staged count + its three
@@ -330,14 +335,29 @@ fn base64_encode(data: &[u8]) -> String {
     out
 }
 
-/// Renders the studio shell with a non-zero staged count -- the busiest the
-/// topbar ever gets, since that's what puts the "N staged" text plus the
-/// Review/Discard/Apply buttons in the right-hand group (the cluster that
-/// actually collided with the tabs; see R2 brief) -- inlines the real
-/// stylesheet (fonts included; see below), and checks at a spread of widths
-/// from 1400px down to 380px that no rendered piece of the brand, tabs, or
-/// top-right controls ever overlaps a piece from a different group, and
-/// that the page never scrolls horizontally.
+/// The staged count rendered in the test below. "N staged" grows a digit
+/// once this crosses into double digits, which is where the string's width
+/// actually jumps -- so the test needs a plausibly *wide* count, not a
+/// small one. `staged` is `Session::ops().len()` (`src/studio/edit.rs`),
+/// which is uncapped and never deduplicated (re-saving the same fragment
+/// three times pushes three ops, not one); applying a single starter pack
+/// already stages 14-15 ops (`server.rs`'s pack-apply tests), and a heavier
+/// single sitting -- a pack apply plus hand-adopting several more palette
+/// fragments, a few edits redone, a profile toggle or two -- plausibly
+/// reaches well into double digits. 99 is used here: the widest count still
+/// inside that plausible double-digit range, without assuming an
+/// implausible triple-digit session.
+const TOPBAR_TEST_STAGED_COUNT: usize = 99;
+
+/// Renders the studio shell with a wide staged count (see
+/// [`TOPBAR_TEST_STAGED_COUNT`]) -- the busiest the topbar ever gets, since
+/// that's what puts the "N staged" text plus the Review/Discard/Apply
+/// buttons in the right-hand group (the cluster that actually collided with
+/// the tabs; see R2 brief) -- inlines the real stylesheet (fonts included;
+/// see below), and checks at a spread of widths from 1400px down to 380px
+/// that no rendered piece of the brand, tabs, or top-right controls ever
+/// overlaps a piece from a different group, and that the page never scrolls
+/// horizontally.
 ///
 /// Each width gets its own `<iframe>` (a nested browsing context whose CSS
 /// viewport is exactly its own rendered box) rather than relaunching Chrome
@@ -346,13 +366,13 @@ fn base64_encode(data: &[u8]) -> String {
 /// a real OS/window-manager minimum, not a bug in this test), which would
 /// have made the 480px and 380px cases secretly re-test 500px. The iframe
 /// approach sidesteps that floor entirely and needs only one Chrome launch
-/// for all ten widths.
+/// for all twelve widths.
 #[test]
 #[ignore = "needs Chrome; CI runs it via `cargo test --test browser_smoke -- --ignored`"]
 fn topbar_never_overlaps_or_overflows_from_1400px_to_380px() {
     let chrome = chrome().expect("no Chrome found; set CHROME_BIN");
 
-    let shell = loadout::studio::views::shell(maud::html! {}, 3, "profiles");
+    let shell = loadout::studio::views::shell(maud::html! {}, TOPBAR_TEST_STAGED_COUNT, "profiles");
 
     // The shell's own `<link rel="stylesheet" href="/assets/studio.css">`
     // 404s under `file://`/`srcdoc` (a rooted path doesn't resolve on disk),

--- a/tests/browser_smoke.rs
+++ b/tests/browser_smoke.rs
@@ -1,5 +1,6 @@
-//! Headless-Chrome smoke test for the plan viewer's JS (`#selftest` mode).
-//! `#[ignore]`d locally (needs Chrome); CI runs it explicitly.
+//! Headless-Chrome smoke tests: the plan viewer's JS (`#selftest` mode) and
+//! studio's topbar layout. `#[ignore]`d locally (needs Chrome); CI runs them
+//! explicitly.
 
 use std::process::Command;
 
@@ -206,6 +207,198 @@ fn viewer_selftest_passes_under_opaque_origin_sandbox() {
             relay.contains(probe),
             "missing '{probe}' in relay:\n{}",
             char_boundary_tail(relay, 2000)
+        );
+    }
+}
+
+// --- studio topbar responsiveness -------------------------------------------
+
+/// The widths the topbar is required to handle without overlap or
+/// horizontal overflow (R2 brief): 1400px down to 380px.
+const TOPBAR_TEST_WIDTHS: [u32; 8] = [1400, 1200, 1024, 900, 768, 600, 480, 380];
+
+/// Injected into the harness page below (`__WIDTHS__` is substituted with the
+/// literal widths array first). Runs once every iframe has loaded, measures
+/// each of `.brand`/`.tabs`/`.topbar-right` inside each one, and writes a
+/// single `{width: {innerWidth, scrollWidth, overlaps}}` JSON blob into a
+/// `<pre id="topbar-check-result">` for `--dump-dom` to capture -- the same
+/// marker-element pattern the `#selftest-result` probe above uses, rather
+/// than grepping the dump for a bare string that could also appear in
+/// inlined source.
+///
+/// Each "group" is a *list* of its meaningful rendered pieces, not one
+/// `getBoundingClientRect()` on the group's own wrapper: a flex item that
+/// can't shrink to fit (unhidden label text, a nowrap button) keeps its own
+/// natural size and paints outside its shrunk *parent* box without ever
+/// enlarging that parent's own rect, so comparing only the three wrapper
+/// boxes misses exactly the collision this bug produces (confirmed by
+/// running this test against the pre-fix CSS: the wrapper boxes stayed
+/// clear at every width while brand/tab/button text visibly overlapped on
+/// screen). Comparing every piece against every other group's pieces
+/// catches that.
+const TOPBAR_HARNESS_JS: &str = r#"
+<script>
+window.addEventListener('load', function () {
+  function pieces(doc, sels) {
+    var out = [];
+    sels.forEach(function (sel) {
+      doc.querySelectorAll(sel).forEach(function (el) {
+        var r = el.getBoundingClientRect();
+        var label = (el.title || el.textContent || '').trim().slice(0, 24);
+        out.push({ sel: sel, label: label, left: r.left, right: r.right, top: r.top, bottom: r.bottom });
+      });
+    });
+    return out;
+  }
+  function overlaps(a, b) {
+    return a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
+  }
+  var widths = [__WIDTHS__];
+  var results = {};
+  widths.forEach(function (w) {
+    var frame = document.getElementById('w-' + w);
+    var doc = frame.contentDocument;
+    var win = frame.contentWindow;
+    var groups = {
+      brand: pieces(doc, ['.brand-mark', '.brand-name']),
+      tabs: pieces(doc, ['.tab']),
+      'topbar-right': pieces(doc, ['.staged-count', '#staged .btn', '.icon-btn'])
+    };
+    var names = Object.keys(groups);
+    var hits = [];
+    for (var i = 0; i < names.length; i++) {
+      for (var j = i + 1; j < names.length; j++) {
+        groups[names[i]].forEach(function (a) {
+          groups[names[j]].forEach(function (b) {
+            if (overlaps(a, b)) {
+              hits.push(names[i] + ' [' + a.label + '] + ' + names[j] + ' [' + b.label + ']');
+            }
+          });
+        });
+      }
+    }
+    results[w] = { innerWidth: win.innerWidth, scrollWidth: doc.documentElement.scrollWidth, overlaps: hits };
+  });
+  var pre = document.createElement('pre');
+  pre.id = 'topbar-check-result';
+  pre.textContent = JSON.stringify(results);
+  document.body.appendChild(pre);
+});
+</script>
+"#;
+
+/// Renders the studio shell with a non-zero staged count -- the busiest the
+/// topbar ever gets, since that's what puts the "N staged" text plus the
+/// Review/Discard/Apply buttons in the right-hand group (the cluster that
+/// actually collided with the tabs; see R2 brief) -- inlines the real
+/// stylesheet, and checks at a spread of widths from 1400px down to 380px
+/// that no rendered piece of the brand, tabs, or top-right controls ever
+/// overlaps a piece from a different group, and that the page never scrolls
+/// horizontally.
+///
+/// Each width gets its own `<iframe>` (a nested browsing context whose CSS
+/// viewport is exactly its own rendered box) rather than relaunching Chrome
+/// with `--window-size=<width>`: this build of Chrome silently clamps
+/// `--window-size` widths below ~500px up to 500px (verified empirically --
+/// a real OS/window-manager minimum, not a bug in this test), which would
+/// have made the 480px and 380px cases secretly re-test 500px. The iframe
+/// approach sidesteps that floor entirely and needs only one Chrome launch
+/// for all eight widths.
+#[test]
+#[ignore = "needs Chrome; CI runs it via `cargo test --test browser_smoke -- --ignored`"]
+fn topbar_never_overlaps_or_overflows_from_1400px_to_380px() {
+    let chrome = chrome().expect("no Chrome found; set CHROME_BIN");
+
+    let shell = loadout::studio::views::shell(maud::html! {}, 3, "profiles");
+
+    // The shell's own `<link rel="stylesheet" href="/assets/studio.css">`
+    // 404s under `file://`/`srcdoc` (a rooted path doesn't resolve on disk),
+    // so styling would silently not apply without inlining it. The CSS is
+    // embedded via rust-embed and reachable through `studio::assets::get`,
+    // so no server is needed to fetch it.
+    let (css_bytes, _) =
+        loadout::studio::assets::get("/assets/studio.css").expect("studio.css must be embedded");
+    let css = String::from_utf8(css_bytes).unwrap();
+    let styled = shell.replacen("</head>", &format!("<style>{css}</style></head>"), 1);
+    // Escaped for embedding in each iframe's `srcdoc` attribute (the same
+    // technique `viewer_selftest_passes_under_opaque_origin_sandbox` uses
+    // above). No `sandbox` attribute here -- unlike that test, this harness
+    // needs same-origin access to each frame to read its layout.
+    let escaped = styled.replace('&', "&amp;").replace('"', "&quot;");
+
+    let mut harness = String::from("<!doctype html>\n<html><body>\n");
+    for w in TOPBAR_TEST_WIDTHS {
+        harness.push_str(&format!(
+            "<iframe id=\"w-{w}\" style=\"display:block;width:{w}px;height:220px;border:0\" scrolling=\"no\" srcdoc=\"{escaped}\"></iframe>\n"
+        ));
+    }
+    let widths_js = TOPBAR_TEST_WIDTHS
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    harness.push_str(&TOPBAR_HARNESS_JS.replace("__WIDTHS__", &widths_js));
+    harness.push_str("</body></html>\n");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("topbar.html");
+    std::fs::write(&path, harness).unwrap();
+
+    let out = Command::new(&chrome)
+        .args([
+            "--headless=new",
+            "--disable-gpu",
+            "--no-sandbox",
+            "--virtual-time-budget=5000",
+            "--dump-dom",
+            // Comfortably above every tested width plus the widest frame, so
+            // the *outer* harness page never itself has to shrink anything.
+            "--window-size=1600,1200",
+        ])
+        .arg(format!("file://{}", path.display()))
+        .output()
+        .expect("chrome runs");
+    let dom = String::from_utf8_lossy(&out.stdout);
+
+    let marker = "id=\"topbar-check-result\"";
+    let tag_start = dom.find(marker).unwrap_or_else(|| {
+        panic!(
+            "no topbar-check-result in DOM; tail:\n{}",
+            char_boundary_tail(&dom, 2000)
+        )
+    });
+    let body_start = dom[tag_start..]
+        .find('>')
+        .map(|i| tag_start + i + 1)
+        .unwrap_or_else(|| panic!("unterminated result tag"));
+    let body_end = dom[body_start..]
+        .find("</pre>")
+        .map(|i| body_start + i)
+        .unwrap_or_else(|| panic!("unterminated result element"));
+    let json = &dom[body_start..body_end];
+    let v: serde_json::Value =
+        serde_json::from_str(json).unwrap_or_else(|e| panic!("bad result JSON {json:?}: {e}"));
+
+    for w in TOPBAR_TEST_WIDTHS {
+        let r = &v[w.to_string()];
+        assert!(!r.is_null(), "width {w}px: missing from results {v}");
+
+        let overlaps: Vec<&str> = r["overlaps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s.as_str().unwrap())
+            .collect();
+        assert!(
+            overlaps.is_empty(),
+            "width {w}px: overlap between {overlaps:?}"
+        );
+
+        let inner = r["innerWidth"].as_u64().unwrap();
+        let scroll = r["scrollWidth"].as_u64().unwrap();
+        assert!(
+            scroll <= inner,
+            "width {w}px: horizontal overflow (scrollWidth {scroll} > innerWidth {inner})"
         );
     }
 }

--- a/tests/browser_smoke.rs
+++ b/tests/browser_smoke.rs
@@ -214,17 +214,29 @@ fn viewer_selftest_passes_under_opaque_origin_sandbox() {
 // --- studio topbar responsiveness -------------------------------------------
 
 /// The widths the topbar is required to handle without overlap or
-/// horizontal overflow (R2 brief): 1400px down to 380px.
-const TOPBAR_TEST_WIDTHS: [u32; 8] = [1400, 1200, 1024, 900, 768, 600, 480, 380];
+/// horizontal overflow (R2 brief): 1400px down to 380px. 1310 and 1301 are
+/// the tightest sampled points just above the 1300px compact-mode
+/// breakpoint (`studio.css`) -- everything else here is round; these two
+/// exist specifically to catch the breakpoint being set too low.
+const TOPBAR_TEST_WIDTHS: [u32; 10] = [1400, 1310, 1301, 1200, 1024, 900, 768, 600, 480, 380];
+
+/// Expected count of measured pieces per group (brand: mark + wordmark;
+/// tabs: the two nav buttons; topbar-right: the staged count + its three
+/// action buttons + the four icon buttons). Asserted at every width so a
+/// selector rename can't silently empty a group -- an empty group can never
+/// overlap anything, which would make the overlap assertion pass having
+/// measured nothing.
+const TOPBAR_EXPECTED_PIECE_COUNTS: [(&str, u32); 3] =
+    [("brand", 2), ("tabs", 2), ("topbar-right", 8)];
 
 /// Injected into the harness page below (`__WIDTHS__` is substituted with the
 /// literal widths array first). Runs once every iframe has loaded, measures
 /// each of `.brand`/`.tabs`/`.topbar-right` inside each one, and writes a
-/// single `{width: {innerWidth, scrollWidth, overlaps}}` JSON blob into a
-/// `<pre id="topbar-check-result">` for `--dump-dom` to capture -- the same
-/// marker-element pattern the `#selftest-result` probe above uses, rather
-/// than grepping the dump for a bare string that could also appear in
-/// inlined source.
+/// single `{width: {innerWidth, scrollWidth, overlaps, counts}}` JSON blob
+/// into a `<pre id="topbar-check-result">` for `--dump-dom` to capture --
+/// the same marker-element pattern the `#selftest-result` probe above uses,
+/// rather than grepping the dump for a bare string that could also appear
+/// in inlined source.
 ///
 /// Each "group" is a *list* of its meaningful rendered pieces, not one
 /// `getBoundingClientRect()` on the group's own wrapper: a flex item that
@@ -235,7 +247,8 @@ const TOPBAR_TEST_WIDTHS: [u32; 8] = [1400, 1200, 1024, 900, 768, 600, 480, 380]
 /// running this test against the pre-fix CSS: the wrapper boxes stayed
 /// clear at every width while brand/tab/button text visibly overlapped on
 /// screen). Comparing every piece against every other group's pieces
-/// catches that.
+/// catches that. `counts` (each group's piece count) guards against the
+/// same check passing vacuously if a selector ever stops matching anything.
 const TOPBAR_HARNESS_JS: &str = r#"
 <script>
 window.addEventListener('load', function () {
@@ -266,6 +279,8 @@ window.addEventListener('load', function () {
     };
     var names = Object.keys(groups);
     var hits = [];
+    var counts = {};
+    names.forEach(function (n) { counts[n] = groups[n].length; });
     for (var i = 0; i < names.length; i++) {
       for (var j = i + 1; j < names.length; j++) {
         groups[names[i]].forEach(function (a) {
@@ -277,7 +292,7 @@ window.addEventListener('load', function () {
         });
       }
     }
-    results[w] = { innerWidth: win.innerWidth, scrollWidth: doc.documentElement.scrollWidth, overlaps: hits };
+    results[w] = { innerWidth: win.innerWidth, scrollWidth: doc.documentElement.scrollWidth, overlaps: hits, counts: counts };
   });
   var pre = document.createElement('pre');
   pre.id = 'topbar-check-result';
@@ -287,14 +302,42 @@ window.addEventListener('load', function () {
 </script>
 "#;
 
+/// A minimal base64 encoder (standard alphabet, `=`-padded) -- just enough
+/// to turn the two embedded woff2 fonts into `data:` URIs below. No new
+/// dependency: this repo has no base64 crate, and pulling one in for a
+/// dozen lines of test-only encoding isn't worth it.
+fn base64_encode(data: &[u8]) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = chunk.get(1).copied().unwrap_or(0);
+        let b2 = chunk.get(2).copied().unwrap_or(0);
+        let n = ((b0 as u32) << 16) | ((b1 as u32) << 8) | (b2 as u32);
+        out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            ALPHABET[((n >> 6) & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[(n & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
 /// Renders the studio shell with a non-zero staged count -- the busiest the
 /// topbar ever gets, since that's what puts the "N staged" text plus the
 /// Review/Discard/Apply buttons in the right-hand group (the cluster that
 /// actually collided with the tabs; see R2 brief) -- inlines the real
-/// stylesheet, and checks at a spread of widths from 1400px down to 380px
-/// that no rendered piece of the brand, tabs, or top-right controls ever
-/// overlaps a piece from a different group, and that the page never scrolls
-/// horizontally.
+/// stylesheet (fonts included; see below), and checks at a spread of widths
+/// from 1400px down to 380px that no rendered piece of the brand, tabs, or
+/// top-right controls ever overlaps a piece from a different group, and
+/// that the page never scrolls horizontally.
 ///
 /// Each width gets its own `<iframe>` (a nested browsing context whose CSS
 /// viewport is exactly its own rendered box) rather than relaunching Chrome
@@ -303,7 +346,7 @@ window.addEventListener('load', function () {
 /// a real OS/window-manager minimum, not a bug in this test), which would
 /// have made the 480px and 380px cases secretly re-test 500px. The iframe
 /// approach sidesteps that floor entirely and needs only one Chrome launch
-/// for all eight widths.
+/// for all ten widths.
 #[test]
 #[ignore = "needs Chrome; CI runs it via `cargo test --test browser_smoke -- --ignored`"]
 fn topbar_never_overlaps_or_overflows_from_1400px_to_380px() {
@@ -318,7 +361,24 @@ fn topbar_never_overlaps_or_overflows_from_1400px_to_380px() {
     // so no server is needed to fetch it.
     let (css_bytes, _) =
         loadout::studio::assets::get("/assets/studio.css").expect("studio.css must be embedded");
-    let css = String::from_utf8(css_bytes).unwrap();
+    let mut css = String::from_utf8(css_bytes).unwrap();
+    // The two self-hosted fonts (`@font-face { src: url(/assets/fonts/…) }`)
+    // would 404 under `file://`/`srcdoc` same as the stylesheet link, and
+    // font-display: swap never recovers from a font that never loads -- the
+    // page would silently fall back to a system font for good. That matters
+    // here: the fallback for "Alfa Slab One" measured ~11px narrower than
+    // the real face for the "LOADOUT" wordmark, which is exactly the kind of
+    // slack that could hide a real near-miss at the 1300px breakpoint. Inline
+    // both as `data:` URIs so the test measures the font production ships.
+    for (path, mime) in [
+        ("/assets/fonts/inter.woff2", "font/woff2"),
+        ("/assets/fonts/alfa-slab-one.woff2", "font/woff2"),
+    ] {
+        let (bytes, _) =
+            loadout::studio::assets::get(path).unwrap_or_else(|| panic!("{path} must be embedded"));
+        let data_uri = format!("data:{mime};base64,{}", base64_encode(&bytes));
+        css = css.replacen(path, &data_uri, 1);
+    }
     let styled = shell.replacen("</head>", &format!("<style>{css}</style></head>"), 1);
     // Escaped for embedding in each iframe's `srcdoc` attribute (the same
     // technique `viewer_selftest_passes_under_opaque_origin_sandbox` uses
@@ -382,6 +442,21 @@ fn topbar_never_overlaps_or_overflows_from_1400px_to_380px() {
     for w in TOPBAR_TEST_WIDTHS {
         let r = &v[w.to_string()];
         assert!(!r.is_null(), "width {w}px: missing from results {v}");
+
+        // Guards against the overlap check below passing vacuously: an
+        // empty group (a renamed selector matching nothing) can never
+        // overlap anything. This also covers "no functionality may be
+        // hidden" -- every control's piece is still present at every width.
+        for (name, expected) in TOPBAR_EXPECTED_PIECE_COUNTS {
+            let got = r["counts"][name].as_u64().unwrap_or_else(|| {
+                panic!("width {w}px: no piece count reported for group {name:?}")
+            });
+            assert_eq!(
+                got, expected as u64,
+                "width {w}px: group {name:?} has {got} rendered pieces, expected {expected} \
+                 -- a selector likely stopped matching"
+            );
+        }
 
         let overlaps: Vec<&str> = r["overlaps"]
             .as_array()


### PR DESCRIPTION
Two studio bugs found while dogfooding the VS Code extension.

## Saving any config change could fail with a misleading error

Reported as `apply failed: backing up /Users/ellery/.config/loadout/config.toml`, with nothing saved.

`Session::apply` backed up **every** layer into `cache_dir(repo_base)/studio-backups`, where `repo_base` comes from studio's own cwd (`repo_base_for` → git root of cwd, else cwd). The VS Code extension spawns studio without setting a cwd, so it inherits the extension host's — `/` on macOS, confirmed on a live process. Backing up the **global** config therefore tried to create `/.loadout/cache/studio-backups`, which macOS does not permit, and apply aborts on a failed backup rather than writing a config it cannot roll back.

The underlying mistake: a global layer's backup location was decided by whichever repo happened to be open. Those are unrelated.

- Global and global-local backups now go to `state_dir()/studio-backups` (`~/.local/state/loadout`). Deliberately **not** the global config dir — `load sync` puts that under git, so `.bak` files there would be committed and synced between machines. Repo layers are unchanged.
- `backup_dir_for` is a pure function and `Session` takes an injected state dir via `open_with`, so the routing is testable without env mutation or touching the real `~/.local/state`. `Session::open`'s existing call sites are untouched.
- Regression test drives a real `apply()` with a `chmod 0o555` repo base and asserts the backup lands in the state dir with the exact pre-apply contents, plus that the repo cache is never created. Skipped when running as root, where the permission bits would not bite.

The error reporting was its own defect: `{e}` prints only the outermost anyhow context, so "Read-only file system" never reached the user. Fixed at the two `server.rs` sites, and at `settings.rs`, which additionally hardcoded "config changed on disk — review and apply from the top bar" for *every* apply failure. It now checks `external_edits()` and only says that when it is true.

## The top bar overlapped itself below ~1300px

The Library tab painted over the staged indicator. `.tabs` was `flex: 0 0 auto` while `.brand` and `.topbar-right` were `flex: 1 1 0; min-width: 0`, so the side groups shrank past their content and spilled into the centre. The stylesheet had no topbar media queries at all. This matters more than it used to: studio now opens inside the IDE's Simple Browser, often beside a chat panel.

Responsive from 1400px down to 380px. Each group sheds its **label** and keeps every control; icon-only controls keep an accessible name.

Three things surfaced during review, each worth noting because the obvious version of this fix hides them:

1. **The first test passed against visibly broken CSS.** Comparing the three wrapper boxes cannot fail — leftward overflow neither enlarges the parent's rect nor extends `scrollWidth`. The test now measures rendered content per element, and asserts it found all 12 pieces so a renamed selector cannot make it pass vacuously.
2. **The test measured without the real fonts**, giving it ~11px of slack production does not have (the wordmark is 111.0px with fallbacks, 121.8px with Alfa Slab One). Both woff2 files are now inlined as data URIs.
3. With those two fixed, the original 1300px breakpoint **genuinely overlapped** at 1305–1310px once the staged count reaches two digits — and it does: a single starter-pack apply stages 14–15 ops, and `ops` is uncapped and never deduplicated. The test now renders the widest plausible count, and the breakpoint is 1360px with ~23px of measured margin.

## Verification

`cargo test` 668 passing, `cargo clippy --all-targets` clean, `cargo fmt --check` clean, all 3 headless-Chrome tests passing.

The companion extension fix (spawning studio in the workspace folder) is a separate PR in `loadout-tools/vscode`. Either fix alone resolves the reported failure; both are correct independently.
