### PR TITLE
release: v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ All notable changes to loadout are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
+## 0.26.0 — 2026-08-11
+
+### Added
+
+- **Config sync, set up and run from studio Settings.** Sharing one config
+  across machines no longer means a terminal. Settings grows a sync card that
+  shows where your config lives and whether it's in step with its remote, plus
+  three actions: **Sync now** (pull, resolving divergence in place, then push),
+  **Set up sync** (create the config repo — `gh` does the creating when it's
+  installed and authenticated), and **Clone an existing config** (point a new
+  machine at a repo you already have). Studio already pushed after every apply;
+  what was missing was setup, pull, and being able to see the state at all.
+  Authentication stays where it belongs: if the remote refuses, the error names
+  `gh auth login` rather than asking you for credentials.
+
+### Fixed
+
+- **Saving a config change could fail with a misleading error and save
+  nothing.** Reported as `apply failed: backing up ~/.config/loadout/config.toml`.
+  Before writing, studio snapshots a `.bak` of every file it's about to change —
+  but it put *every* layer's backup under a directory derived from studio's own
+  working directory. Your **global** config's backup location therefore depended
+  on whichever repo happened to be open, which are unrelated things. Opened from
+  the VS Code extension, studio's working directory is `/`, so the backup tried
+  to land in `/.loadout/cache/` — which macOS does not permit — and apply stops
+  on a failed backup rather than writing a config it cannot roll back. Global
+  backups now go to `~/.local/state/loadout/studio-backups`, independent of where
+  studio was launched. Not the config directory itself: `load sync` puts that
+  under git, and the `.bak` files would sync between your machines.
+- **Studio's error messages hid the actual cause.** They printed only the
+  outermost layer of an error, so the reason above surfaced as "backing up
+  <file>" instead of "Read-only file system". Settings was worse still — it
+  labelled *every* apply failure "config changed on disk", a cause it had not
+  checked. It now checks, and says so only when it's true.
+- **Studio's top bar overlapped itself in a narrow window.** Below roughly
+  1360px the tab labels and the staged-changes indicator were drawn on top of
+  each other. The bar is now responsive from 1400px down to 380px: each group
+  drops its *label* and keeps every control, so nothing is hidden behind a menu
+  and icon-only buttons keep their names for screen readers. This shows up most
+  in an IDE, where studio opens in a side pane beside a chat panel.
+- **Studio kept serving a config that a sync had replaced.** After a pull or
+  clone rewrote `config.toml`, the running studio still held the version it read
+  at startup: it rendered stale content, every later Apply failed telling you to
+  reload, and the advice to reopen studio didn't help because `load studio`
+  re-attaches to the running instance. It now reloads the session as part of the
+  sync.
+- **`load sync init` could leave a repo `gh` had already created without the
+  right author email.** The noreply address is now stamped first.
+
 ## 0.25.0 — 2026-08-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "loadout"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loadout"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Equip the right context for the job — detect the project, select the loadout that fits, and render your global context as an agent-specific instruction overlay."


### PR DESCRIPTION
Cuts v0.26.0. Everything since v0.25.0 was unreleased, including the whole studio config-sync workstream, so this is a minor bump rather than a patch.

**Added:** config sync set up and run from studio Settings — status card, Sync now, Set up sync, Clone an existing config.

**Fixed:** the apply failure that saved nothing (global-config backups no longer depend on where studio was launched), studio errors that hid their real cause, the top bar overlapping itself in a narrow window, studio serving a config a sync had replaced, and `sync init` leaving a gh-created repo without the noreply author email.

The changelog had no Unreleased section, so the sync entries are written here for the first time. `dist plan` previews cleanly for all four targets plus the installer. `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all --locked` (668 tests) are green locally.

Tag `v0.26.0` goes on main once this merges, which is what triggers the release build.