### PR TITLE
feat(studio): pick a workflow when creating a loadout, and stop edits deleting one

### DIFF
--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -4041,6 +4041,67 @@ mod tests {
     }
 
     #[test]
+    fn editing_a_loadout_preserves_its_bound_workflow() {
+        // Regression (problem 2, found while scoping the picker — not the
+        // reported bug): `profile_from_form` used to hardcode `workflow:
+        // None`, so saving the editor form for a loadout that already had a
+        // workflow bound (e.g. via the Board's "Equip a workflow" tile)
+        // silently wiped it out on any edit — no warning, no diff signal. An
+        // edit that changes something unrelated (equipping a second fragment)
+        // must not touch the workflow.
+        let cfg = "[[fragments]]\nid = \"rc\"\nguidance = \"x\"\n\
+             \n[[fragments]]\nid = \"tc\"\nguidance = \"y\"\n\
+             \n[[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\nworkflow = \"superpowers\"\n";
+        let d = rust_repo();
+        let st = state_for(d.path(), Some(cfg));
+
+        // The edit form pre-selects the loadout's current workflow.
+        let edit = body_of(route(
+            &st,
+            &req("GET", "/profiles/rust/edit", "", &[HOST, COOKIE], ""),
+        ));
+        assert!(
+            edit.contains(r#"value="superpowers" checked"#),
+            "workflow pre-selected in the edit form: {edit}"
+        );
+
+        // Save exactly as the editor would submit it: the pre-selected
+        // `workflow` field carried forward, plus one unrelated change.
+        let saved = body_of(route(
+            &st,
+            &req(
+                "POST",
+                "/profiles",
+                "",
+                &[HOST, COOKIE, ORIGIN],
+                "original_name=rust&name=rust&targets=rust&fragments=rc&fragments=tc&workflow=superpowers",
+            ),
+        ));
+        assert!(saved.contains("staged loadout"), "save succeeded: {saved}");
+
+        // The workflow survived the edit, in the staged config…
+        let board = body_of(route(
+            &st,
+            &req("GET", "/profiles/rust/select", "", &[HOST, COOKIE], ""),
+        ));
+        assert!(
+            board.contains("superpowers"),
+            "workflow still bound after edit: {board}"
+        );
+
+        // …and on disk after apply.
+        body_of(route(
+            &st,
+            &req("POST", "/apply", "", &[HOST, COOKIE, ORIGIN], ""),
+        ));
+        let on_disk = std::fs::read_to_string(global_config_path(d.path())).unwrap();
+        assert!(
+            on_disk.contains("workflow = \"superpowers\""),
+            "workflow persisted on disk: {on_disk}"
+        );
+    }
+
+    #[test]
     fn profile_rename_onto_existing_name_is_rejected() {
         // Renaming `a` onto the existing `b` would clobber it — refused inline.
         let cfg = "[[fragments]]\nid = \"rc\"\nguidance = \"x\"\n\n\

--- a/src/studio/server.rs
+++ b/src/studio/server.rs
@@ -4102,6 +4102,59 @@ mod tests {
     }
 
     #[test]
+    fn editing_a_loadout_preserves_its_template_override() {
+        // Sibling to the workflow regression above, same failure mode: the
+        // editor form never grew a `template` control (nobody asked for one —
+        // this is a rare, hand-authored override), so nothing ever posted a
+        // `template` field back. `profile_from_form` reads `template` from the
+        // form correctly, but an absent field reads as `None` regardless of
+        // what the loadout had before — so any edit through the studio form
+        // silently dropped a `template = "…"` override, with no warning.
+        let cfg = "[[fragments]]\nid = \"rc\"\nguidance = \"x\"\n\
+             \n[[fragments]]\nid = \"tc\"\nguidance = \"y\"\n\
+             \n[[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\ntemplate = \"custom\"\n";
+        let d = rust_repo();
+        let st = state_for(d.path(), Some(cfg));
+
+        // The edit form carries the current template forward — no visible
+        // control is required, just a hidden field so a save round-trips it.
+        let edit = body_of(route(
+            &st,
+            &req("GET", "/profiles/rust/edit", "", &[HOST, COOKIE], ""),
+        ));
+        assert!(
+            edit.contains(r#"name="template" value="custom""#),
+            "template carried in the edit form: {edit}"
+        );
+
+        // Save exactly as the editor would submit it: the carried `template`
+        // field forward, plus one unrelated change.
+        let saved = body_of(route(
+            &st,
+            &req(
+                "POST",
+                "/profiles",
+                "",
+                &[HOST, COOKIE, ORIGIN],
+                "original_name=rust&name=rust&targets=rust&fragments=rc&fragments=tc&template=custom",
+            ),
+        ));
+        assert!(saved.contains("staged loadout"), "save succeeded: {saved}");
+
+        // …and on disk after apply — the assertion that matters: the data,
+        // not just the form markup.
+        body_of(route(
+            &st,
+            &req("POST", "/apply", "", &[HOST, COOKIE, ORIGIN], ""),
+        ));
+        let on_disk = std::fs::read_to_string(global_config_path(d.path())).unwrap();
+        assert!(
+            on_disk.contains("template = \"custom\""),
+            "template persisted on disk: {on_disk}"
+        );
+    }
+
+    #[test]
     fn profile_rename_onto_existing_name_is_rejected() {
         // Renaming `a` onto the existing `b` would clobber it — refused inline.
         let cfg = "[[fragments]]\nid = \"rc\"\nguidance = \"x\"\n\n\

--- a/src/studio/state.rs
+++ b/src/studio/state.rs
@@ -1771,7 +1771,7 @@ pub fn draft_profile_from_form(pairs: &[(String, String)]) -> LoadoutConfig {
             .map(FragmentRef::Id)
             .collect(),
         workflow: opt(value_of(pairs, "workflow")),
-        template: None,
+        template: opt(value_of(pairs, "template")),
         disabled: value_of(pairs, "disabled").is_some(),
     }
 }
@@ -2060,6 +2060,20 @@ mod tests {
         assert_eq!(none.workflow, None);
         let some = draft_profile_from_form(&parse_pairs("name=rust&workflow=lean"));
         assert_eq!(some.workflow.as_deref(), Some("lean"));
+    }
+
+    #[test]
+    fn draft_profile_from_form_carries_template() {
+        // Same care as the workflow field: `template` has no visible editor
+        // control, but the editor carries it forward as a hidden field, and
+        // this draft path — the one that feeds the re-render after a
+        // validation error or an inline fragment add — must not drop it, or
+        // the hidden field vanishes from the next render and the value is
+        // lost for good.
+        let none = draft_profile_from_form(&parse_pairs("name=rust"));
+        assert_eq!(none.template, None);
+        let some = draft_profile_from_form(&parse_pairs("name=rust&template=custom"));
+        assert_eq!(some.template.as_deref(), Some("custom"));
     }
 
     #[test]

--- a/src/studio/state.rs
+++ b/src/studio/state.rs
@@ -167,6 +167,11 @@ pub struct LibraryView {
     /// Selectable target options for the profile editor (built-ins + custom
     /// targets + the `machine` scope), in catalog order, each with its icon.
     pub targets: Vec<TargetChip>,
+    /// Selectable workflow options for the profile editor's workflow picker —
+    /// the same `(id, title, spine)` rows and the same source
+    /// ([`board_workflow_options`]) as the Board view's "Equip a workflow"
+    /// modal, so both surfaces always agree.
+    pub workflows: Vec<(String, String, String)>,
 }
 
 /// One target row for the Targets tab.
@@ -791,6 +796,7 @@ pub fn library_view(snap: &Snapshot) -> crate::Result<LibraryView> {
         palette,
         profiles,
         targets: target_options,
+        workflows: board_workflow_options(snap),
     })
 }
 
@@ -1706,7 +1712,7 @@ pub fn profile_from_form(pairs: &[(String, String)]) -> crate::Result<LoadoutCon
         name,
         targets: values_for(pairs, "targets"),
         fragments,
-        workflow: None,
+        workflow: opt(value_of(pairs, "workflow")),
         template: opt(value_of(pairs, "template")),
         disabled: value_of(pairs, "disabled").is_some(),
     })
@@ -1764,7 +1770,7 @@ pub fn draft_profile_from_form(pairs: &[(String, String)]) -> LoadoutConfig {
             .into_iter()
             .map(FragmentRef::Id)
             .collect(),
-        workflow: None,
+        workflow: opt(value_of(pairs, "workflow")),
         template: None,
         disabled: value_of(pairs, "disabled").is_some(),
     }
@@ -2011,6 +2017,49 @@ mod tests {
         assert_eq!(p.fragments.len(), 2);
         // Zero fragments is rejected (§3).
         assert!(profile_from_form(&parse_pairs("name=rust&targets=rust")).is_err());
+    }
+
+    #[test]
+    fn profile_from_form_workflow_selection() {
+        // Table: (form body, expected workflow) — a selected workflow lands on
+        // the profile; no `workflow` field at all, and an explicit empty
+        // selection (the "None" radio), both yield `None`.
+        let base = "name=rust&targets=rust&fragments=rc";
+        let cases: &[(&str, Option<&str>)] = &[
+            (base, None),
+            (&format!("{base}&workflow="), None),
+            (&format!("{base}&workflow=lean"), Some("lean")),
+        ];
+        for (body, want) in cases {
+            let p = profile_from_form(&parse_pairs(body)).unwrap();
+            assert_eq!(p.workflow.as_deref(), *want, "body: {body}");
+        }
+    }
+
+    #[test]
+    fn profile_from_form_edit_path_preserves_existing_workflow() {
+        // Regression (problem 2): `profile_from_form` used to hardcode
+        // `workflow: None`, so `handle_profile_save` — which calls this
+        // function directly on the posted form — silently dropped a workflow
+        // that was bound before the edit, with no warning. Simulating the
+        // editor's edit-mode submission (an `original_name` present) with the
+        // pre-selected workflow field carried along must round-trip it.
+        let p = profile_from_form(&parse_pairs(
+            "name=rust&original_name=rust&targets=rust&fragments=rc&workflow=lean",
+        ))
+        .unwrap();
+        assert_eq!(p.workflow.as_deref(), Some("lean"));
+    }
+
+    #[test]
+    fn draft_profile_from_form_carries_workflow() {
+        // The lenient live-preview draft must round-trip the selection too, so
+        // the preview and the re-render after a validation error don't drop it
+        // mid-edit.
+        let none = draft_profile_from_form(&parse_pairs("name=rust"));
+        assert_eq!(none.workflow, None);
+        let some = draft_profile_from_form(&parse_pairs("name=rust&workflow=lean"));
+        assert_eq!(some.workflow.as_deref(), Some("lean"));
     }
 
     #[test]

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -2587,6 +2587,16 @@ pub fn profile_editor(
         .map(String::as_str)
         .filter(|t| !known.contains(t))
         .collect();
+    // The bound workflow may be a dangling id (the workflow that defined it
+    // was deleted, or it was hand-edited into the TOML) — the model tolerates
+    // this (doctor warns, run notes it), so the picker must too: still offer
+    // it as a genuinely-selected option instead of silently dropping it.
+    let known_workflows: std::collections::HashSet<&str> =
+        lib.workflows.iter().map(|(id, _, _)| id.as_str()).collect();
+    let extra_workflow = draft
+        .workflow
+        .as_deref()
+        .filter(|w| !known_workflows.contains(w));
     html! {
         div class="profile-editor" {
             form class="editor-form" hx-post="/profiles/preview" hx-trigger="change delay:200ms" hx-target="#editor-preview" {
@@ -2635,6 +2645,36 @@ pub fn profile_editor(
                         }
                     }
                     (inline_new_cap())
+                }
+                fieldset class="workflow-picker" {
+                    legend { "Workflow" span class="field-hint" { "the process it works by — optional, at most one" } }
+                    div class="pick-list" {
+                        label class="pick" {
+                            input type="radio" name="workflow" value="" checked[draft.workflow.is_none()];
+                            span class="pick-glyph" { (icon("power")) }
+                            span class="pick-main" { span class="pick-title" { "None" } }
+                        }
+                        @for (id, title, spine) in &lib.workflows {
+                            label class="pick" {
+                                input type="radio" name="workflow" value=(id) checked[draft.workflow.as_deref() == Some(id.as_str())];
+                                span class="pick-glyph" { (icon("git-branch")) }
+                                span class="pick-main" {
+                                    span class="pick-title" { (title) }
+                                    @if !spine.is_empty() { span class="pick-id" { (spine) } }
+                                }
+                            }
+                        }
+                        @if let Some(w) = extra_workflow {
+                            label class="pick" {
+                                input type="radio" name="workflow" value=(w) checked;
+                                span class="pick-glyph" { (icon("alert")) }
+                                span class="pick-main" {
+                                    span class="pick-title" { (w) }
+                                    span class="pick-id" { "not in your workflow catalog" }
+                                }
+                            }
+                        }
+                    }
                 }
                 fieldset class="lives-in" {
                     legend { "Where it lives" }
@@ -2963,6 +3003,76 @@ mod tests {
         let html = skill_card(&["loadout-migrate"], &[], &SkillCardState::HandsOff);
         assert!(html.contains("loadout-migrate"));
         assert!(!html.contains("hx-post=\"/skills/"));
+    }
+
+    fn empty_library() -> LibraryView {
+        LibraryView {
+            yours: vec![],
+            palette: vec![],
+            profiles: vec![],
+            targets: vec![],
+            workflows: vec![],
+        }
+    }
+
+    fn empty_preview() -> PreviewOutcome {
+        PreviewOutcome {
+            agent: String::new(),
+            context_summary: String::new(),
+            fragment_count: 0,
+            overlay: String::new(),
+            caps: vec![],
+            note: None,
+        }
+    }
+
+    #[test]
+    fn profile_editor_renders_with_no_fragments_targets_or_workflows() {
+        // An empty catalog (a fresh global config with no `[[workflows]]`, no
+        // custom targets, and no fragments yet) must not panic or render a
+        // broken workflow control — it should degrade to just the "None"
+        // option, same as the Targets/Fragments fieldsets degrade to empty
+        // lists.
+        let draft = LoadoutConfig {
+            name: "new".into(),
+            targets: vec![],
+            fragments: vec![],
+            workflow: None,
+            template: None,
+            disabled: false,
+        };
+        let html = profile_editor(&draft, true, None, &empty_library(), &empty_preview(), None);
+        assert!(html.contains("workflow-picker"));
+        assert!(html.contains(r#"input type="radio" name="workflow" value="" checked"#));
+        // No known workflows and no dangling selection → exactly the "None" row.
+        assert_eq!(html.matches(r#"name="workflow""#).count(), 1);
+    }
+
+    #[test]
+    fn profile_editor_workflow_picker_preselects_the_draft_and_keeps_a_dangling_id() {
+        let mut lib = empty_library();
+        lib.workflows = vec![
+            ("lean".into(), "Lean".into(), "plan → implement".into()),
+            ("compound".into(), "Compound".into(), "".into()),
+        ];
+        // A dangling id — no longer in the catalog — must still round-trip
+        // instead of silently vanishing from the form.
+        let draft = LoadoutConfig {
+            name: "rust".into(),
+            targets: vec![],
+            fragments: vec![],
+            workflow: Some("deleted-workflow".into()),
+            template: None,
+            disabled: false,
+        };
+        let html = profile_editor(&draft, false, Some("rust"), &lib, &empty_preview(), None);
+        assert!(html.contains(r#"value="lean""#));
+        assert!(html.contains(r#"value="compound""#));
+        assert!(html.contains(r#"value="deleted-workflow" checked"#));
+        assert!(html.contains("not in your workflow catalog"));
+        // The known options are present but not checked (the dangling id is).
+        assert!(!html.contains(r#"value="lean" checked"#));
+        assert!(!html.contains(r#"value="compound" checked"#));
     }
 
     #[test]

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -2613,6 +2613,12 @@ pub fn profile_editor(
                     // When editing, carry the original name as the rename key so
                     // the save can find-and-replace the right profile.
                     @if let Some(orig) = original_name { input type="hidden" name="original_name" value=(orig); }
+                    // `template` has no editor control (a rare, hand-authored
+                    // override — nobody asked to edit it here), but it must
+                    // still round-trip: carry it forward as a hidden field so
+                    // a save doesn't silently drop it, the same failure mode
+                    // `workflow` had before its picker.
+                    @if let Some(t) = &draft.template { input type="hidden" name="template" value=(t); }
                 }
                 fieldset class="targets-picker" {
                     legend { "Targets" span class="field-hint" { "applies when the repo looks like one of these" } }


### PR DESCRIPTION
You could not choose a workflow when creating a loadout — the only picker was the Board view's "Equip a workflow" tile, so a workflow was invisible unless you created the loadout, opened it, and switched views. The New/Edit form now has one: optional, defaults to none, at most one, pre-selected when editing, reading the same catalog the Board slot uses.

## Two silent data-loss bugs found while scoping it

Neither was reported. Both destroy a setting you deliberately made, with no warning and nothing obvious in the diff.

**Editing a loadout deleted its workflow.** `profile_from_form` hardcoded `workflow: None`, and saving stages a full profile replace. So: equip a workflow from the Board view, later rename the loadout or tick one more fragment, hit Stage loadout — the workflow is gone. Reproduced with a failing test before fixing.

**Editing a loadout deleted its `template` override.** The identical bug on a sibling field: `profile_from_form` reads `template` from the form, but the editor rendered no `template` control, so a hand-authored `template = "…"` vanished on the first studio edit. Fixed by carrying the value through the form — no visible control, since editing templates in studio is not something anyone asked for.

The picker fixes the first as a side effect, because the value then round-trips instead of being dropped. Both have regression tests aimed squarely at the data loss.

## Verification

519 lib tests, clippy clean with `-D warnings`, `cargo fmt --check` clean.

Both reviewers verified the regression tests by reverting the fixes and confirming the tests fail — the workflow one fails at the *data* assertion (the board re-read after save), not merely a cosmetic form-field check. The two entry points were tested in both directions: equipping from the Board then opening the form, and from the form then reading the board. A dangling workflow id round-trips rather than being eaten, matching what `src/profile.rs` documents.
