### PR TITLE
release: v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to loadout are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
+## 0.27.0 — 2026-08-12
+
+### Added
+
+- **Pick a workflow when you create a loadout.** The New/Edit loadout form now
+  has a workflow field — optional, one at a time, and pre-selected with whatever
+  the loadout already binds. Until now the only place to equip one was the Board
+  view's "Equip a workflow" tile, so unless you created the loadout, opened it,
+  and switched views, workflows were effectively invisible.
+
+### Fixed
+
+- **Editing a loadout no longer deletes its workflow.** Saving from the editor
+  replaced the whole loadout while the form carried no workflow field, so a
+  workflow you had equipped from the Board view vanished the next time you
+  renamed the loadout or ticked one more fragment — silently, with nothing in the
+  diff to catch your eye. The form now carries the value through.
+- **Editing a loadout no longer deletes a `template` override.** The same bug on
+  a sibling field: a hand-authored `template = "…"` was dropped on the first
+  studio edit. It now survives, carried through the form. There is still no
+  visible control for it — editing templates in studio is not a thing you asked
+  for, and this is about not destroying what you wrote by hand.
+
 ## 0.26.0 — 2026-08-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "loadout"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loadout"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Equip the right context for the job — detect the project, select the loadout that fits, and render your global context as an agent-specific instruction overlay."


### PR DESCRIPTION
Cuts v0.27.0.

**Added:** a workflow picker in the New/Edit loadout form — until now the only place to equip one was the Board view's tile, so workflows were effectively invisible unless you went looking.

**Fixed:** two silent data-loss bugs found while building that picker. Editing a loadout deleted its bound workflow, and deleted a hand-authored `template` override, because saving replaced the whole loadout while the form carried neither field. Both now round-trip, both have regression tests that were verified to fail without the fix.

There is a second reason to cut this now: the extension's next release pins its bundled CLI to this version, and that pin is what its new update prompt compares against. Without a v0.27.0 release the extension cannot even package — `fetch-cli.mjs` downloads the pinned tag and fails on a 404.

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all --locked` (519 lib tests) are green locally, and `dist plan` previews cleanly for all four targets plus the installer.