### PR TITLE
feat: give Codex and the Copilot CLI workflow stage commands

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -84,12 +84,29 @@ every agent the same way a loadout carries your context. Where a loadout answers
 *"what context applies here?"*, a workflow answers *"what's the process for doing
 the work?"*
 
-**One fixed command spine.** loadout always exposes the same six slash commands
-to your agent — `/loadout:explore`, `/loadout:brainstorm`, `/loadout:plan`,
-`/loadout:implement`, `/loadout:verify`, `/loadout:ship`. Picking a workflow does
-**not** add or rename commands; it changes what each step *means*. "Plan
-spec-first" and "plan compound-style" are the same `/loadout:plan` command
-carrying different instructions.
+**One fixed command spine.** loadout always exposes the same six steps to your
+agent — explore, brainstorm, plan, implement, verify, ship. Picking a workflow
+does **not** add or rename them; it changes what each step *means*. "Plan
+spec-first" and "plan compound-style" are the same plan step carrying different
+instructions.
+
+How you reach a step depends on the agent, because each one discovers commands
+its own way. `load run` prints the right form for the agent it launches:
+
+| Agent | Written as | Reached by |
+| --- | --- | --- |
+| Claude Code | `.claude/commands/loadout/plan.md` | `/loadout:plan` |
+| Cursor | `.cursor/skills/loadout/loadout-plan/SKILL.md` | `/loadout-plan` |
+| Copilot (VS Code) | `.github/prompts/loadout-plan.prompt.md` | `/loadout-plan` |
+| Copilot (CLI) | `.github/skills/loadout/loadout-plan/SKILL.md` | the `loadout-plan` skill, by name |
+| Codex | `.codex/skills/loadout/loadout-plan/SKILL.md` | the `loadout-plan` skill, by name |
+| opencode, generic | — | context section only |
+
+Codex and the Copilot CLI load a skill from its description rather than from a
+slash menu, so you ask for it by name ("use the loadout-plan skill") or let the
+agent pick it up. Every one of these directories is loadout-owned and
+gitignored; neither CLI filters its skill discovery by gitignore (verified
+against codex-cli 0.146.0 and the Copilot CLI).
 
 - A workflow is an ordered list of **stages**, each a free-form `name` plus a
   short `purpose`. Each stage maps onto one of the six canonical slots by its
@@ -252,7 +269,8 @@ a committed, shared instruction file** (`AGENTS.md`,
 content in a shared file.
 
 Built-ins: `claude` (import), `codex` (auto `AGENTS.override.md` merge,
-`--no-override` to skip), `copilot` (owned, gitignored
+`--no-override` to skip; workflow stages land as project skills in
+`.codex/skills/loadout/`), `copilot` (owned, gitignored
 `.github/instructions/loadout.instructions.md` wires VS Code's Copilot Chat;
 `load run` also sets `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` → the gitignored
 overlay for the CLI, which can't see that owned file), `cursor` (owned
@@ -260,12 +278,15 @@ overlay for the CLI, which can't see that owned file), `cursor` (owned
 `cursor-agent` CLI — plus a user-level `sessionStart` hook in `~/.cursor/hooks.json`
 that keeps repos fresh — and auto-adopts a git repo some loadout applies to on
 first open, no prior `load refresh` needed — since IDE sessions never pass
-through `load run`; workflow commands land as Cursor Skills,
-`.cursor/skills/loadout/loadout-<slot>/SKILL.md`, invoked `/loadout-<slot>`
-rather than `/loadout:<slot>`),
-`opencode` (registers
+through `load run`), `opencode` (registers
 the overlay path in `~/.config/opencode/opencode.json` `instructions`), `generic`
 (emit-only). All overridable / extendable via `[[agents]]`.
+
+An agent can have more than one **command channel** when its surfaces read
+different directories. Copilot is the case: the CLI reads `.github/skills/` and
+has no notion of prompt files at all, while VS Code reads `.github/prompts/`, so
+loadout writes both. Channels are built-in descriptor data; an `[[agents]]`
+override declares a single channel with `commands_dir` / `command_format`.
 
 ## Freshness **(implemented)**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -254,14 +254,18 @@ wire_hint = "include .loadout/generated/opencode.md from your agent config"
 
 Built-in defaults:
 
-| id | generated file | wiring | launch |
-| --- | --- | --- | --- |
-| `claude` | `claude.md` | import → `CLAUDE.local.md` | `claude` |
-| `codex` | `agents.md` | auto → gitignored `AGENTS.override.md` (Codex prefers it); `--no-override` = emit-only | `codex` |
-| `opencode` | `opencode.md` | registers overlay path in `~/.config/opencode/opencode.json` `instructions` | `opencode` |
-| `copilot` | `copilot/.github/instructions/loadout.instructions.md` | owned file → gitignored `.github/instructions/loadout.instructions.md` (`applyTo: '**'`, wires VS Code's Copilot Chat) + `load run` sets `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` → `.loadout/generated/copilot` for the CLI | `copilot` |
-| `cursor` | `cursor.md` | owned file → gitignored `.cursor/rules/loadout.mdc` (`alwaysApply` rule, IDE + CLI) + `sessionStart` hook in `~/.cursor/hooks.json` for IDE freshness | `cursor-agent` |
-| `generic` | `generic.md` | emit-only | — |
+| id | generated file | wiring | workflow stages | launch |
+| --- | --- | --- | --- | --- |
+| `claude` | `claude.md` | import → `CLAUDE.local.md` | `.claude/commands/loadout/` → `/loadout:<slot>` | `claude` |
+| `codex` | `agents.md` | auto → gitignored `AGENTS.override.md` (Codex prefers it); `--no-override` = emit-only | `.codex/skills/loadout/` → `loadout-<slot>` skill | `codex` |
+| `opencode` | `opencode.md` | registers overlay path in `~/.config/opencode/opencode.json` `instructions` | — (context section only) | `opencode` |
+| `copilot` | `copilot/.github/instructions/loadout.instructions.md` | owned file → gitignored `.github/instructions/loadout.instructions.md` (`applyTo: '**'`, wires VS Code's Copilot Chat) + `load run` sets `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` → `.loadout/generated/copilot` for the CLI | `.github/skills/loadout/` → `loadout-<slot>` skill (CLI); `.github/prompts/loadout-<slot>.prompt.md` → `/loadout-<slot>` (VS Code) | `copilot` |
+| `cursor` | `cursor.md` | owned file → gitignored `.cursor/rules/loadout.mdc` (`alwaysApply` rule, IDE + CLI) + `sessionStart` hook in `~/.cursor/hooks.json` for IDE freshness | `.cursor/skills/loadout/` → `/loadout-<slot>` | `cursor-agent` |
+| `generic` | `generic.md` | emit-only | — (context section only) | — |
+
+Every stage directory above is loadout-owned and gitignored. Codex and the
+Copilot CLI surface a stage as a named skill rather than a slash command, so you
+ask for it by name; the others are real slash commands.
 
 ## `[host_classes]` (implemented; keep mappings private)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,6 +267,18 @@ Every stage directory above is loadout-owned and gitignored. Codex and the
 Copilot CLI surface a stage as a named skill rather than a slash command, so you
 ask for it by name; the others are real slash commands.
 
+**An `[[agents]]` override replaces a built-in descriptor whole.** It does not
+merge field by field. Two consequences worth knowing before you write one:
+
+- The built-in command channels are dropped. If you override `copilot` just to
+  change `launch`, it stops writing both its CLI skills and its VS Code prompts
+  until you add a `commands_dir` back. `commands_dir` declares one channel, so
+  an override cannot reproduce Copilot's two.
+- Stage files written before the override took effect are no longer in any
+  channel loadout knows about, so `clean` won't find them. Remove the override,
+  run `load clean --agent <id>`, then put it back — or delete the directory by
+  hand.
+
 ## `[host_classes]` (implemented; keep mappings private)
 
 Maps hostname globs (`*`/`?`) to a class you reference in rules

--- a/src/adapters/commands.rs
+++ b/src/adapters/commands.rs
@@ -103,6 +103,18 @@ impl CommandFormat {
         format!("{COMMAND_NAMESPACE}-")
     }
 
+    /// How a generated stage actually invokes in this agent, as a display
+    /// pattern (`<stage>` stands in for the stage name). Claude namespaces by
+    /// subdirectory, so its commands carry a colon; every other format encodes
+    /// the namespace in the name itself and carries a hyphen. Shown in the
+    /// `load run` summary, so it must match what the user can really type.
+    pub fn invocation(self) -> &'static str {
+        match self {
+            CommandFormat::Markdown => "/loadout:<stage>",
+            CommandFormat::Skill | CommandFormat::Prompt => "/loadout-<stage>",
+        }
+    }
+
     /// The placeholder this agent substitutes the user's command text into.
     /// Cursor skills have no substitution syntax — the invoking message rides
     /// along as-is, so the body just points the agent at it. VS Code prompt

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -977,6 +977,18 @@ fn command_format(d: &AgentDescriptor) -> commands::CommandFormat {
         .unwrap_or(commands::CommandFormat::Markdown)
 }
 
+/// How this agent invokes a generated workflow stage (`/loadout:<stage>`,
+/// `/loadout-<stage>`, …), or `None` when it has no command channel at all and
+/// only ever sees the always-on `## Workflow` context section.
+///
+/// The invocation differs per agent and is easy to state wrongly, so every
+/// user-facing mention of it should come from here rather than hardcode
+/// Claude's shape.
+pub fn stage_invocation(d: &AgentDescriptor) -> Option<&'static str> {
+    d.commands_dir.as_ref()?;
+    Some(command_format(d).invocation())
+}
+
 /// Whether `name` is a generated command file in a *shared* command dir — the
 /// only entries loadout may prune or remove there.
 fn is_generated_shared_command(name: &str, format: commands::CommandFormat) -> bool {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -783,17 +783,15 @@ pub fn apply(
     // importer. One file per stage, in the owned `<commands_dir>/loadout/` dir
     // or flat with a `loadout-` prefix when the dir is shared with the user.
     if let Some(wf) = workflow.as_ref() {
-        for channel in command_channels(d) {
-            if app.in_repo() && !bleeds && is_repo_relative(&channel.dir) {
-                write_stage_commands(app, d, &channel, wf, &mut files)?;
-                let (dir, fmt) = (&channel.dir, channel.format);
-                gitignore_extra.push(if fmt.owns_namespace_dir() {
-                    format!("{dir}/{}/", commands::COMMAND_NAMESPACE)
-                } else {
-                    // Shared dir: ignore only our own files, by prefix.
-                    format!("{dir}/{}*.{}", fmt.shared_dir_prefix(), fmt.ext())
-                });
-            }
+        for channel in emitted_channels(d, app.context) {
+            write_stage_commands(app, d, &channel, wf, &mut files)?;
+            let (dir, fmt) = (&channel.dir, channel.format);
+            gitignore_extra.push(if fmt.owns_namespace_dir() {
+                format!("{dir}/{}/", commands::COMMAND_NAMESPACE)
+            } else {
+                // Shared dir: ignore only our own files, by prefix.
+                format!("{dir}/{}*.{}", fmt.shared_dir_prefix(), fmt.ext())
+            });
         }
     }
 
@@ -877,7 +875,7 @@ pub fn artifacts(d: &AgentDescriptor, repo_base: &Path) -> Vec<PathBuf> {
     }
     // Generated slash commands: the owned dir, or — in a shared dir — each of
     // our own prefixed files.
-    for channel in command_channels(d) {
+    for channel in managed_channels(d, repo_base) {
         let fmt = channel.format;
         let ns = command_namespace_dir(repo_base, &channel.dir, fmt);
         if fmt.owns_namespace_dir() {
@@ -953,7 +951,7 @@ pub fn clean(d: &AgentDescriptor, app: &AppContext) -> crate::Result<CleanResult
     // dir (VS Code's `.github/prompts/`) gives up only our prefixed files —
     // the dir itself and the user's own prompts stay. The agent's own
     // `<commands_dir>` (e.g. `.claude/commands/`) is left alone either way.
-    for channel in command_channels(d) {
+    for channel in managed_channels(d, app.repo_base()) {
         let fmt = channel.format;
         let ns = command_namespace_dir(app.repo_base(), &channel.dir, fmt);
         if fmt.owns_namespace_dir() {
@@ -1105,16 +1103,47 @@ fn command_channels(d: &AgentDescriptor) -> Vec<CommandChannel> {
         .collect()
 }
 
-/// How this agent invokes a generated workflow stage (`/loadout:<stage>`,
-/// `/loadout-<stage>`, `loadout-<stage> skill`), or `None` when it has no
-/// command channel at all and only ever sees the always-on `## Workflow`
-/// context section.
+/// The channels loadout may touch under `repo_base` — the destructive-safety
+/// gate, shared by writing, discovery (`artifacts`) and removal (`clean`) so
+/// those three can never disagree about which directories are loadout's to
+/// manage.
 ///
-/// Reports the first channel — the surface `load run` launches. The invocation
-/// differs per agent and is easy to state wrongly, so every user-facing mention
-/// of it should come from here rather than hardcode Claude's shape.
-pub fn stage_invocation(d: &AgentDescriptor) -> Option<&'static str> {
-    command_channels(d).first().map(|c| c.invocation)
+/// Two exclusions, both of which apply to deleting as much as to writing:
+/// `$HOME` (a global command dir like `~/.codex/skills/` bleeds into every
+/// repo, and loadout keeps its own global skill links there), and any channel
+/// that escapes the project tree. Removal used to skip both checks while
+/// writing enforced them, so `clean` could delete a directory `refresh` would
+/// have refused to create.
+fn managed_channels(d: &AgentDescriptor, repo_base: &Path) -> Vec<CommandChannel> {
+    if is_home(repo_base) {
+        return Vec::new();
+    }
+    command_channels(d)
+        .into_iter()
+        .filter(|c| is_repo_relative(&c.dir))
+        .collect()
+}
+
+/// The channels a render will actually write: [`managed_channels`] plus the
+/// requirement that we're inside a git repo at all.
+pub fn emitted_channels(d: &AgentDescriptor, ctx: &Context) -> Vec<CommandChannel> {
+    if ctx.git.is_none() {
+        return Vec::new();
+    }
+    managed_channels(d, &ctx.repo_base)
+}
+
+/// How this agent invokes a generated workflow stage (`/loadout:<stage>`,
+/// `/loadout-<stage>`, `loadout-<stage> skill`), or `None` when this render
+/// writes no stage commands for it — either the agent has no command channel
+/// and only ever sees the always-on `## Workflow` context section, or the
+/// channels it does have are gated off here (outside a repo, at `$HOME`).
+///
+/// Reports the first channel — the surface `load run` launches. Deliberately
+/// derived from the same [`emitted_channels`] the writer uses: the whole point
+/// is that what we *say* and what we *write* cannot drift apart.
+pub fn stage_invocation(d: &AgentDescriptor, ctx: &Context) -> Option<&'static str> {
+    emitted_channels(d, ctx).first().map(|c| c.invocation)
 }
 
 /// Whether `name` is a generated command file in a *shared* command dir — the

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -126,6 +126,22 @@ pub struct AgentDescriptor {
     /// set; defaults to markdown.
     #[serde(default)]
     pub command_format: Option<commands::CommandFormat>,
+    /// Every command channel this agent has, when one directory isn't enough.
+    /// Copilot is the case that forced it: its IDE and its CLI read *different*
+    /// directories in different formats (`.github/prompts` vs `.github/skills`),
+    /// and one descriptor covers both surfaces.
+    ///
+    /// Built-in descriptor data only — deliberately NOT part of the `[[agents]]`
+    /// config schema (`deny_unknown_fields` still rejects it there), so a
+    /// newer-written, synced config can never brick an older binary. The same
+    /// reasoning as `review_commands`.
+    ///
+    /// When non-empty this **replaces** `commands_dir`/`command_format`, which
+    /// then exist purely so a user's `[[agents]]` override can declare a single
+    /// channel by hand. The first entry is the surface `load run` launches, so
+    /// it's the one the run summary names.
+    #[serde(skip)]
+    pub command_channels: Vec<CommandChannel>,
     /// Native review commands to run during the verify stage (e.g. Claude
     /// Code's `/code-review`, `/security-review`). Built-in descriptor data
     /// only — deliberately NOT part of the `[[agents]]` config schema
@@ -138,6 +154,53 @@ pub struct AgentDescriptor {
 fn default_template() -> String {
     "overlay".to_string()
 }
+
+/// One directory an agent reads generated workflow-stage commands from, in one
+/// on-disk format. Most agents have exactly one; Copilot has two (IDE + CLI).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandChannel {
+    /// Project-relative directory the agent scans (e.g. `.claude/commands`).
+    pub dir: String,
+    /// On-disk shape of the files written there.
+    pub format: commands::CommandFormat,
+    /// How a user actually reaches a generated stage through this channel,
+    /// with `<stage>` standing in for the stage name.
+    ///
+    /// This is per-channel, not per-format, because the same on-disk shape
+    /// surfaces differently per agent: a Cursor skill is a real slash command
+    /// (`/loadout-plan`), while a Codex or Copilot CLI skill is loaded by name
+    /// from its description and never appears in a slash menu.
+    pub invocation: &'static str,
+}
+
+impl CommandChannel {
+    /// A channel whose invocation is the format's default — used for a channel
+    /// a user declared by hand via `commands_dir` in `[[agents]]`.
+    fn new(dir: impl Into<String>, format: commands::CommandFormat) -> Self {
+        Self {
+            dir: dir.into(),
+            format,
+            invocation: format.invocation(),
+        }
+    }
+
+    /// A channel that states its own invocation (built-in descriptors).
+    fn invoked_as(
+        dir: impl Into<String>,
+        format: commands::CommandFormat,
+        invocation: &'static str,
+    ) -> Self {
+        Self {
+            dir: dir.into(),
+            format,
+            invocation,
+        }
+    }
+}
+
+/// Display pattern for a stage loaded by name rather than typed as a command —
+/// Codex and the Copilot CLI both work this way.
+const NAMED_SKILL: &str = "loadout-<stage> skill";
 
 /// How to register an [`AgentDescriptor::importer`]'s filename in an agent's own
 /// settings file so the agent actually loads it. The settings file is resolved
@@ -234,6 +297,7 @@ pub fn builtin_agents() -> Vec<AgentDescriptor> {
             launch_context_dir: None,
             commands_dir: None,
             command_format: None,
+            command_channels: Vec::new(),
             review_commands: Vec::new(),
         }
     }
@@ -245,7 +309,10 @@ pub fn builtin_agents() -> Vec<AgentDescriptor> {
             append_prompt_flag: Some("--append-system-prompt".into()),
             // Claude reads project commands from `.claude/commands/`; a `loadout/`
             // subdir namespaces them as `/loadout:<stage>`.
-            commands_dir: Some(".claude/commands".into()),
+            command_channels: vec![CommandChannel::new(
+                ".claude/commands",
+                commands::CommandFormat::Markdown,
+            )],
             review_commands: vec!["/code-review".into(), "/security-review".into()],
             ..d("claude", "claude.md")
         },
@@ -254,6 +321,23 @@ pub fn builtin_agents() -> Vec<AgentDescriptor> {
             launch: Some("codex".into()),
             override_target: Some("AGENTS.override.md".into()),
             override_base: Some("AGENTS.md".into()),
+            // Codex scans `<repo>/.codex/skills/**/SKILL.md` for project skills
+            // — verified live against codex-cli 0.146.0 with `codex debug
+            // prompt-input`, which renders the model-visible prompt without an
+            // API call: a probe skill appears there, nested one level under a
+            // `loadout/` dir appears too, and — unlike Copilot's
+            // `.github/instructions` — discovery is NOT gitignore-filtered, so
+            // a gitignored, loadout-owned `loadout/` subdir is read normally.
+            //
+            // That makes the ownership model identical to Cursor's: same
+            // `CommandFormat::Skill` layout, same owned namespace dir. A Codex
+            // skill isn't a slash command though — it's listed to the model with
+            // its description and loaded by name — hence `NAMED_SKILL`.
+            command_channels: vec![CommandChannel::invoked_as(
+                ".codex/skills",
+                commands::CommandFormat::Skill,
+                NAMED_SKILL,
+            )],
             wire_hint: Some(
                 "override writing is OFF — Codex won't see this overlay (it only reads \
                  AGENTS.md). Drop --no-override (or set [codex] write_override = true) to \
@@ -316,17 +400,38 @@ pub fn builtin_agents() -> Vec<AgentDescriptor> {
             ),
             launch_context_dir_env: Some("COPILOT_CUSTOM_INSTRUCTIONS_DIRS".into()),
             launch_context_dir: Some("copilot".into()),
-            // Workflow stages as VS Code prompt files: `.github/prompts` is a
-            // default discovery location, and a `<name>.prompt.md` there is
-            // invocable as `/<name>` in Copilot Chat. Unlike the instructions
-            // above, prompt discovery does NOT recurse into subdirectories
-            // (verified live), so these land flat in a dir the user also owns
-            // — hence `CommandFormat::Prompt`'s `loadout-` prefix ownership,
-            // which keeps pruning and `clean` off the user's own prompts.
-            // Gitignore-filtering doesn't apply either way, so ours stay
-            // gitignored by prefix.
-            commands_dir: Some(".github/prompts".into()),
-            command_format: Some(commands::CommandFormat::Prompt),
+            // Two command channels, because the two surfaces read different
+            // directories in different formats. CLI first: that's what
+            // `load run copilot` launches, so it's the invocation the run
+            // summary names.
+            //
+            // 1. Copilot CLI reads project skills from `.github/skills/`
+            //    (its own `copilot skill --help` documents `.github/skills/`,
+            //    `.agents/skills/`, `.claude/skills/`; verified live with
+            //    `copilot skill list`, which finds a probe both flat and nested
+            //    under a `loadout/` dir). Discovery is NOT gitignore-filtered —
+            //    unlike this agent's `.github/instructions` discovery above —
+            //    so the owned `loadout/` subdir works gitignored. The CLI never
+            //    reads `.github/prompts`: no reference to prompt files exists
+            //    anywhere in its bundle. A skill there is loaded by name from
+            //    its description, not typed as a command, hence `NAMED_SKILL`.
+            //
+            // 2. VS Code (Copilot Chat) reads `.github/prompts`, a default
+            //    discovery location where a `<name>.prompt.md` is invocable as
+            //    `/<name>`. Prompt discovery does NOT recurse into
+            //    subdirectories (verified live), so these land flat in a dir the
+            //    user also owns — hence `CommandFormat::Prompt`'s `loadout-`
+            //    prefix ownership, which keeps pruning and `clean` off the
+            //    user's own prompts. Gitignore-filtering doesn't apply here
+            //    either, so ours stay gitignored by prefix.
+            command_channels: vec![
+                CommandChannel::invoked_as(
+                    ".github/skills",
+                    commands::CommandFormat::Skill,
+                    NAMED_SKILL,
+                ),
+                CommandChannel::new(".github/prompts", commands::CommandFormat::Prompt),
+            ],
             wire_hint: Some(
                 "VS Code reads the gitignored .github/instructions/loadout.instructions.md; \
                  `load run copilot` wires the CLI via COPILOT_CUSTOM_INSTRUCTIONS_DIRS."
@@ -372,9 +477,13 @@ pub fn builtin_agents() -> Vec<AgentDescriptor> {
             // Cursor Skills: `.cursor/skills/<category>/<skill>/SKILL.md` — the
             // leaf folder names the skill (the category above it doesn't), so
             // loadout owns `.cursor/skills/loadout/` whole and the stages
-            // invoke as `/loadout-<stage>`.
-            commands_dir: Some(".cursor/skills".into()),
-            command_format: Some(commands::CommandFormat::Skill),
+            // invoke as `/loadout-<stage>`. Cursor is the one agent whose skills
+            // *are* real slash commands, so it keeps the format's default
+            // invocation rather than `NAMED_SKILL`.
+            command_channels: vec![CommandChannel::new(
+                ".cursor/skills",
+                commands::CommandFormat::Skill,
+            )],
             ..d("cursor", "cursor.md")
         },
         AgentDescriptor {
@@ -673,16 +782,18 @@ pub fn apply(
     // dir (`~/.claude/commands/`) would bleed into every repo, exactly like an
     // importer. One file per stage, in the owned `<commands_dir>/loadout/` dir
     // or flat with a `loadout-` prefix when the dir is shared with the user.
-    if let (Some(commands_dir), Some(wf)) = (&d.commands_dir, workflow.as_ref()) {
-        if app.in_repo() && !bleeds && is_repo_relative(commands_dir) {
-            write_stage_commands(app, d, commands_dir, wf, &mut files)?;
-            let fmt = command_format(d);
-            gitignore_extra.push(if fmt.owns_namespace_dir() {
-                format!("{commands_dir}/{}/", commands::COMMAND_NAMESPACE)
-            } else {
-                // Shared dir: ignore only our own files, by prefix.
-                format!("{commands_dir}/{}*.{}", fmt.shared_dir_prefix(), fmt.ext())
-            });
+    if let Some(wf) = workflow.as_ref() {
+        for channel in command_channels(d) {
+            if app.in_repo() && !bleeds && is_repo_relative(&channel.dir) {
+                write_stage_commands(app, d, &channel, wf, &mut files)?;
+                let (dir, fmt) = (&channel.dir, channel.format);
+                gitignore_extra.push(if fmt.owns_namespace_dir() {
+                    format!("{dir}/{}/", commands::COMMAND_NAMESPACE)
+                } else {
+                    // Shared dir: ignore only our own files, by prefix.
+                    format!("{dir}/{}*.{}", fmt.shared_dir_prefix(), fmt.ext())
+                });
+            }
         }
     }
 
@@ -766,9 +877,9 @@ pub fn artifacts(d: &AgentDescriptor, repo_base: &Path) -> Vec<PathBuf> {
     }
     // Generated slash commands: the owned dir, or — in a shared dir — each of
     // our own prefixed files.
-    if let Some(commands_dir) = &d.commands_dir {
-        let fmt = command_format(d);
-        let ns = command_namespace_dir(repo_base, commands_dir, fmt);
+    for channel in command_channels(d) {
+        let fmt = channel.format;
+        let ns = command_namespace_dir(repo_base, &channel.dir, fmt);
         if fmt.owns_namespace_dir() {
             if ns.exists() {
                 out.push(ns);
@@ -842,9 +953,9 @@ pub fn clean(d: &AgentDescriptor, app: &AppContext) -> crate::Result<CleanResult
     // dir (VS Code's `.github/prompts/`) gives up only our prefixed files —
     // the dir itself and the user's own prompts stay. The agent's own
     // `<commands_dir>` (e.g. `.claude/commands/`) is left alone either way.
-    if let Some(commands_dir) = &d.commands_dir {
-        let fmt = command_format(d);
-        let ns = command_namespace_dir(app.repo_base(), commands_dir, fmt);
+    for channel in command_channels(d) {
+        let fmt = channel.format;
+        let ns = command_namespace_dir(app.repo_base(), &channel.dir, fmt);
         if fmt.owns_namespace_dir() {
             if ns.exists() {
                 if !dry {
@@ -977,16 +1088,33 @@ fn command_format(d: &AgentDescriptor) -> commands::CommandFormat {
         .unwrap_or(commands::CommandFormat::Markdown)
 }
 
-/// How this agent invokes a generated workflow stage (`/loadout:<stage>`,
-/// `/loadout-<stage>`, …), or `None` when it has no command channel at all and
-/// only ever sees the always-on `## Workflow` context section.
+/// Every command channel this agent has, in launch order. Built-in
+/// `command_channels` win; otherwise a user's `[[agents]]` override may declare
+/// a single channel via `commands_dir`/`command_format`. Empty means the agent
+/// gets the `## Workflow` context section and nothing else.
 ///
-/// The invocation differs per agent and is easy to state wrongly, so every
-/// user-facing mention of it should come from here rather than hardcode
-/// Claude's shape.
+/// The single place these two spellings are reconciled — every consumer
+/// (`apply`, `artifacts`, `clean`, the run summary) goes through here.
+fn command_channels(d: &AgentDescriptor) -> Vec<CommandChannel> {
+    if !d.command_channels.is_empty() {
+        return d.command_channels.clone();
+    }
+    d.commands_dir
+        .iter()
+        .map(|dir| CommandChannel::new(dir.clone(), command_format(d)))
+        .collect()
+}
+
+/// How this agent invokes a generated workflow stage (`/loadout:<stage>`,
+/// `/loadout-<stage>`, `loadout-<stage> skill`), or `None` when it has no
+/// command channel at all and only ever sees the always-on `## Workflow`
+/// context section.
+///
+/// Reports the first channel — the surface `load run` launches. The invocation
+/// differs per agent and is easy to state wrongly, so every user-facing mention
+/// of it should come from here rather than hardcode Claude's shape.
 pub fn stage_invocation(d: &AgentDescriptor) -> Option<&'static str> {
-    d.commands_dir.as_ref()?;
-    Some(command_format(d).invocation())
+    command_channels(d).first().map(|c| c.invocation)
 }
 
 /// Whether `name` is a generated command file in a *shared* command dir — the
@@ -1014,14 +1142,12 @@ fn is_repo_relative(dir: &str) -> bool {
 fn write_stage_commands(
     app: &AppContext,
     d: &AgentDescriptor,
-    commands_dir: &str,
+    channel: &CommandChannel,
     wf: &Workflow,
     files: &mut Vec<WrittenFile>,
 ) -> crate::Result<()> {
-    let format = d
-        .command_format
-        .unwrap_or(commands::CommandFormat::Markdown);
-    let ns_dir = command_namespace_dir(app.repo_base(), commands_dir, format);
+    let format = channel.format;
+    let ns_dir = command_namespace_dir(app.repo_base(), &channel.dir, format);
     let generated = commands::stage_commands(wf, format, &d.review_commands);
     // A command's top-level entry in the namespace dir: the file itself, or —
     // for folder-shaped formats (Cursor skills' `loadout-plan/SKILL.md`) — the

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -311,7 +311,7 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
             Phase::Flow,
             Glyph::Ok,
             Some(wf.title().to_string()),
-            workflow_step_line(&p, workflow.as_ref()),
+            workflow_step_line(&p, workflow.as_ref(), &descriptor),
         ),
         None => hud.settle(Phase::Flow, Glyph::Ok, None, None),
     }
@@ -605,9 +605,22 @@ fn launch_step_line(p: &Painter, program: &str, args: &[String]) -> String {
 }
 
 /// One concise run-summary line naming the active workflow (or `None` when
-/// none is bound). Tells the user the spine is live and how to invoke a stage.
-fn workflow_step_line(p: &Painter, workflow: Option<&crate::workflow::Workflow>) -> Option<String> {
+/// none is bound). Tells the user the spine is live and how to invoke a stage
+/// **in the agent being launched** — the invocation is per-agent
+/// (`/loadout:plan` on Claude, `/loadout-plan` on Cursor and Copilot), and some
+/// agents get no command files at all and see only the `## Workflow` context
+/// section. Saying `/loadout:<stage>` unconditionally sent users hunting for a
+/// command their agent never had.
+fn workflow_step_line(
+    p: &Painter,
+    workflow: Option<&crate::workflow::Workflow>,
+    descriptor: &AgentDescriptor,
+) -> Option<String> {
     let wf = workflow?;
+    let how = match adapters::stage_invocation(descriptor) {
+        Some(invocation) => invocation.to_string(),
+        None => format!("no stage commands for {}", descriptor.id),
+    };
     Some(step(
         p,
         p.cyan("◆"),
@@ -615,7 +628,7 @@ fn workflow_step_line(p: &Painter, workflow: Option<&crate::workflow::Workflow>)
         format!(
             "{} {}",
             wf.title(),
-            p.dim(&format!("· {} stages · /loadout:<stage>", wf.stages.len()))
+            p.dim(&format!("· {} stages · {how}", wf.stages.len()))
         ),
     ))
 }
@@ -819,6 +832,41 @@ mod tests {
             out[1]
         );
         assert_eq!(out[2..], user[..]);
+    }
+
+    /// The flow line must name the invocation the *launched agent* actually
+    /// has. It used to print `/loadout:<stage>` for every agent, which is only
+    /// true for Claude — Cursor and Copilot use a hyphen, and Codex has no
+    /// stage commands at all.
+    #[test]
+    fn flow_line_states_each_agents_real_stage_invocation() {
+        let p = Painter::new(false);
+        let wf = crate::workflow::builtin_workflows()
+            .into_iter()
+            .next()
+            .expect("at least one built-in workflow");
+        let line = |id: &str| {
+            workflow_step_line(&p, Some(&wf), &descriptor(id)).expect("a bound workflow prints")
+        };
+
+        assert!(line("claude").contains("/loadout:<stage>"));
+        assert!(line("cursor").contains("/loadout-<stage>"));
+        assert!(line("copilot").contains("/loadout-<stage>"));
+
+        // No command channel → say so plainly instead of promising a command.
+        let codex = line("codex");
+        assert!(
+            codex.contains("no stage commands for codex"),
+            "codex has no commands_dir, got: {codex}"
+        );
+        assert!(!codex.contains("/loadout"));
+    }
+
+    /// No workflow bound → no flow line at all, for any agent.
+    #[test]
+    fn flow_line_absent_without_a_workflow() {
+        let p = Painter::new(false);
+        assert!(workflow_step_line(&p, None, &descriptor("claude")).is_none());
     }
 
     #[test]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -311,7 +311,7 @@ pub fn run(rt: &Runtime, args: &RunArgs) -> crate::Result<()> {
             Phase::Flow,
             Glyph::Ok,
             Some(wf.title().to_string()),
-            workflow_step_line(&p, workflow.as_ref(), &descriptor),
+            workflow_step_line(&p, workflow.as_ref(), &descriptor, &prep.context),
         ),
         None => hud.settle(Phase::Flow, Glyph::Ok, None, None),
     }
@@ -607,17 +607,20 @@ fn launch_step_line(p: &Painter, program: &str, args: &[String]) -> String {
 /// One concise run-summary line naming the active workflow (or `None` when
 /// none is bound). Tells the user the spine is live and how to invoke a stage
 /// **in the agent being launched** — the invocation is per-agent
-/// (`/loadout:plan` on Claude, `/loadout-plan` on Cursor and Copilot), and some
-/// agents get no command files at all and see only the `## Workflow` context
-/// section. Saying `/loadout:<stage>` unconditionally sent users hunting for a
-/// command their agent never had.
+/// (`/loadout:plan` on Claude, `/loadout-plan` on Cursor, a named skill on
+/// Codex and the Copilot CLI), and a stage command may not exist at all: the
+/// agent may have no channel, or this render may be gated (outside a git repo,
+/// or at `$HOME`). Saying `/loadout:<stage>` unconditionally sent users hunting
+/// for a command their agent never had, so the invocation is read from the same
+/// `emitted_channels` the writer uses rather than from the descriptor alone.
 fn workflow_step_line(
     p: &Painter,
     workflow: Option<&crate::workflow::Workflow>,
     descriptor: &AgentDescriptor,
+    ctx: &Context,
 ) -> Option<String> {
     let wf = workflow?;
-    let how = match adapters::stage_invocation(descriptor) {
+    let how = match adapters::stage_invocation(descriptor, ctx) {
         Some(invocation) => invocation.to_string(),
         None => format!("no stage commands for {}", descriptor.id),
     };
@@ -834,19 +837,36 @@ mod tests {
         assert_eq!(out[2..], user[..]);
     }
 
+    /// A `Context` inside a git repo — stage commands are only ever written
+    /// there, so the flow line only names an invocation there.
+    fn in_repo_context() -> Context {
+        let mut ctx = prepared().context;
+        ctx.git = Some(crate::context::GitContext {
+            root: PathBuf::from("/repo"),
+            branch: Some("main".to_string()),
+            remotes: Vec::new(),
+            is_worktree: false,
+        });
+        ctx
+    }
+
+    fn a_workflow() -> crate::workflow::Workflow {
+        crate::workflow::builtin_workflows()
+            .into_iter()
+            .next()
+            .expect("at least one built-in workflow")
+    }
+
     /// The flow line must name the invocation the *launched agent* actually
     /// has. It used to print `/loadout:<stage>` for every agent, which is only
     /// true for Claude — Cursor uses a hyphen, and Codex and the Copilot CLI
     /// load a named skill that never appears in a slash menu.
     #[test]
     fn flow_line_states_each_agents_real_stage_invocation() {
-        let p = Painter::new(false);
-        let wf = crate::workflow::builtin_workflows()
-            .into_iter()
-            .next()
-            .expect("at least one built-in workflow");
+        let (p, wf, ctx) = (Painter::new(false), a_workflow(), in_repo_context());
         let line = |id: &str| {
-            workflow_step_line(&p, Some(&wf), &descriptor(id)).expect("a bound workflow prints")
+            workflow_step_line(&p, Some(&wf), &descriptor(id), &ctx)
+                .expect("a bound workflow prints")
         };
 
         assert!(line("claude").contains("/loadout:<stage>"));
@@ -867,24 +887,41 @@ mod tests {
     /// An agent with no command channel at all must not be promised one.
     #[test]
     fn flow_line_says_so_when_an_agent_has_no_stage_commands() {
-        let p = Painter::new(false);
-        let wf = crate::workflow::builtin_workflows()
-            .into_iter()
-            .next()
-            .expect("at least one built-in workflow");
+        let (p, wf, ctx) = (Painter::new(false), a_workflow(), in_repo_context());
         let d = descriptor("opencode");
-        assert!(adapters::stage_invocation(&d).is_none());
+        assert!(adapters::stage_invocation(&d, &ctx).is_none());
 
-        let got = workflow_step_line(&p, Some(&wf), &d).expect("a bound workflow prints");
+        let got = workflow_step_line(&p, Some(&wf), &d, &ctx).expect("a bound workflow prints");
         assert!(got.contains("no stage commands for opencode"), "got: {got}");
         assert!(!got.contains("/loadout"));
+    }
+
+    /// Outside a git repo `apply` writes no command files at all, so the line
+    /// must not name an invocation there either. Saying what we don't do is the
+    /// same bug this line was fixed for, one scenario over.
+    #[test]
+    fn flow_line_promises_nothing_outside_a_git_repo() {
+        let (p, wf) = (Painter::new(false), a_workflow());
+        let ctx = prepared().context; // git: None
+        for id in ["claude", "codex", "copilot", "cursor"] {
+            let d = descriptor(id);
+            assert!(
+                adapters::stage_invocation(&d, &ctx).is_none(),
+                "{id} must promise nothing outside a repo"
+            );
+            let got = workflow_step_line(&p, Some(&wf), &d, &ctx).expect("workflow still prints");
+            assert!(
+                got.contains(&format!("no stage commands for {id}")),
+                "got: {got}"
+            );
+        }
     }
 
     /// No workflow bound → no flow line at all, for any agent.
     #[test]
     fn flow_line_absent_without_a_workflow() {
         let p = Painter::new(false);
-        assert!(workflow_step_line(&p, None, &descriptor("claude")).is_none());
+        assert!(workflow_step_line(&p, None, &descriptor("claude"), &in_repo_context()).is_none());
     }
 
     #[test]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -836,8 +836,8 @@ mod tests {
 
     /// The flow line must name the invocation the *launched agent* actually
     /// has. It used to print `/loadout:<stage>` for every agent, which is only
-    /// true for Claude — Cursor and Copilot use a hyphen, and Codex has no
-    /// stage commands at all.
+    /// true for Claude — Cursor uses a hyphen, and Codex and the Copilot CLI
+    /// load a named skill that never appears in a slash menu.
     #[test]
     fn flow_line_states_each_agents_real_stage_invocation() {
         let p = Painter::new(false);
@@ -851,15 +851,33 @@ mod tests {
 
         assert!(line("claude").contains("/loadout:<stage>"));
         assert!(line("cursor").contains("/loadout-<stage>"));
-        assert!(line("copilot").contains("/loadout-<stage>"));
 
-        // No command channel → say so plainly instead of promising a command.
-        let codex = line("codex");
-        assert!(
-            codex.contains("no stage commands for codex"),
-            "codex has no commands_dir, got: {codex}"
-        );
-        assert!(!codex.contains("/loadout"));
+        // `load run` launches the CLI for both, so the CLI's skill channel is
+        // what the line names — not Copilot's VS Code prompt files.
+        for id in ["codex", "copilot"] {
+            let got = line(id);
+            assert!(
+                got.contains("loadout-<stage> skill"),
+                "{id} loads stages as a named skill, got: {got}"
+            );
+            assert!(!got.contains('/'), "{id} has no slash command, got: {got}");
+        }
+    }
+
+    /// An agent with no command channel at all must not be promised one.
+    #[test]
+    fn flow_line_says_so_when_an_agent_has_no_stage_commands() {
+        let p = Painter::new(false);
+        let wf = crate::workflow::builtin_workflows()
+            .into_iter()
+            .next()
+            .expect("at least one built-in workflow");
+        let d = descriptor("opencode");
+        assert!(adapters::stage_invocation(&d).is_none());
+
+        let got = workflow_step_line(&p, Some(&wf), &d).expect("a bound workflow prints");
+        assert!(got.contains("no stage commands for opencode"), "got: {got}");
+        assert!(!got.contains("/loadout"));
     }
 
     /// No workflow bound → no flow line at all, for any agent.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2417,6 +2417,134 @@ fn cursor_workflow_generates_skills() {
     assert!(!fx.exists(".cursor/skills/loadout"));
 }
 
+/// Codex reads project skills from `<repo>/.codex/skills/**/SKILL.md` — the
+/// same folder-per-stage layout as Cursor, in an owned `loadout/` namespace.
+/// Verified live against codex-cli 0.146.0 (`codex debug prompt-input` lists
+/// the skill, and gitignoring the dir does not hide it), which is why loadout
+/// can own a gitignored subdir here at all.
+#[test]
+fn codex_workflow_generates_project_skills() {
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.author(
+        "[[fragments]]\nid = \"rc\"\nguidance = \"Rust.\"\n\
+         \n\
+         [[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\nworkflow = \"superpowers\"\n",
+    );
+    fx.git_init();
+
+    fx.cmd()
+        .args(["refresh", "--agent", "codex"])
+        .assert()
+        .success();
+
+    for stage in ["brainstorm", "plan", "implement", "verify", "ship"] {
+        let p = format!(".codex/skills/loadout/loadout-{stage}/SKILL.md");
+        assert!(fx.exists(&p), "missing {p}");
+    }
+    let skill = fx.read(".codex/skills/loadout/loadout-plan/SKILL.md");
+    assert!(skill.contains("name: loadout-plan"));
+    assert!(skill.contains("$LOADOUT_PLAN_PATH"));
+    assert!(fx.read(".gitignore").contains(".codex/skills/loadout/"));
+
+    // The overlay channel still works alongside it.
+    assert!(fx.exists("AGENTS.override.md"));
+
+    // clean removes the whole owned namespace dir, leaving `.codex/skills/`
+    // (where loadout also symlinks its global skills) alone.
+    fx.cmd()
+        .args(["clean", "--agent", "codex"])
+        .assert()
+        .success();
+    assert!(!fx.exists(".codex/skills/loadout"));
+}
+
+/// Copilot is one descriptor over two surfaces that read different directories:
+/// the CLI reads `.github/skills/` (it has no notion of prompt files at all),
+/// VS Code reads `.github/prompts/`. Both channels must be written, gitignored
+/// by their own ownership rule, and removed by `clean`.
+#[test]
+fn copilot_writes_both_the_cli_skill_and_vs_code_prompt_channels() {
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.git_init();
+    fx.author(
+        "[[fragments]]\nid = \"rc\"\nguidance = \"Rust.\"\n\n\
+         [[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\nworkflow = \"superpowers\"\n",
+    );
+
+    fx.cmd()
+        .args(["refresh", "--agent", "copilot"])
+        .assert()
+        .success();
+
+    for stage in ["brainstorm", "plan", "implement", "verify", "ship"] {
+        let cli = format!(".github/skills/loadout/loadout-{stage}/SKILL.md");
+        let ide = format!(".github/prompts/loadout-{stage}.prompt.md");
+        assert!(fx.exists(&cli), "missing CLI channel {cli}");
+        assert!(fx.exists(&ide), "missing VS Code channel {ide}");
+    }
+
+    // Each channel carries its own format's frontmatter.
+    assert!(fx
+        .read(".github/skills/loadout/loadout-plan/SKILL.md")
+        .contains("name: loadout-plan"));
+    assert!(fx
+        .read(".github/prompts/loadout-plan.prompt.md")
+        .starts_with("---\nmode: agent\n"));
+
+    // Owned dir ignored whole; shared dir ignored by prefix only.
+    let ignore = fx.read(".gitignore");
+    assert!(ignore.contains(".github/skills/loadout/"));
+    assert!(ignore.contains(".github/prompts/loadout-*.prompt.md"));
+
+    fx.cmd()
+        .args(["clean", "--agent", "copilot"])
+        .assert()
+        .success();
+    assert!(!fx.exists(".github/skills/loadout"));
+    assert!(!fx.exists(".github/prompts/loadout-plan.prompt.md"));
+}
+
+/// `.github/skills/` is a shared discovery location for the Copilot CLI —
+/// loadout owns only its `loadout/` subdir and must leave the user's own
+/// project skills untouched by pruning and by `clean`.
+#[test]
+fn copilot_cli_skills_never_touch_the_users_own_project_skills() {
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.git_init();
+    fx.author(
+        "[[fragments]]\nid = \"rc\"\nguidance = \"Rust.\"\n\n\
+         [[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\nworkflow = \"superpowers\"\n",
+    );
+    fx.write(
+        ".github/skills/my-own/SKILL.md",
+        "---\nname: my-own\ndescription: mine\n---\nmine\n",
+    );
+
+    for _ in 0..2 {
+        fx.cmd()
+            .args(["refresh", "--agent", "copilot"])
+            .assert()
+            .success();
+        assert_eq!(
+            fx.read(".github/skills/my-own/SKILL.md"),
+            "---\nname: my-own\ndescription: mine\n---\nmine\n"
+        );
+    }
+
+    fx.cmd()
+        .args(["clean", "--agent", "copilot"])
+        .assert()
+        .success();
+    assert!(
+        fx.exists(".github/skills/my-own/SKILL.md"),
+        "clean removed a project skill loadout does not own"
+    );
+    assert!(!fx.exists(".github/skills/loadout"));
+}
+
 /// `load agents` lists cursor with the owned-file delivery.
 #[test]
 fn agents_lists_cursor_owned_file_delivery() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2545,6 +2545,52 @@ fn copilot_cli_skills_never_touch_the_users_own_project_skills() {
     assert!(!fx.exists(".github/skills/loadout"));
 }
 
+/// Writing and deleting must agree on which directories are loadout's. At
+/// `$HOME` a command dir would bleed into every repo underneath, so `refresh`
+/// refuses to write there — and `clean` must refuse to delete there too.
+/// `~/.codex/skills/` is the sharp case: loadout keeps its own global skill
+/// links in that very directory.
+#[test]
+fn clean_refuses_to_touch_command_dirs_refresh_would_not_write() {
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.git_init();
+    fx.author(
+        "[[fragments]]\nid = \"rc\"\nguidance = \"Rust.\"\n\n\
+         [[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\nworkflow = \"superpowers\"\n",
+    );
+    // Something already living where codex's channel would go.
+    fx.write(
+        ".codex/skills/loadout/keep-me/SKILL.md",
+        "---\nname: keep-me\ndescription: pre-existing\n---\nkeep\n",
+    );
+
+    // `--cwd` IS `$HOME` for these two runs.
+    let at_home = || {
+        let mut c = fx.cmd();
+        c.env("HOME", fx.repo_path());
+        c
+    };
+
+    at_home()
+        .args(["refresh", "--agent", "codex"])
+        .assert()
+        .success();
+    assert!(
+        !fx.exists(".codex/skills/loadout/loadout-plan/SKILL.md"),
+        "refresh wrote a command dir at $HOME"
+    );
+
+    at_home()
+        .args(["clean", "--agent", "codex"])
+        .assert()
+        .success();
+    assert!(
+        fx.exists(".codex/skills/loadout/keep-me/SKILL.md"),
+        "clean deleted a directory refresh would have refused to create"
+    );
+}
+
 /// `load agents` lists cursor with the owned-file delivery.
 #[test]
 fn agents_lists_cursor_owned_file_delivery() {


### PR DESCRIPTION
## The bug

A user installed loadout, created a Next.js profile from a starter pack, and ran `load copilot` and `load codex`. Global skills like `loadout-remember` showed up. The workflow stages did not.

Two separate mechanisms were being conflated:

- `loadout-remember` is a **global skill**, installed once into `~/.agents/skills/` and symlinked into `~/.claude/skills/` and `~/.codex/skills/`. Both CLIs scan those, so it appeared.
- `/loadout:plan` and friends are **per-repo command files**, written only for agents whose descriptor declares a command directory. Codex declared none. Copilot declared `.github/prompts`, which only VS Code reads.

And `load run` printed `/loadout:<stage>` for **every** agent whenever a workflow was bound — a Claude-only shape. That is what sent the user hunting for a command their agent never had.

## Fix 1 — the run summary tells the truth

```
claude    flow    Superpowers · 5 stages · /loadout:<stage>
codex     flow    Superpowers · 5 stages · loadout-<stage> skill
copilot   flow    Superpowers · 5 stages · loadout-<stage> skill
cursor    flow    Superpowers · 5 stages · /loadout-<stage>
opencode  flow    Superpowers · 5 stages · no stage commands for opencode
```

The invocation now comes from the agent's own descriptor via `adapters::stage_invocation`, so there is one place to get it wrong instead of many.

## Fix 2 — both CLIs get the stages

No launch-time wiring was needed. Both CLIs already read a project skills directory, in exactly the folder-per-stage layout `CommandFormat::Skill` produces for Cursor:

| Agent | Written as | Reached by |
| --- | --- | --- |
| Codex | `.codex/skills/loadout/loadout-plan/SKILL.md` | `loadout-plan` skill, by name |
| Copilot (CLI) | `.github/skills/loadout/loadout-plan/SKILL.md` | `loadout-plan` skill, by name |
| Copilot (VS Code) | `.github/prompts/loadout-plan.prompt.md` | `/loadout-plan` |

Two properties made this work, both verified live rather than assumed:

- Each CLI discovers a **nested** `loadout/` namespace dir, so loadout owns a subdir outright and never touches the user's own skills beside it.
- Neither filters skill discovery by **gitignore** — unlike Copilot's `.github/instructions` discovery, which does. So the files stay out of the repo and are still read.

Because it is static and per-repo, the stages are there for a plain `codex` or `copilot` too, not only under `load run`.

## The one structural change

Copilot's IDE and CLI read different directories in different formats, so one `commands_dir` was not enough. `AgentDescriptor` grows `command_channels`, a list that replaces `commands_dir`/`command_format` when set.

It is built-in data marked `#[serde(skip)]`, following the existing `review_commands` precedent, so a config written by a newer binary and synced to an older one still parses. `commands_dir` remains for single-channel `[[agents]]` overrides.

## Verification

- 678 tests pass; clippy and `cargo fmt` clean.
- 4 new integration tests: Codex project skills, Copilot writing both channels, and both shared dirs leaving the user's own files alone through refresh, re-refresh, and `clean`.
- End-to-end in a scratch repo with the built binary: `codex debug prompt-input` (renders the model-visible prompt with no API call) lists all five stages, and `copilot skill list` lists all five — both while gitignored. `load clean` removes both channels and spares the user's files.
- Discovery claims checked against codex-cli 0.146.0 and the installed Copilot CLI, not from memory.

## Not in scope

`src/studio/views.rs:1358` still describes the spine as `/loadout:explore · plan · implement · verify` — the same Claude-only shape, in the studio's workflow tab. One-line copy fix, left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)