### PR TITLE
fix: close a symlink escape in command dirs, and stop studio quoting Claude's invocation

### DIFF
--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -784,7 +784,7 @@ pub fn apply(
     // or flat with a `loadout-` prefix when the dir is shared with the user.
     if let Some(wf) = workflow.as_ref() {
         for channel in emitted_channels(d, app.context) {
-            write_stage_commands(app, d, &channel, wf, &mut files)?;
+            write_stage_commands(app, d, &channel, wf, &mut files, &mut warnings)?;
             let (dir, fmt) = (&channel.dir, channel.format);
             gitignore_extra.push(if fmt.owns_namespace_dir() {
                 format!("{dir}/{}/", commands::COMMAND_NAMESPACE)
@@ -877,7 +877,9 @@ pub fn artifacts(d: &AgentDescriptor, repo_base: &Path) -> Vec<PathBuf> {
     // our own prefixed files.
     for channel in managed_channels(d, repo_base) {
         let fmt = channel.format;
-        let ns = command_namespace_dir(repo_base, &channel.dir, fmt);
+        let Some(ns) = command_namespace_dir(repo_base, &channel.dir, fmt) else {
+            continue;
+        };
         if fmt.owns_namespace_dir() {
             if ns.exists() {
                 out.push(ns);
@@ -953,7 +955,9 @@ pub fn clean(d: &AgentDescriptor, app: &AppContext) -> crate::Result<CleanResult
     // `<commands_dir>` (e.g. `.claude/commands/`) is left alone either way.
     for channel in managed_channels(d, app.repo_base()) {
         let fmt = channel.format;
-        let ns = command_namespace_dir(app.repo_base(), &channel.dir, fmt);
+        let Some(ns) = command_namespace_dir(app.repo_base(), &channel.dir, fmt) else {
+            continue;
+        };
         if fmt.owns_namespace_dir() {
             if ns.exists() {
                 if !dry {
@@ -1067,16 +1071,53 @@ fn redact_artifact(content: String, what: &str) -> String {
 /// loadout owns outright, or — for formats whose discovery doesn't recurse
 /// (VS Code prompt files) — the agent's command dir itself, shared with the
 /// user's own files and owned only by filename prefix.
+///
+/// `None` when that directory doesn't actually resolve inside the repo (see
+/// [`resolves_inside`]), which callers must treat as "this channel has no
+/// namespace dir" — never as "use the unchecked path".
 fn command_namespace_dir(
     repo_base: &Path,
     commands_dir: &str,
     format: commands::CommandFormat,
-) -> PathBuf {
+) -> Option<PathBuf> {
     let base = repo_base.join(commands_dir);
-    if format.owns_namespace_dir() {
+    let ns = if format.owns_namespace_dir() {
         base.join(commands::COMMAND_NAMESPACE)
     } else {
         base
+    };
+    resolves_inside(repo_base, &ns).then_some(ns)
+}
+
+/// Whether `path` really lands inside `repo_base` once symlinks are resolved.
+///
+/// [`is_repo_relative`] only inspects the configured *string*, so it cannot see
+/// a link: a repo that ships `.codex/skills/loadout -> ../../../.ssh` passes it,
+/// and loadout would then prune "stale" entries — deleting through the link —
+/// before writing stage files there. Cloning a repo must never hand it a
+/// delete-anywhere primitive.
+///
+/// The namespace dir usually doesn't exist yet on a first render, so this
+/// canonicalizes the deepest ancestor that *does* exist. A link anywhere along
+/// the path (`.codex`, `.codex/skills`, or the namespace dir itself) is
+/// therefore caught, because canonicalizing that ancestor already leaves the
+/// repo. Both sides are canonicalized so a symlinked repo root (macOS `/tmp` →
+/// `/private/tmp`) still compares equal.
+fn resolves_inside(repo_base: &Path, path: &Path) -> bool {
+    let Ok(root) = repo_base.canonicalize() else {
+        return false;
+    };
+    let mut probe = path;
+    loop {
+        match probe.canonicalize() {
+            Ok(real) => return real.starts_with(&root),
+            // Doesn't exist yet — ask the same question of its parent, which is
+            // where a link would have to sit for this path to escape.
+            Err(_) => match probe.parent() {
+                Some(parent) => probe = parent,
+                None => return false,
+            },
+        }
     }
 }
 
@@ -1174,9 +1215,18 @@ fn write_stage_commands(
     channel: &CommandChannel,
     wf: &Workflow,
     files: &mut Vec<WrittenFile>,
+    warnings: &mut Vec<String>,
 ) -> crate::Result<()> {
     let format = channel.format;
-    let ns_dir = command_namespace_dir(app.repo_base(), &channel.dir, format);
+    // Escapes the repo (a symlinked path component) → write nothing and say so.
+    // Silence would look like a working channel that simply produced no files.
+    let Some(ns_dir) = command_namespace_dir(app.repo_base(), &channel.dir, format) else {
+        warnings.push(format!(
+            "{} resolves outside the repo (symlinked?) — skipping {}'s stage commands there",
+            channel.dir, d.id
+        ));
+        return Ok(());
+    };
     let generated = commands::stage_commands(wf, format, &d.review_commands);
     // A command's top-level entry in the namespace dir: the file itself, or —
     // for folder-shaped formats (Cursor skills' `loadout-plan/SKILL.md`) — the

--- a/src/studio/views.rs
+++ b/src/studio/views.rs
@@ -1353,9 +1353,13 @@ pub fn workflows_tab(view: &WorkflowsView, flash: Option<&str>) -> Markup {
                 h1 { "Workflows" }
             }
             @if let Some(msg) = flash { p class="flash" { (icon("check")) (msg) } }
+            // Names the slots, not one agent's invocation: how you reach a step
+            // differs per agent (`/loadout:plan` on Claude, `/loadout-plan` on
+            // Cursor, a named skill on Codex and the Copilot CLI), and studio
+            // edits the global config rather than any single agent.
             p class="muted workflows-lead" {
-                "One fixed set of commands — "
-                code { "/loadout:explore" } " · " code { "plan" } " · " code { "implement" } " · " code { "verify" }
+                "One fixed set of steps — "
+                code { "explore" } " · " code { "plan" } " · " code { "implement" } " · " code { "verify" }
                 ". The " strong { "workflow" } " you pick decides what each one does."
             }
             // The gallery: tiny named cards across the top, always visible.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2596,6 +2596,7 @@ fn clean_refuses_to_touch_command_dirs_refresh_would_not_write() {
 /// the lexical `is_repo_relative` check, so without resolving the path loadout
 /// would prune "stale" entries through the link — deleting the target's real
 /// contents — and then write stage files there.
+#[cfg(unix)]
 #[test]
 fn a_symlinked_command_dir_cannot_escape_the_repo() {
     let fx = Fixture::new();
@@ -2645,6 +2646,7 @@ fn a_symlinked_command_dir_cannot_escape_the_repo() {
 /// The escape guard must not break the ordinary case: a repo whose own root is
 /// reached through a symlink (macOS `/tmp` → `/private/tmp`) still gets its
 /// stage commands, because both sides are canonicalized before comparing.
+#[cfg(unix)]
 #[test]
 fn a_symlinked_repo_root_still_gets_stage_commands() {
     let fx = Fixture::new();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2591,6 +2591,86 @@ fn clean_refuses_to_touch_command_dirs_refresh_would_not_write() {
     );
 }
 
+/// Cloning a repo must never hand it a delete-anywhere primitive. A repo that
+/// ships its command namespace as a symlink pointing outside the tree passes
+/// the lexical `is_repo_relative` check, so without resolving the path loadout
+/// would prune "stale" entries through the link — deleting the target's real
+/// contents — and then write stage files there.
+#[test]
+fn a_symlinked_command_dir_cannot_escape_the_repo() {
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.git_init();
+    fx.author(
+        "[[fragments]]\nid = \"rc\"\nguidance = \"Rust.\"\n\n\
+         [[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\nworkflow = \"superpowers\"\n",
+    );
+
+    // A directory outside the repo holding something precious.
+    let outside = fx.global.path().join("precious");
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(outside.join("id_rsa"), "PRIVATE KEY").unwrap();
+
+    // The repo points its codex namespace dir straight at it.
+    fs::create_dir_all(fx.repo.path().join(".codex/skills")).unwrap();
+    std::os::unix::fs::symlink(&outside, fx.repo.path().join(".codex/skills/loadout")).unwrap();
+
+    fx.cmd()
+        .args(["refresh", "--agent", "codex"])
+        .assert()
+        .success();
+
+    // Nothing pruned, nothing written through the link.
+    assert_eq!(
+        fs::read_to_string(outside.join("id_rsa")).unwrap(),
+        "PRIVATE KEY",
+        "pruning deleted through a symlinked command dir"
+    );
+    assert!(
+        !outside.join("loadout-plan").exists(),
+        "wrote stage commands outside the repo"
+    );
+
+    // `clean` must not remove the link's target either.
+    fx.cmd()
+        .args(["clean", "--agent", "codex"])
+        .assert()
+        .success();
+    assert!(
+        outside.join("id_rsa").exists(),
+        "clean removed a directory outside the repo"
+    );
+}
+
+/// The escape guard must not break the ordinary case: a repo whose own root is
+/// reached through a symlink (macOS `/tmp` → `/private/tmp`) still gets its
+/// stage commands, because both sides are canonicalized before comparing.
+#[test]
+fn a_symlinked_repo_root_still_gets_stage_commands() {
+    let fx = Fixture::new();
+    fx.rust_project();
+    fx.git_init();
+    fx.author(
+        "[[fragments]]\nid = \"rc\"\nguidance = \"Rust.\"\n\n\
+         [[loadouts]]\nname = \"rust\"\ntargets = [\"rust\"]\nfragments = [\"rc\"]\nworkflow = \"superpowers\"\n",
+    );
+
+    let link = fx.global.path().join("repo-link");
+    std::os::unix::fs::symlink(fx.repo.path(), &link).unwrap();
+
+    let mut c = Command::cargo_bin("load").unwrap();
+    c.env("LOADOUT_CONFIG_DIR", fx.global.path().join("empty"));
+    c.env("HOME", fx.global.path().join("home"));
+    c.env("LOADOUT_STATE_DIR", fx.global.path().join("state"));
+    c.arg("--cwd").arg(&link);
+    c.args(["refresh", "--agent", "codex"]).assert().success();
+
+    assert!(
+        fx.exists(".codex/skills/loadout/loadout-plan/SKILL.md"),
+        "the guard rejected a legitimately symlinked repo root"
+    );
+}
+
 /// `load agents` lists cursor with the owned-file delivery.
 #[test]
 fn agents_lists_cursor_owned_file_delivery() {


### PR DESCRIPTION
Two follow-ups from #54, both flagged there and deferred out of it.

## 1. A symlinked command dir could delete files outside the repo

`is_repo_relative` only inspects the configured **string** — not absolute, no `..`. It cannot see a symlink. So a repo shipping

```
.codex/skills/loadout -> ../../../.ssh
```

passed the check, and the pruning pass in `write_stage_commands` then walked that directory and deleted every entry that wasn't a generated stage name.

**Cloning a repo and running `load refresh` was enough.** The new test reproduces it — with the guard removed, a file named `id_rsa` outside the repo is deleted outright:

```
panicked at tests/cli.rs:2625: called `Result::unwrap()` on an `Err` value: No such file or directory
```

### Fix

`command_namespace_dir` now returns `None` unless the directory really resolves inside the repo, so writing, `artifacts` and `clean` all refuse it from one choke point — the same shape as the `managed_channels` gate added in #54.

Resolution canonicalizes the deepest **existing** ancestor. That is what catches a link at any level: the namespace dir itself rarely exists on a first render, but the `.codex` or `.codex/skills` above it does, and canonicalizing that already leaves the repo.

Both sides are canonicalized, so a repo reached through a symlinked root (macOS `/tmp` → `/private/tmp`) still works. A second test pins that — a guard that rejects legitimate repos would be its own bug.

A skipped channel warns rather than passing silently, which would look like a working channel that happened to produce no files.

### Scope

This predates the Codex and Copilot channels; Claude and Cursor were reachable the same way. Adding two more command dirs is what made it worth closing now.

## 2. studio quoted Claude's invocation

The Workflows tab described the spine as `/loadout:explore · plan · implement · verify`. That colon form is Claude Code's alone — Cursor and VS Code Copilot use `/loadout-<slot>`, and Codex and the Copilot CLI load a named skill with no slash command.

studio edits the global config, not one agent's wiring, so it now names the slots plainly (`explore · plan · implement · verify`) and leaves the per-agent invocation to `load run`, which knows which agent it launched.

This was the last place still repeating the misdirection that sent a Copilot/Codex user hunting for `/loadout:plan`.

## Verification

- 681 tests pass; clippy and `cargo fmt` clean.
- 2 new integration tests. The escape test is verified to fail without the guard (deleting the sentinel file), so it catches the bug rather than merely passing.
- No test asserted the old studio copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)