### PR TITLE
release: v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ All notable changes to loadout are documented here. The format follows
 keep entries user-facing. When cutting a release, rename **Unreleased** to the
 version and date (see [RELEASING.md](RELEASING.md)).
 
+## 0.28.0 — 2026-08-17
+
+### Added
+
+- **Codex and the GitHub Copilot CLI now get your workflow's steps.** Until now
+  they saw the always-on `## Workflow` section in their context and nothing else,
+  so there was no way to actually *start* a step — the commands existed for
+  Claude Code, Cursor, and VS Code Copilot only. Both CLIs read project skills,
+  so loadout now writes one skill per step: `.codex/skills/loadout/` for Codex,
+  `.github/skills/loadout/` for the Copilot CLI. They aren't slash commands
+  there — you ask for one by name ("use the loadout-plan skill") or let the agent
+  pick it up from the description. Nothing to configure, and it works whether you
+  launch through `load run` or run the CLI yourself.
+
+  Copilot's VS Code prompt files are unchanged. Its editor and its CLI read
+  different directories in different formats, so loadout now writes both.
+
+### Fixed
+
+- **`load run` no longer tells you to type a command your agent doesn't have.**
+  It announced `/loadout:<stage>` for every agent, which is true only for Claude
+  Code: Cursor and VS Code Copilot use `/loadout-<stage>`, Codex and the Copilot
+  CLI load a named skill, and some agents get no step commands at all. The line
+  now reports what the agent you're launching actually offers — including saying
+  plainly that there are none, which is also the honest answer outside a git
+  repo, where loadout writes no command files.
+- **studio's Workflows tab no longer quotes one agent's commands.** It described
+  the spine as `/loadout:explore · plan · …`, the Claude-only form. studio edits
+  your global config rather than any single agent's wiring, so it now names the
+  steps themselves and leaves the invocation to `load run`.
+- **`load clean` no longer removes directories `load refresh` refuses to
+  create.** Writing skipped a command directory sitting at `$HOME` or outside the
+  project; removal checked neither. Running `load clean` from `$HOME` could
+  therefore delete `~/.codex/skills/loadout` — inside the very directory loadout
+  keeps your global skill links in.
+
+### Security
+
+- **A repository you clone can no longer make loadout delete files outside it.**
+  loadout checked only that a command directory's *path* stayed inside the
+  project, and a symlink walks straight past that kind of check. A repository
+  shipping `.codex/skills/loadout` as a link to somewhere else — `~/.ssh`, say —
+  would have had that directory's real contents pruned as "stale", on nothing
+  more than a `load refresh` after cloning.
+
+  Command directories are now resolved before they're used, so a path that leaves
+  the project is refused and reported instead of followed. This affected Claude
+  Code and Cursor too, in every version that generated workflow commands.
+
 ## 0.27.0 — 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "loadout"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loadout"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Equip the right context for the job — detect the project, select the loadout that fits, and render your global context as an agent-specific instruction overlay."


### PR DESCRIPTION
Cuts **v0.28.0**. Version bumped in `Cargo.toml` + `Cargo.lock`, `## Unreleased` written up as `## 0.28.0 — 2026-08-17` (dist pulls that section into the release notes).

Minor bump: the release adds user-visible agent support, so it isn't a patch.

## What ships

**Added — Codex and the GitHub Copilot CLI get workflow step commands.** They previously saw the always-on `## Workflow` context section and nothing else, so there was no way to start a step. Both read project skills, so loadout writes one per step: `.codex/skills/loadout/` and `.github/skills/loadout/`. Copilot's VS Code prompt files are unchanged — its editor and CLI read different directories, and both are now written.

**Security — a cloned repo can no longer make loadout delete files outside it.** loadout checked only that a command directory's path stayed in the project, which a symlink walks past. A repo shipping `.codex/skills/loadout` as a link to `~/.ssh` would have had that directory pruned on a plain `load refresh`. Affected Claude Code and Cursor too, in every version that generated workflow commands.

**Fixed** — `load run` announcing a command your agent doesn't have; studio's Workflows tab quoting Claude's invocation; `load clean` removing directories `load refresh` refuses to create.

## Release gate

Ran exactly what RELEASING.md specifies:

```
cargo fmt --all --check                          ✅
cargo clippy --all-targets -- -D warnings        ✅
cargo test --all --locked                        ✅  681 tests
dist plan                                        ✅  v0.28.0, 4 targets + installer
```

`dist plan` output: `aarch64-apple-darwin`, `x86_64-apple-darwin`, `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-gnu`, plus `loadout-installer.sh`, checksums, and the source tarball.

## After merge

Tag `v0.28.0` on `main` and push it — that fires `.github/workflows/release.yml`, which builds the binaries and publishes the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)